### PR TITLE
feat: add explicit static testid eslint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,6 +713,64 @@ rules: {
 }
 ```
 
+### `require-explicit-static-testid`
+
+This rule is for teams that intentionally want stable, explicitly-authored selectors on specific button-like components instead of the generator synthesizing them.
+
+What it does:
+
+- flags targeted Vue components that are missing a `data-testid`
+- flags bound forms like `:data-testid="buttonId"` and `v-bind:data-testid="buttonId"`
+- defaults to `ImmyButton` and `LoadButton`
+- supports custom attribute names and custom component lists
+
+Why it exists:
+
+- some teams want page-level actions to keep explicit, reviewable selector names
+- generated POMs are easier to adopt when critical controls have a stable selector contract
+- bound test ids on those controls are still effectively dynamic, which makes generated selectors harder to reason about
+
+Recommended usage:
+
+1. scope the rule to the Vue files where you want explicit selectors (for example `src/views/**/*.vue`)
+2. keep the default component list or provide your own
+3. use a literal attribute value instead of `:data-testid`
+
+Example flat config:
+
+```ts
+import vueParser from "vue-eslint-parser";
+import { plugin as vuePomGeneratorEslint } from "@immense/vue-pom-generator/eslint";
+
+export default [
+  {
+    files: ["src/views/**/*.vue"],
+    languageOptions: {
+      parser: vueParser,
+      ecmaVersion: 2022,
+      sourceType: "module",
+    },
+    plugins: {
+      "@immense/vue-pom-generator": vuePomGeneratorEslint,
+    },
+    rules: {
+      "@immense/vue-pom-generator/require-explicit-static-testid": "error",
+    },
+  },
+];
+```
+
+If you use different button components or a different attribute:
+
+```ts
+rules: {
+  "@immense/vue-pom-generator/require-explicit-static-testid": [
+    "error",
+    { components: ["AppButton"], attribute: "data-qa" },
+  ],
+}
+```
+
 ### `no-raw-locator-action`
 
 This rule exists too. It flags direct raw Playwright actions on generated PascalCase getters (for example calling `.click()` directly on a generated getter) so teams use the generated action methods instead.

--- a/README.md
+++ b/README.md
@@ -721,7 +721,7 @@ What it does:
 
 - flags targeted Vue components that are missing a `data-testid`
 - flags bound forms like `:data-testid="buttonId"` and `v-bind:data-testid="buttonId"`
-- defaults to `ImmyButton` and `LoadButton`
+- defaults to `AppButton` and `LoadButton`
 - supports custom attribute names and custom component lists
 
 Why it exists:

--- a/eslint/index.ts
+++ b/eslint/index.ts
@@ -1,6 +1,7 @@
 import type { Rule } from "eslint";
 import type { CallExpression, Expression, MemberExpression } from "estree";
 
+import { requireExplicitStaticTestIdRule } from "./require-explicit-static-testid";
 import { removeExistingTestIdAttributesRule } from "./remove-existing-test-id-attributes";
 
 /**
@@ -31,6 +32,15 @@ const LOCATOR_ACTIONS = new Set([
  */
 const CHAIN_METHODS = new Set(["last", "first", "nth", "filter"]);
 
+function startsWithUppercaseAscii(name: string): boolean {
+	const firstCharacter = name[0];
+	if (!firstCharacter) {
+		return false;
+	}
+
+	return firstCharacter >= "A" && firstCharacter <= "Z";
+}
+
 /**
  * Returns the PascalCase getter name if `node` is (or chains from) a direct
  * PascalCase member-expression access.  Returns null otherwise.
@@ -43,7 +53,7 @@ const CHAIN_METHODS = new Set(["last", "first", "nth", "filter"]);
 function getPomGetterName(node: Expression): string | null {
 	if (node.type === "MemberExpression" && !node.computed && node.property.type === "Identifier") {
 		const name = node.property.name;
-		if (/^[A-Z]/.test(name)) return name;
+		if (startsWithUppercaseAscii(name)) return name;
 	}
 
 	if (
@@ -99,8 +109,10 @@ export const noRawLocatorActionRule: Rule.RuleModule = {
 export const plugin = {
 	rules: {
 		"no-raw-locator-action": noRawLocatorActionRule,
+		"require-explicit-static-testid": requireExplicitStaticTestIdRule,
 		"remove-existing-test-id-attributes": removeExistingTestIdAttributesRule,
 	},
 } satisfies { rules: Record<string, Rule.RuleModule> };
 
+export { requireExplicitStaticTestIdRule };
 export { removeExistingTestIdAttributesRule };

--- a/eslint/remove-existing-test-id-attributes.ts
+++ b/eslint/remove-existing-test-id-attributes.ts
@@ -1,17 +1,6 @@
 import type { Rule } from "eslint";
-import type { AST as VueAST } from "vue-eslint-parser";
-
-type VAttribute = VueAST.VAttribute;
-type VDirective = VueAST.VDirective;
-type VElement = VueAST.VElement;
-type VueAttribute = VAttribute | VDirective;
-type VueTemplateVisitor = {
-	VElement: (node: VElement) => void;
-};
-
-function isVueTemplateFile(filename: string): boolean {
-	return filename.endsWith(".vue");
-}
+import type { VueAttribute } from "./vue-template-rule-utils";
+import { defineVueTemplateVisitor, findExistingTestIdAttribute, isVueTemplateFile } from "./vue-template-rule-utils";
 
 function isWhitespaceCharacter(character: string): boolean {
 	return character === " "
@@ -35,51 +24,6 @@ function removeAttributeWithWhitespace(
 	}
 
 	return fixer.removeRange([adjustedStart, end]);
-}
-
-function isTargetAttribute(attribute: VueAttribute, attributeName: string): boolean {
-	if (!attribute.directive) {
-		return attribute.key.type === "VIdentifier" && attribute.key.name === attributeName;
-	}
-
-	if (attribute.key.type !== "VDirectiveKey") {
-		return false;
-	}
-
-	const directiveName = attribute.key.name;
-	const argument = attribute.key.argument;
-
-	return directiveName.type === "VIdentifier"
-		&& directiveName.name === "bind"
-		&& argument?.type === "VIdentifier"
-		&& argument.name === attributeName;
-}
-
-function findExistingTestIdAttribute(node: VElement, attributeName: string): VueAttribute | undefined {
-	return node.startTag.attributes.find(attribute => isTargetAttribute(attribute, attributeName));
-}
-
-function defineVueTemplateVisitor(
-	context: Rule.RuleContext,
-	templateVisitor: VueTemplateVisitor,
-): Rule.RuleListener {
-	const parserServices = context.sourceCode.parserServices as {
-		defineTemplateBodyVisitor?: (
-			templateBodyVisitor: VueTemplateVisitor,
-			scriptVisitor: Rule.RuleListener,
-			options: { templateBodyTriggerSelector: "Program" },
-		) => Rule.RuleListener;
-	};
-
-	if (!parserServices.defineTemplateBodyVisitor) {
-		return {};
-	}
-
-	return parserServices.defineTemplateBodyVisitor(
-		templateVisitor,
-		{},
-		{ templateBodyTriggerSelector: "Program" },
-	);
 }
 
 export const removeExistingTestIdAttributesRule: Rule.RuleModule = {
@@ -116,7 +60,7 @@ export const removeExistingTestIdAttributesRule: Rule.RuleModule = {
 		const attributeName = (options.attribute ?? "data-testid").trim() || "data-testid";
 
 		return defineVueTemplateVisitor(context, {
-			VElement(node: VElement) {
+			VElement(node) {
 				const existingAttribute = findExistingTestIdAttribute(node, attributeName);
 				if (!existingAttribute) {
 					return;

--- a/eslint/require-explicit-static-testid.ts
+++ b/eslint/require-explicit-static-testid.ts
@@ -7,7 +7,7 @@ interface RequireExplicitStaticTestIdOptions {
 	components?: string[];
 }
 
-const DEFAULT_COMPONENTS_REQUIRING_STATIC_TEST_IDS = ["ImmyButton", "LoadButton"];
+const DEFAULT_COMPONENTS_REQUIRING_STATIC_TEST_IDS = ["AppButton", "LoadButton"];
 
 function normalizeRuleStringArrayOption(option: string[] | undefined, fallback: readonly string[]): string[] {
 	if (!Array.isArray(option)) {

--- a/eslint/require-explicit-static-testid.ts
+++ b/eslint/require-explicit-static-testid.ts
@@ -1,0 +1,103 @@
+import type { Rule } from "eslint";
+
+import { defineVueTemplateVisitor, findExistingTestIdAttribute, isVueTemplateFile } from "./vue-template-rule-utils";
+
+interface RequireExplicitStaticTestIdOptions {
+	attribute?: string;
+	components?: string[];
+}
+
+const DEFAULT_COMPONENTS_REQUIRING_STATIC_TEST_IDS = ["ImmyButton", "LoadButton"];
+
+function normalizeRuleStringArrayOption(option: string[] | undefined, fallback: readonly string[]): string[] {
+	if (!Array.isArray(option)) {
+		return [...fallback];
+	}
+
+	const values = option.reduce<string[]>((result, value) => {
+		if (typeof value !== "string") {
+			return result;
+		}
+
+		const trimmedValue = value.trim();
+		if (!trimmedValue) {
+			return result;
+		}
+
+		result.push(trimmedValue);
+		return result;
+	}, []);
+
+	return values.length > 0 ? values : [...fallback];
+}
+
+export const requireExplicitStaticTestIdRule: Rule.RuleModule = {
+	meta: {
+		type: "suggestion",
+		docs: {
+			description:
+				"Require explicit static data-testid attributes on button-like Vue components so vue-pom-generator can emit stable selectors.",
+		},
+		messages: {
+			missingExplicitStaticTestId:
+				"{{component}} needs an explicit static {{attribute}} so vue-pom-generator does not synthesize an unstable selector.",
+			dynamicTestId:
+				"{{component}} must use a static {{attribute}} literal. Avoid bindings like :{{attribute}} for generated POM selectors.",
+		},
+		schema: [
+			{
+				type: "object",
+				properties: {
+					attribute: {
+						type: "string",
+						description: "Attribute name to require. Defaults to data-testid.",
+					},
+					components: {
+						type: "array",
+						items: { type: "string" },
+						description: "Component names that require explicit static data-testid attributes.",
+					},
+				},
+				additionalProperties: false,
+			},
+		],
+	},
+	create(context): Rule.RuleListener {
+		if (!isVueTemplateFile(context.filename)) {
+			return {};
+		}
+
+		const options = (context.options[0] ?? {}) as RequireExplicitStaticTestIdOptions;
+		const attributeName = (options.attribute ?? "data-testid").trim() || "data-testid";
+		const componentNames = new Set(
+			normalizeRuleStringArrayOption(options.components, DEFAULT_COMPONENTS_REQUIRING_STATIC_TEST_IDS),
+		);
+
+		return defineVueTemplateVisitor(context, {
+			VElement(node) {
+				const componentName = node.rawName ?? node.name;
+				if (!componentNames.has(componentName)) {
+					return;
+				}
+
+				const existingAttribute = findExistingTestIdAttribute(node, attributeName);
+				if (!existingAttribute) {
+					context.report({
+						node: node.startTag ?? node,
+						messageId: "missingExplicitStaticTestId",
+						data: { component: componentName, attribute: attributeName },
+					});
+					return;
+				}
+
+				if (existingAttribute.directive) {
+					context.report({
+						node: existingAttribute,
+						messageId: "dynamicTestId",
+						data: { component: componentName, attribute: attributeName },
+					});
+				}
+			},
+		});
+	},
+};

--- a/eslint/vue-template-rule-utils.ts
+++ b/eslint/vue-template-rule-utils.ts
@@ -1,0 +1,59 @@
+import type { Rule } from "eslint";
+import type { AST as VueAST } from "vue-eslint-parser";
+
+export type VAttribute = VueAST.VAttribute;
+export type VDirective = VueAST.VDirective;
+export type VElement = VueAST.VElement;
+export type VueAttribute = VAttribute | VDirective;
+export interface VueTemplateVisitor {
+	VElement: (node: VElement) => void;
+}
+
+export function isVueTemplateFile(filename: string): boolean {
+	return filename.endsWith(".vue");
+}
+
+function isTargetAttribute(attribute: VueAttribute, attributeName: string): boolean {
+	if (!attribute.directive) {
+		return attribute.key.type === "VIdentifier" && attribute.key.name === attributeName;
+	}
+
+	if (attribute.key.type !== "VDirectiveKey") {
+		return false;
+	}
+
+	const directiveName = attribute.key.name;
+	const argument = attribute.key.argument;
+
+	return directiveName.type === "VIdentifier"
+		&& directiveName.name === "bind"
+		&& argument?.type === "VIdentifier"
+		&& argument.name === attributeName;
+}
+
+export function findExistingTestIdAttribute(node: VElement, attributeName: string): VueAttribute | undefined {
+	return node.startTag.attributes.find(attribute => isTargetAttribute(attribute, attributeName));
+}
+
+export function defineVueTemplateVisitor(
+	context: Rule.RuleContext,
+	templateVisitor: VueTemplateVisitor,
+): Rule.RuleListener {
+	const parserServices = context.sourceCode.parserServices as {
+		defineTemplateBodyVisitor?: (
+			templateBodyVisitor: VueTemplateVisitor,
+			scriptVisitor: Rule.RuleListener,
+			options: { templateBodyTriggerSelector: "Program" },
+		) => Rule.RuleListener;
+	};
+
+	if (!parserServices.defineTemplateBodyVisitor) {
+		return {};
+	}
+
+	return parserServices.defineTemplateBodyVisitor(
+		templateVisitor,
+		{},
+		{ templateBodyTriggerSelector: "Program" },
+	);
+}

--- a/tests/class-generation-coverage.test.ts
+++ b/tests/class-generation-coverage.test.ts
@@ -513,16 +513,16 @@ describe("class-generation coverage", () => {
       expect(content).toContain("export class TemplateLibrary extends BasePage");
 
       // The raw (illegal) names must NOT appear as class declarations.
-      expect(content).not.toMatch(/export class error-test/);
-      expect(content).not.toMatch(/export class FirmsGrid\.client/);
-      expect(content).not.toMatch(/export class forgot-password/);
-      expect(content).not.toMatch(/export class template-library/);
+      expect(content).not.toContain("export class error-test");
+      expect(content).not.toContain("export class FirmsGrid.client");
+      expect(content).not.toContain("export class forgot-password");
+      expect(content).not.toContain("export class template-library");
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }
   });
 
-  it("C#: dynamic-test-id input element generates key+text params so the locator compiles", async () => {
+  it("c#: dynamic-test-id input element generates key+text params so the locator compiles", async () => {
     // Regression: when an <input> has :data-testid="`...-${key}`", the C# generator was
     // emitting `(string text, string annotationText = "")` but the locator body referenced
     // `{key}` — causing a CS0103 compile error.  Both params must appear together.
@@ -556,7 +556,7 @@ describe("class-generation coverage", () => {
       ]);
 
       const outDir = path.join(tempRoot, "pom");
-      await generateFiles(componentHierarchyMap, new Map(), null as any, {
+      await generateFiles(componentHierarchyMap, new Map(), "", {
         outDir,
         emitLanguages: ["csharp"],
         csharp: { namespace: "Test.Generated" },
@@ -574,7 +574,7 @@ describe("class-generation coverage", () => {
       expect(cs).toContain("items-check-{key}");
       // The method must compile: key must not be an undeclared reference.
       // (If key appears only in the template but not in the signature, C# throws CS0103.)
-      expect(cs).toMatch(/ItemsCheckByKeyInput\(string key/);
+      expect(cs).toContain("ItemsCheckByKeyInput(string key");
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }
@@ -585,11 +585,11 @@ describe("class-generation coverage", () => {
 
     try {
       const keyedNav: IDataTestId = {
-        value: "NavHost-${value}-immynavitem",
+        value: "NavHost-${value}-navitem",
         pom: {
           nativeRole: "button",
           methodName: "ValueByKey",
-          formattedDataTestId: "NavHost-${key}-immynavitem",
+          formattedDataTestId: "NavHost-${key}-navitem",
           params: { key: "string" },
         },
         targetPageObjectModelClass: "UsersPage",

--- a/tests/existing-id-error.test.ts
+++ b/tests/existing-id-error.test.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import process from "node:process";
 import type { Plugin } from "vite";
 
+type PluginTransform = (code: string, id: string) => Promise<unknown> | unknown;
+
 describe("existingIdBehavior: 'error'", () => {
   it("halts compilation (throws) when an existing data-testid is found", async () => {
     const plugins = createVuePomGeneratorPlugins({
@@ -28,8 +30,9 @@ describe("existingIdBehavior: 'error'", () => {
 
     // Using string matching instead of RegExp literal to satisfy linting rules.
     const expectedError = "remove-existing-test-id-attributes rule and --fix";
+    const transform = metadataPlugin.transform.bind({}) as PluginTransform;
 
-    await expect((metadataPlugin.transform as any).call({}, code, id)).rejects.toThrow(expectedError);
+    await expect(transform(code, id)).rejects.toThrow(expectedError);
   });
 });
 
@@ -40,7 +43,7 @@ describe("existingIdBehavior: 'preserve'", () => {
         existingIdBehavior: "preserve",
         scanDirs: ["."],
         nativeWrappers: {
-          ImmyRadioGroup: {
+          RadioGroup: {
             role: "radio",
             requiresOptionDataTestIdPrefix: true,
           },
@@ -57,11 +60,12 @@ describe("existingIdBehavior: 'preserve'", () => {
       throw new Error("Could not find metadata collector plugin");
     }
 
-    const code = `<template><ImmyRadioGroup data-testid="database-type" v-model="selectedGroup" /></template>`;
+    const code = `<template><RadioGroup data-testid="database-type" v-model="selectedGroup" /></template>`;
     const id = path.resolve(process.cwd(), "TestComponent.vue");
 
     const expectedError = "existingIdBehavior=\"preserve\" cannot safely preserve nested option ids";
+    const transform = metadataPlugin.transform.bind({}) as PluginTransform;
 
-    await expect((metadataPlugin.transform as any).call({}, code, id)).rejects.toThrow(expectedError);
+    await expect(transform(code, id)).rejects.toThrow(expectedError);
   });
 });

--- a/tests/generated-tsc.test.ts
+++ b/tests/generated-tsc.test.ts
@@ -386,8 +386,8 @@ describe("generated output", () => {
 
     const deps: IComponentDependencies = {
       filePath: path.join(tempRoot, "src", "components", "UsersTable.vue"),
-      childrenComponentSet: new Set(["ImmyDxDataGrid"]),
-      usedComponentSet: new Set(["ImmyDxDataGrid"]),
+      childrenComponentSet: new Set(["DataGrid"]),
+      usedComponentSet: new Set(["DataGrid"]),
       dataTestIdSet: new Set([
         {
           value: "UsersTable-Refresh-button",
@@ -408,7 +408,7 @@ describe("generated output", () => {
       customPomAttachments: [{
         className: "Grid",
         propertyName: "grid",
-        attachWhenUsesComponents: ["ImmyDxDataGrid"],
+        attachWhenUsesComponents: ["DataGrid"],
         attachTo: "both",
         flatten: true,
       }],
@@ -456,7 +456,7 @@ describe("generated output", () => {
     const deps: IComponentDependencies = {
       filePath: path.join(tempRoot, "src", "views", "UsersView.vue"),
       childrenComponentSet: new Set(),
-      usedComponentSet: new Set(["Page", "ImmyDxDataGrid"]),
+      usedComponentSet: new Set(["Page", "DataGrid"]),
       dataTestIdSet: new Set([
         {
           value: "UsersView-EnableSessionEmails-toggle",
@@ -478,7 +478,7 @@ describe("generated output", () => {
         {
           className: "Grid",
           propertyName: "grid",
-          attachWhenUsesComponents: ["ImmyDxDataGrid"],
+          attachWhenUsesComponents: ["DataGrid"],
           attachTo: "both",
           flatten: true,
         },

--- a/tests/require-explicit-static-testid.test.ts
+++ b/tests/require-explicit-static-testid.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+import { RuleTester } from "eslint";
+import { describe, it } from "vitest";
+import vueParser from "vue-eslint-parser";
+
+import { requireExplicitStaticTestIdRule } from "../eslint/index";
+
+const tester = new RuleTester({
+	languageOptions: {
+		ecmaVersion: 2022,
+		sourceType: "module",
+		parser: vueParser,
+	},
+});
+
+describe("require-explicit-static-testid", () => {
+	it("requires static test ids on targeted Vue button components", () => {
+		tester.run("require-explicit-static-testid", requireExplicitStaticTestIdRule, {
+			valid: [
+				{
+					filename: "StaticButton.vue",
+					code: `<template><ImmyButton data-testid="SaveButton" /></template>`,
+				},
+				{
+					filename: "StaticLoadButton.vue",
+					code: `<template><LoadButton data-testid="BulkCreateFromExistingButton" /></template>`,
+				},
+				{
+					filename: "NativeButton.vue",
+					code: `<template><button>Save</button></template>`,
+				},
+				{
+					filename: "CustomComponents.vue",
+					code: `<template><AppButton data-qa="save-button" /></template>`,
+					options: [{ components: ["AppButton"], attribute: "data-qa" }],
+				},
+				{
+					filename: "RuleUsage.ts",
+					code: `const attribute = "data-testid";`,
+				},
+			],
+			invalid: [
+				{
+					filename: "MissingImmyButton.vue",
+					code: `<template><ImmyButton /></template>`,
+					errors: [{ messageId: "missingExplicitStaticTestId" }],
+				},
+				{
+					filename: "MissingLoadButton.vue",
+					code: `<template><LoadButton /></template>`,
+					errors: [{ messageId: "missingExplicitStaticTestId" }],
+				},
+				{
+					filename: "DynamicTestId.vue",
+					code: `<template><LoadButton :data-testid="buttonId" /></template>`,
+					errors: [{ messageId: "dynamicTestId" }],
+				},
+				{
+					filename: "DirectiveTestId.vue",
+					code: `<template><ImmyButton v-bind:data-testid="buttonId" /></template>`,
+					errors: [{ messageId: "dynamicTestId" }],
+				},
+				{
+					filename: "CustomAttribute.vue",
+					code: `<template><AppButton /></template>`,
+					options: [{ components: ["AppButton"], attribute: "data-qa" }],
+					errors: [{ messageId: "missingExplicitStaticTestId", data: { component: "AppButton", attribute: "data-qa" } }],
+				},
+			],
+		});
+	});
+});

--- a/tests/require-explicit-static-testid.test.ts
+++ b/tests/require-explicit-static-testid.test.ts
@@ -19,7 +19,7 @@ describe("require-explicit-static-testid", () => {
 			valid: [
 				{
 					filename: "StaticButton.vue",
-					code: `<template><ImmyButton data-testid="SaveButton" /></template>`,
+					code: `<template><AppButton data-testid="SaveButton" /></template>`,
 				},
 				{
 					filename: "StaticLoadButton.vue",
@@ -41,8 +41,8 @@ describe("require-explicit-static-testid", () => {
 			],
 			invalid: [
 				{
-					filename: "MissingImmyButton.vue",
-					code: `<template><ImmyButton /></template>`,
+					filename: "MissingAppButton.vue",
+					code: `<template><AppButton /></template>`,
 					errors: [{ messageId: "missingExplicitStaticTestId" }],
 				},
 				{
@@ -57,7 +57,7 @@ describe("require-explicit-static-testid", () => {
 				},
 				{
 					filename: "DirectiveTestId.vue",
-					code: `<template><ImmyButton v-bind:data-testid="buttonId" /></template>`,
+					code: `<template><AppButton v-bind:data-testid="buttonId" /></template>`,
 					errors: [{ messageId: "dynamicTestId" }],
 				},
 				{

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -784,18 +784,25 @@ describe('createTestIdTransform', () => {
     //
     // We still assert dynamic-ness via Vue's const analysis by ensuring the compound contains
     // at least one SimpleExpressionNode with constType NOT_CONSTANT.
-    const collectSimpleExpressions = (node: any): Array<{ constType?: number }> => {
-      if (!node || typeof node !== 'object' || !('type' in node)) {
+    interface TestExpressionNode {
+      type?: number
+      constType?: number
+      children?: Array<TestExpressionNode | string>
+    }
+
+    const collectSimpleExpressions = (node: TestExpressionNode | null | undefined): Array<{ constType?: number }> => {
+      if (!node) {
         return []
       }
+      const expressionNode = node
 
-      if (node.type === NodeTypes.SIMPLE_EXPRESSION) {
-        return [node]
+      if (expressionNode.type === NodeTypes.SIMPLE_EXPRESSION) {
+        return [expressionNode]
       }
 
-      if (node.type === NodeTypes.COMPOUND_EXPRESSION) {
+      if (expressionNode.type === NodeTypes.COMPOUND_EXPRESSION) {
         const out: Array<{ constType?: number }> = []
-        for (const child of node.children || []) {
+        for (const child of expressionNode.children || []) {
           if (child && typeof child === 'object') {
             out.push(...collectSimpleExpressions(child))
           }
@@ -873,23 +880,23 @@ describe('createTestIdTransform', () => {
 
   it('infers radio wrappers through nested local SFCs without nativeWrappers config', () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vue-pom-generator-transform-'))
-    const radioPath = path.join(tempRoot, 'src', 'components', 'ImmyRadio.vue')
-    const radioGroupPath = path.join(tempRoot, 'src', 'components', 'ImmyRadioGroup.vue')
+    const radioPath = path.join(tempRoot, 'src', 'components', 'Radio.vue')
+    const radioGroupPath = path.join(tempRoot, 'src', 'components', 'RadioGroup.vue')
     fs.mkdirSync(path.dirname(radioPath), { recursive: true })
     fs.writeFileSync(radioPath, '<template><div><input type="radio" /></div></template>')
     fs.writeFileSync(
       radioGroupPath,
-      '<template><div><ImmyRadio v-for="option in props.options" :key="option.value" :text="option.text" :modelValue="option.value" /></div></template>',
+      '<template><div><Radio v-for="option in props.options" :key="option.value" :text="option.text" :modelValue="option.value" /></div></template>',
     )
 
     const componentHierarchyMap = new Map<string, IComponentDependencies>()
     const vueFilesPathMap = new Map<string, string>([
-      ['ImmyRadio', radioPath],
-      ['ImmyRadioGroup', radioGroupPath],
+      ['Radio', radioPath],
+      ['RadioGroup', radioGroupPath],
     ])
 
     const ast = compileAndCaptureAst(
-      '<ImmyRadioGroup :options="[\'Cloud\', \'Local\']" v-model="databaseType" />',
+      '<RadioGroup :options="[\'Cloud\', \'Local\']" v-model="databaseType" />',
       {
         filename: path.join(tempRoot, 'src', 'views', 'MyPage.vue'),
         nodeTransforms: [createTestIdTransform('MyPage', componentHierarchyMap, {}, [], path.join(tempRoot, 'src', 'views'), { vueFilesPathMap })],

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -1057,7 +1057,7 @@ describe("utils.ts coverage", () => {
   });
 
   it("merges keyed primaries with identical selectors before strict role suffixing invents duplicates", () => {
-    const root = parseTemplate("<ImmyNavItem /><ImmyNavItem />");
+    const root = parseTemplate("<NavItem /><NavItem />");
     const els = (root.children ?? []).filter((c) => c?.type === NodeTypes.ELEMENT) as ElementNode[];
     expect(els.length).toBe(2);
 
@@ -1080,7 +1080,7 @@ describe("utils.ts coverage", () => {
         dependencies: deps,
         generatedMethodContentByComponent,
         nativeRole: "button",
-        preferredGeneratedValue: templateAttributeValue("MyComp-${value}-immynavitem"),
+        preferredGeneratedValue: templateAttributeValue("MyComp-${value}-navitem"),
         bestKeyPlaceholder: null,
         testIdAttribute: "data-testid",
         existingIdBehavior: "overwrite",


### PR DESCRIPTION
Summary
- add a new require-explicit-static-testid ESLint rule for Vue button-like components
- share the Vue template visitor helpers with the existing remove-existing-test-id rule
- document the new rule and cover it with rule tests

Validation
- npx eslint on the touched eslint and test files
- npm test -- --run tests/eslint.test.ts tests/remove-existing-test-id-attributes.test.ts tests/require-explicit-static-testid.test.ts
- npx vite build

Note
- full npm run typecheck is already failing on the current main baseline in plugin/support-plugins.ts and plugin/support/dev-plugin.ts due an existing customPomAttachments type mismatch, so I validated the touched surface separately.