### PR TITLE
chore: bump version to 1.0.43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@immense/vue-pom-generator",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@immense/vue-pom-generator",
-      "version": "1.0.42",
+      "version": "1.0.43",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@immense/vue-pom-generator",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "description": "Injects data-testid attributes for all interactive elements and generates page object models for every page.",
   "type": "module",
   "repository": {


### PR DESCRIPTION
Bump release version to 1.0.43 to publish the build–serve parity fixes from #5.