### PR TITLE
Fix keyed POM dedupe and C# navigation returns

### DIFF
--- a/class-generation/index.ts
+++ b/class-generation/index.ts
@@ -855,6 +855,7 @@ function generateAggregatedCSharpFiles(
         chunks.push("    {");
         if (pom.formattedDataTestId.includes("${") || allTestIds.length <= 1) {
           chunks.push(`        await ${locatorName}${pom.formattedDataTestId.includes("${") ? `(${args})` : ""}.ClickAsync();`);
+          chunks.push(`        return new ${target}(Page);`);
         }
         else {
           chunks.push("        Exception? lastError = null;");
@@ -876,7 +877,6 @@ function generateAggregatedCSharpFiles(
           chunks.push("        }");
           chunks.push("        throw lastError ?? new System.Exception(\"[pom] Failed to navigate using any candidate test id.\");");
         }
-        chunks.push(`        return new ${target}(Page);`);
         chunks.push("    }");
         chunks.push("");
         continue;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@immense/vue-pom-generator",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@immense/vue-pom-generator",
-      "version": "1.0.39",
+      "version": "1.0.40",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@immense/vue-pom-generator",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "description": "Injects data-testid attributes for all interactive elements and generates page object models for every page.",
   "type": "module",
   "repository": {

--- a/tests/class-generation-coverage.test.ts
+++ b/tests/class-generation-coverage.test.ts
@@ -579,4 +579,64 @@ describe("class-generation coverage", () => {
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }
   });
+
+  it("c#: navigation methods return on success without leaving unreachable code after terminal throws", async () => {
+    const tempRoot = makeTempRoot("vue-pom-csharp-nav-return-");
+
+    try {
+      const keyedNav: IDataTestId = {
+        value: "NavHost-${value}-immynavitem",
+        pom: {
+          nativeRole: "button",
+          methodName: "ValueByKey",
+          formattedDataTestId: "NavHost-${key}-immynavitem",
+          params: { key: "string" },
+        },
+        targetPageObjectModelClass: "UsersPage",
+      };
+
+      const alternateNav: IDataTestId = {
+        value: "NavHost-SystemUpdate-routerlink",
+        pom: {
+          nativeRole: "button",
+          methodName: "SystemUpdate",
+          formattedDataTestId: "NavHost-SystemUpdate-routerlink",
+          alternateFormattedDataTestIds: ["NavHost-Update-routerlink"],
+          params: {},
+        },
+        targetPageObjectModelClass: "SystemUpdatePage",
+      };
+
+      const componentHierarchyMap = new Map<string, IComponentDependencies>([
+        [
+          "NavHost",
+          makeDeps({
+            filePath: path.join(tempRoot, "src", "components", "NavHost.vue"),
+            isView: false,
+            dataTestIdSet: new Set([keyedNav, alternateNav]),
+          }),
+        ],
+      ]);
+
+      const outDir = path.join(tempRoot, "pom");
+      const basePagePath = path.join(tempRoot, "BasePage.ts");
+      writeMinimalBasePage(basePagePath);
+      await generateFiles(componentHierarchyMap, new Map(), basePagePath, {
+        outDir,
+        emitLanguages: ["csharp"],
+        csharp: { namespace: "Test.Generated" },
+      });
+
+      const csFile = path.join(outDir, "page-object-models.g.cs");
+      const cs = readFile(csFile);
+
+      expect(cs).toContain("await ValueByKeyButton(key).ClickAsync();\n        return new UsersPage(Page);");
+      expect(cs).not.toContain(
+        "throw lastError ?? new System.Exception(\"[pom] Failed to navigate using any candidate test id.\");\n"
+        + "        return new SystemUpdatePage(Page);",
+      );
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -1056,6 +1056,56 @@ describe("utils.ts coverage", () => {
     }
   });
 
+  it("merges keyed primaries with identical selectors before strict role suffixing invents duplicates", () => {
+    const root = parseTemplate("<ImmyNavItem /><ImmyNavItem />");
+    const els = (root.children ?? []).filter((c) => c?.type === NodeTypes.ELEMENT) as ElementNode[];
+    expect(els.length).toBe(2);
+
+    const deps: IComponentDependencies = {
+      filePath: "/src/components/MyComp.vue",
+      childrenComponentSet: new Set(),
+      usedComponentSet: new Set(),
+      dataTestIdSet: new Set<IDataTestId>(),
+      generatedMethods: new Map(),
+      isView: false,
+    };
+
+    const generatedMethodContentByComponent = new Map<string, Set<string>>();
+
+    const applyKeyedPrimary = (element: ElementNode) => {
+      applyResolvedDataTestId({
+        element,
+        componentName: "MyComp",
+        parentComponentName: "MyComp",
+        dependencies: deps,
+        generatedMethodContentByComponent,
+        nativeRole: "button",
+        preferredGeneratedValue: templateAttributeValue("MyComp-${value}-immynavitem"),
+        bestKeyPlaceholder: null,
+        testIdAttribute: "data-testid",
+        existingIdBehavior: "overwrite",
+        addHtmlAttribute: false,
+        nameCollisionBehavior: "error",
+        semanticNameHint: "Value",
+      });
+    };
+
+    applyKeyedPrimary(els[0]!);
+    applyKeyedPrimary(els[1]!);
+
+    const poms = Array.from(deps.dataTestIdSet)
+      .map(entry => entry.pom)
+      .filter((pom): pom is NonNullable<IDataTestId["pom"]> => !!pom);
+    const primaryPoms = poms.filter(pom => pom.emitPrimary !== false);
+    const mergedPoms = poms.filter(pom => pom.emitPrimary === false);
+
+    expect(primaryPoms.map(pom => pom.methodName)).toEqual(["ValueByKey"]);
+    expect(mergedPoms.map(pom => pom.methodName)).toEqual(["ValueByKey"]);
+    expect(poms.some(pom => pom.methodName === "ValueButtonByKey")).toBe(false);
+    expect(Array.from(deps.generatedMethods?.keys() ?? [])).toContain("clickValueByKey");
+    expect(Array.from(deps.generatedMethods?.keys() ?? [])).not.toContain("clickValueButtonByKey");
+  });
+
   it("avoids select/radio action-name collisions by role-suffixing in strict mode", () => {
     const root = parseTemplate("<MySelect /><MyRadioGroup />");
     const els = (root.children ?? []).filter((c) => c?.type === NodeTypes.ELEMENT) as ElementNode[];

--- a/utils.ts
+++ b/utils.ts
@@ -2585,12 +2585,6 @@ export function applyResolvedDataTestId(args: {
   const tryMergeWithExistingPrimary = (candidateActionName: string): boolean => {
     const mergeKey = (args.pomMergeKey ?? "").trim();
 
-    // For keyed selectors we intentionally do NOT merge: the semantics are ambiguous
-    // and merged locators would require additional runtime branching.
-    if (isKeyed) {
-      return false;
-    }
-
     const existingEntry = primaryByActionName.get(candidateActionName);
     const existingPom = existingEntry?.pom;
     if (!existingEntry || !existingPom) {
@@ -2602,6 +2596,13 @@ export function applyResolvedDataTestId(args: {
       ...(existingPom.alternateFormattedDataTestIds ?? []),
     ];
     const sharesSelectorIdentity = existingSelectors.includes(formattedDataTestIdForPom);
+
+    // Keyed selectors are only safe to merge when both entries already resolve to the exact
+    // same keyed selector pattern. Distinct keyed lists should still force authors to
+    // disambiguate their semantic hints instead of collapsing to one API.
+    if (isKeyed && !sharesSelectorIdentity) {
+      return false;
+    }
 
     // If both candidates already resolve to the exact same selector, separate generated
     // names would be fake differentiation. Merge them even without an explicit merge key.
@@ -2672,10 +2673,21 @@ export function applyResolvedDataTestId(args: {
         }
       }
 
-      // In strict mode (error), prefer trying role-suffixed candidates over hint alternates.
-      // This prevents common collisions where different roles share the same semantic hint
-      // (e.g. a select + radio bound to the same v-model path), causing actionName clashes
-      // like `selectFoo` vs `selectFoo` with different signatures.
+      // If this candidate already resolves to the same semantic action/selector as an
+      // existing primary, merge it before we try to synthesize a role-suffixed variant.
+      // Otherwise keyed/template selectors that collapse to one real selector identity can
+      // spuriously manufacture fake APIs like `ValueButtonByKey`.
+      if (conflicts && nameCollisionBehavior === "error" && tryMergeWithExistingPrimary(actionName)) {
+        methodName = candidate;
+        mergedIntoExisting = true;
+        break;
+      }
+
+      // In strict mode (error), prefer trying role-suffixed candidates over hint alternates
+      // when we cannot safely merge with an existing primary. This prevents common
+      // collisions where different roles share the same semantic hint (e.g. a select +
+      // radio bound to the same v-model path), causing actionName clashes like
+      // `selectFoo` vs `selectFoo` with different signatures.
       if (conflicts && nameCollisionBehavior === "error") {
         const roleSuffix = upperFirst(normalizedRole || "Element");
         const baseNameUpper = upperFirst(baseWithSuffix);
@@ -2736,16 +2748,6 @@ export function applyResolvedDataTestId(args: {
 
         reservedMembers.add(chosenGetterName);
         reservedMembers.add(actionName);
-        break;
-      }
-
-      // Merge-by-handler/target: when we would otherwise throw in error mode, allow
-      // multiple elements that share the same semantic action to converge on a single
-      // POM member (getter/action). The primary spec is mutated to include alternate
-      // test id candidates.
-      if (nameCollisionBehavior === "error" && tryMergeWithExistingPrimary(actionName)) {
-        methodName = candidate;
-        mergedIntoExisting = true;
         break;
       }
 


### PR DESCRIPTION
## Summary
- merge identical keyed primary selectors before strict collision handling invents duplicate APIs
- return directly from successful C# navigation methods so the emitter no longer writes unreachable code after terminal throws
- bump the package to 1.0.40 with regression coverage for both cases

## Validation
- npm test
- npm run build
- npm test -- --run tests/utils-coverage.test.ts tests/class-generation-coverage.test.ts