### PR TITLE
feat: fail fast on unnameable wrapper handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The generator does not use one naming trick. It layers several signals.
 - **Router links / `:to` bindings** can contribute route-based naming and typed navigation return types when the target can be resolved.
 - **Wrapper components** can be explicit (`nativeWrappers`) or inferred from simple local SFC templates.
 - **Fallback naming exists, but it is intentionally conservative.** That is why `generation.nameCollisionBehavior` exists.
-- **You can opt into stricter wrapper-action generation.** `generation.playwright.errorBehavior: "error"` blocks button-like wrapper `:handler` expressions that the generator cannot turn into a semantic action name.
+- **You can opt into stricter wrapper-action generation.** `errorBehavior: "error"` blocks button-like wrapper `:handler` expressions that the generator cannot turn into a semantic action name.
 
 Important limit: wrapper inference is helpful, not magical. The current implementation recursively inspects simple local SFC templates for the first inferable primitive (`input`, `textarea`, `select`, `button`, `vselect`, radio/checkbox inputs). It also recognizes some naming patterns like `*Button`. For anything more complex, configure `nativeWrappers` explicitly.
 
@@ -202,6 +202,7 @@ const pomConfig = defineVuePomGeneratorConfig({
     script: { defineModel: true, propsDestructure: true },
   },
   logging: { verbosity: "info" },
+  errorBehavior: "error",
   injection: {
     attribute: "data-testid",
     viewsDir: "src/views",
@@ -233,7 +234,6 @@ const pomConfig = defineVuePomGeneratorConfig({
     },
     playwright: {
       fixtures: true,
-      errorBehavior: "error",
       customPoms: {
         dir: "tests/playwright/pom/custom",
         importAliases: {
@@ -807,6 +807,18 @@ The sections below follow the actual `VuePomGeneratorPluginOptions` shape from `
   logging: { verbosity: "debug" }
   ```
 
+#### `errorBehavior`
+
+- **What it does:** Controls strict/error behavior for generator checks.
+- **Why it exists:** complex inline handlers can otherwise fall through to generic naming, which makes generated APIs harder to discover and review.
+- **Benefit:** `"error"` lets you opt into fail-fast behavior globally, while the object form lets you turn on only the checks you care about.
+- **Without it:** the default is `"ignore"`, so existing permissive fallback behavior remains in place.
+- **Accepted values:**
+  - `"ignore"` — keep permissive defaults for all supported checks
+  - `"error"` — enable error-on-failure behavior for all supported checks
+  - `{ missingSemanticNameBehavior: "error" }` — enable only the button-wrapper semantic-name check
+- **Current scope:** this first pass is intentionally narrow. The object form currently supports `missingSemanticNameBehavior`, which targets button-like wrappers with `:handler`; value/model-driven wrappers still use their existing naming flow.
+
 ### `injection`
 
 `injection` controls compile-time test-id derivation and template rewriting.
@@ -1024,18 +1036,6 @@ This object holds Playwright-specific additions on top of the generated TypeScri
   - `true` — emit `fixtures.g.ts` next to the generated POMs
   - `"path"` — if the string ends in `.ts` / `.tsx` / `.mts` / `.cts`, it is treated as a file path; otherwise as an output directory
   - `{ outDir }` — emit to a custom directory
-
-#### `generation.playwright.errorBehavior`
-
-- **What it does:** Controls strict/error behavior for Playwright generation checks.
-- **Why it exists:** complex inline handlers can otherwise fall through to generic naming, which makes generated APIs harder to discover and review.
-- **Benefit:** `"error"` lets you opt into fail-fast behavior globally, while the object form lets you turn on only the checks you care about.
-- **Without it:** the default is `"ignore"`, so existing permissive fallback behavior remains in place.
-- **Accepted values:**
-  - `"ignore"` — keep permissive defaults for all supported checks
-  - `"error"` — enable error-on-failure behavior for all supported checks
-  - `{ missingSemanticNameBehavior: "error" }` — enable only the button-wrapper semantic-name check
-- **Current scope:** this first pass is intentionally narrow. The object form currently supports `missingSemanticNameBehavior`, which targets button-like wrappers with `:handler`; value/model-driven wrappers still use their existing naming flow.
 
 #### `generation.playwright.customPoms`
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ If you already use Playwright with `getByTestId`, the point is simple: this pack
 - **Uses real template signals to name ids and methods.** Click handlers, `v-model`, `id`/`name`, `:to`, wrapper configuration, and a few targeted fallbacks all feed the generated API.
 - **Generates one aggregated TypeScript POM file** plus a stable `index.ts` barrel.
 - **Can generate Playwright fixtures** so tests can request `userListPage` instead of constructing `new UserListPage(page)` manually.
+- **Can fail fast on unnameable wrapper-button actions** so complex inline handlers do not silently degrade into low-signal generated APIs.
 - **Can emit a single C# POM file** for Playwright .NET consumers.
 - **Exposes `virtual:testids`** so your app can import the current collected test-id manifest at runtime.
 - **Ships ESLint rules** to remove legacy manually-authored test ids, ban raw `page` fixture usage in spec callbacks, and discourage raw locator actions on generated getters.
@@ -73,6 +74,7 @@ The generator does not use one naming trick. It layers several signals.
 - **Router links / `:to` bindings** can contribute route-based naming and typed navigation return types when the target can be resolved.
 - **Wrapper components** can be explicit (`nativeWrappers`) or inferred from simple local SFC templates.
 - **Fallback naming exists, but it is intentionally conservative.** That is why `generation.nameCollisionBehavior` exists.
+- **You can opt into stricter wrapper-action generation.** `generation.playwright.missingSemanticNameBehavior: "error"` blocks button-like wrapper `:handler` expressions that the generator cannot turn into a semantic action name.
 
 Important limit: wrapper inference is helpful, not magical. The current implementation recursively inspects simple local SFC templates for the first inferable primitive (`input`, `textarea`, `select`, `button`, `vselect`, radio/checkbox inputs). It also recognizes some naming patterns like `*Button`. For anything more complex, configure `nativeWrappers` explicitly.
 
@@ -231,6 +233,7 @@ const pomConfig = defineVuePomGeneratorConfig({
     },
     playwright: {
       fixtures: true,
+      missingSemanticNameBehavior: "error",
       customPoms: {
         dir: "tests/playwright/pom/custom",
         importAliases: {
@@ -1021,6 +1024,17 @@ This object holds Playwright-specific additions on top of the generated TypeScri
   - `true` — emit `fixtures.g.ts` next to the generated POMs
   - `"path"` — if the string ends in `.ts` / `.tsx` / `.mts` / `.cts`, it is treated as a file path; otherwise as an output directory
   - `{ outDir }` — emit to a custom directory
+
+#### `generation.playwright.missingSemanticNameBehavior`
+
+- **What it does:** Controls whether button-like wrapper `:handler` bindings that cannot produce a semantic action name are ignored or treated as errors.
+- **Why it exists:** complex inline handlers can otherwise fall through to generic naming, which makes generated APIs harder to discover and review.
+- **Benefit:** `"error"` turns those cases into an explicit build failure with guidance to extract the logic into a named function or simpler direct call.
+- **Without it:** the default is `"ignore"`, so existing permissive fallback behavior remains in place.
+- **Accepted values:**
+  - `"ignore"` — preserve current permissive behavior
+  - `"error"` — fail generation when a button-like wrapper `:handler` cannot be named semantically
+- **Current scope:** this first pass is intentionally narrow. It targets button-like wrappers with `:handler`; value/model-driven wrappers still use their existing naming flow.
 
 #### `generation.playwright.customPoms`
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The generator does not use one naming trick. It layers several signals.
 - **Router links / `:to` bindings** can contribute route-based naming and typed navigation return types when the target can be resolved.
 - **Wrapper components** can be explicit (`nativeWrappers`) or inferred from simple local SFC templates.
 - **Fallback naming exists, but it is intentionally conservative.** That is why `generation.nameCollisionBehavior` exists.
-- **You can opt into stricter wrapper-action generation.** `generation.playwright.missingSemanticNameBehavior: "error"` blocks button-like wrapper `:handler` expressions that the generator cannot turn into a semantic action name.
+- **You can opt into stricter wrapper-action generation.** `generation.playwright.errorBehavior: "error"` blocks button-like wrapper `:handler` expressions that the generator cannot turn into a semantic action name.
 
 Important limit: wrapper inference is helpful, not magical. The current implementation recursively inspects simple local SFC templates for the first inferable primitive (`input`, `textarea`, `select`, `button`, `vselect`, radio/checkbox inputs). It also recognizes some naming patterns like `*Button`. For anything more complex, configure `nativeWrappers` explicitly.
 
@@ -233,7 +233,7 @@ const pomConfig = defineVuePomGeneratorConfig({
     },
     playwright: {
       fixtures: true,
-      missingSemanticNameBehavior: "error",
+      errorBehavior: "error",
       customPoms: {
         dir: "tests/playwright/pom/custom",
         importAliases: {
@@ -1025,16 +1025,17 @@ This object holds Playwright-specific additions on top of the generated TypeScri
   - `"path"` — if the string ends in `.ts` / `.tsx` / `.mts` / `.cts`, it is treated as a file path; otherwise as an output directory
   - `{ outDir }` — emit to a custom directory
 
-#### `generation.playwright.missingSemanticNameBehavior`
+#### `generation.playwright.errorBehavior`
 
-- **What it does:** Controls whether button-like wrapper `:handler` bindings that cannot produce a semantic action name are ignored or treated as errors.
+- **What it does:** Controls strict/error behavior for Playwright generation checks.
 - **Why it exists:** complex inline handlers can otherwise fall through to generic naming, which makes generated APIs harder to discover and review.
-- **Benefit:** `"error"` turns those cases into an explicit build failure with guidance to extract the logic into a named function or simpler direct call.
+- **Benefit:** `"error"` lets you opt into fail-fast behavior globally, while the object form lets you turn on only the checks you care about.
 - **Without it:** the default is `"ignore"`, so existing permissive fallback behavior remains in place.
 - **Accepted values:**
-  - `"ignore"` — preserve current permissive behavior
-  - `"error"` — fail generation when a button-like wrapper `:handler` cannot be named semantically
-- **Current scope:** this first pass is intentionally narrow. It targets button-like wrappers with `:handler`; value/model-driven wrappers still use their existing naming flow.
+  - `"ignore"` — keep permissive defaults for all supported checks
+  - `"error"` — enable error-on-failure behavior for all supported checks
+  - `{ missingSemanticNameBehavior: "error" }` — enable only the button-wrapper semantic-name check
+- **Current scope:** this first pass is intentionally narrow. The object form currently supports `missingSemanticNameBehavior`, which targets button-like wrappers with `:handler`; value/model-driven wrappers still use their existing naming flow.
 
 #### `generation.playwright.customPoms`
 

--- a/plugin/create-vue-pom-generator-plugins.ts
+++ b/plugin/create-vue-pom-generator-plugins.ts
@@ -7,7 +7,7 @@ import type { VuePomGeneratorLogger, VuePomGeneratorVerbosity } from "./logger";
 import { createLogger } from "./logger";
 import { createSupportPlugins } from "./support-plugins";
 import { createTestIdsVirtualModulesPlugin } from "./support/virtual-modules";
-import type { ExistingIdBehavior, MissingSemanticNameBehavior, PomNameCollisionBehavior, RouterModuleShimDefinition, VuePluginOwnership, VuePomGeneratorPluginOptions } from "./types";
+import type { ExistingIdBehavior, MissingSemanticNameBehavior, PlaywrightErrorBehavior, PlaywrightErrorBehaviorOptions, PomNameCollisionBehavior, RouterModuleShimDefinition, VuePluginOwnership, VuePomGeneratorPluginOptions } from "./types";
 import { createVuePluginWithTestIds } from "./vue-plugin";
 
 import type { ElementMetadata } from "../metadata-collector";
@@ -35,6 +35,46 @@ function assertOneOf<T extends string>(value: T | undefined, allowed: readonly T
     return;
   }
   throw new TypeError(`${name} must be one of: ${allowed.join(", ")}.`);
+}
+
+function assertPlaywrightErrorBehavior(
+  value: PlaywrightErrorBehavior | undefined,
+  name: string,
+): asserts value is PlaywrightErrorBehavior {
+  if (!value) {
+    return;
+  }
+
+  if (value === "ignore" || value === "error") {
+    return;
+  }
+
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${name} must be "ignore", "error", or an object.`);
+  }
+
+  const supportedKeys = new Set<keyof PlaywrightErrorBehaviorOptions>(["missingSemanticNameBehavior"]);
+  for (const key of Object.keys(value)) {
+    if (!supportedKeys.has(key as keyof PlaywrightErrorBehaviorOptions)) {
+      throw new TypeError(`${name} contains unsupported key "${key}".`);
+    }
+  }
+
+  assertOneOf(value.missingSemanticNameBehavior, ["ignore", "error"], `${name}.missingSemanticNameBehavior`);
+}
+
+function resolveMissingSemanticNameBehavior(
+  value: PlaywrightErrorBehavior | undefined,
+): MissingSemanticNameBehavior {
+  if (!value) {
+    return "ignore";
+  }
+
+  if (value === "ignore" || value === "error") {
+    return value;
+  }
+
+  return value.missingSemanticNameBehavior ?? "ignore";
 }
 
 function assertRouterModuleShims(
@@ -231,7 +271,8 @@ export function createVuePomGeneratorPlugins(options: VuePomGeneratorPluginOptio
   const vuePluginOwnership: VuePluginOwnership = isNuxt ? "external" : (options.vuePluginOwnership ?? "internal");
   const usesExternalVuePlugin = vuePluginOwnership === "external";
   const csharp = generationOptions?.csharp;
-  const missingSemanticNameBehavior: MissingSemanticNameBehavior = generationOptions?.playwright?.missingSemanticNameBehavior ?? "ignore";
+  const playwrightErrorBehavior = generationOptions?.playwright?.errorBehavior;
+  const missingSemanticNameBehavior = resolveMissingSemanticNameBehavior(playwrightErrorBehavior);
   const generateFixtures = generationOptions?.playwright?.fixtures;
   const customPoms = generationOptions?.playwright?.customPoms;
 
@@ -273,7 +314,7 @@ export function createVuePomGeneratorPlugins(options: VuePomGeneratorPluginOptio
 
       if (generationEnabled) {
         assertNonEmptyString(outDir, "[vue-pom-generator] generation.outDir");
-        assertOneOf(missingSemanticNameBehavior, ["ignore", "error"], "[vue-pom-generator] generation.playwright.missingSemanticNameBehavior");
+        assertPlaywrightErrorBehavior(playwrightErrorBehavior, "[vue-pom-generator] generation.playwright.errorBehavior");
         assertRouterModuleShims(routerModuleShims, "[vue-pom-generator] generation.router.moduleShims");
 
         if (generationOptions?.router && routerType === "vue-router") {

--- a/plugin/create-vue-pom-generator-plugins.ts
+++ b/plugin/create-vue-pom-generator-plugins.ts
@@ -7,7 +7,7 @@ import type { VuePomGeneratorLogger, VuePomGeneratorVerbosity } from "./logger";
 import { createLogger } from "./logger";
 import { createSupportPlugins } from "./support-plugins";
 import { createTestIdsVirtualModulesPlugin } from "./support/virtual-modules";
-import type { ExistingIdBehavior, MissingSemanticNameBehavior, PlaywrightErrorBehavior, PlaywrightErrorBehaviorOptions, PomNameCollisionBehavior, RouterModuleShimDefinition, VuePluginOwnership, VuePomGeneratorPluginOptions } from "./types";
+import type { ErrorBehavior, ErrorBehaviorOptions, ExistingIdBehavior, MissingSemanticNameBehavior, PomNameCollisionBehavior, RouterModuleShimDefinition, VuePluginOwnership, VuePomGeneratorPluginOptions } from "./types";
 import { createVuePluginWithTestIds } from "./vue-plugin";
 
 import type { ElementMetadata } from "../metadata-collector";
@@ -37,10 +37,10 @@ function assertOneOf<T extends string>(value: T | undefined, allowed: readonly T
   throw new TypeError(`${name} must be one of: ${allowed.join(", ")}.`);
 }
 
-function assertPlaywrightErrorBehavior(
-  value: PlaywrightErrorBehavior | undefined,
+function assertErrorBehavior(
+  value: ErrorBehavior | undefined,
   name: string,
-): asserts value is PlaywrightErrorBehavior {
+): asserts value is ErrorBehavior {
   if (!value) {
     return;
   }
@@ -53,9 +53,9 @@ function assertPlaywrightErrorBehavior(
     throw new TypeError(`${name} must be "ignore", "error", or an object.`);
   }
 
-  const supportedKeys = new Set<keyof PlaywrightErrorBehaviorOptions>(["missingSemanticNameBehavior"]);
+  const supportedKeys = new Set<keyof ErrorBehaviorOptions>(["missingSemanticNameBehavior"]);
   for (const key of Object.keys(value)) {
-    if (!supportedKeys.has(key as keyof PlaywrightErrorBehaviorOptions)) {
+    if (!supportedKeys.has(key as keyof ErrorBehaviorOptions)) {
       throw new TypeError(`${name} contains unsupported key "${key}".`);
     }
   }
@@ -64,7 +64,7 @@ function assertPlaywrightErrorBehavior(
 }
 
 function resolveMissingSemanticNameBehavior(
-  value: PlaywrightErrorBehavior | undefined,
+  value: ErrorBehavior | undefined,
 ): MissingSemanticNameBehavior {
   if (!value) {
     return "ignore";
@@ -271,8 +271,8 @@ export function createVuePomGeneratorPlugins(options: VuePomGeneratorPluginOptio
   const vuePluginOwnership: VuePluginOwnership = isNuxt ? "external" : (options.vuePluginOwnership ?? "internal");
   const usesExternalVuePlugin = vuePluginOwnership === "external";
   const csharp = generationOptions?.csharp;
-  const playwrightErrorBehavior = generationOptions?.playwright?.errorBehavior;
-  const missingSemanticNameBehavior = resolveMissingSemanticNameBehavior(playwrightErrorBehavior);
+  const errorBehavior = options.errorBehavior;
+  const missingSemanticNameBehavior = resolveMissingSemanticNameBehavior(errorBehavior);
   const generateFixtures = generationOptions?.playwright?.fixtures;
   const customPoms = generationOptions?.playwright?.customPoms;
 
@@ -311,10 +311,10 @@ export function createVuePomGeneratorPlugins(options: VuePomGeneratorPluginOptio
       assertNonEmptyString(testIdAttribute, "[vue-pom-generator] injection.attribute");
       assertNonEmptyString(viewsDir, "[vue-pom-generator] injection.viewsDir");
       assertNonEmptyStringArray(wrapperSearchRoots, "[vue-pom-generator] injection.wrapperSearchRoots");
+      assertErrorBehavior(errorBehavior, "[vue-pom-generator] errorBehavior");
 
       if (generationEnabled) {
         assertNonEmptyString(outDir, "[vue-pom-generator] generation.outDir");
-        assertPlaywrightErrorBehavior(playwrightErrorBehavior, "[vue-pom-generator] generation.playwright.errorBehavior");
         assertRouterModuleShims(routerModuleShims, "[vue-pom-generator] generation.router.moduleShims");
 
         if (generationOptions?.router && routerType === "vue-router") {

--- a/plugin/create-vue-pom-generator-plugins.ts
+++ b/plugin/create-vue-pom-generator-plugins.ts
@@ -7,7 +7,7 @@ import type { VuePomGeneratorLogger, VuePomGeneratorVerbosity } from "./logger";
 import { createLogger } from "./logger";
 import { createSupportPlugins } from "./support-plugins";
 import { createTestIdsVirtualModulesPlugin } from "./support/virtual-modules";
-import type { ExistingIdBehavior, PomNameCollisionBehavior, RouterModuleShimDefinition, VuePluginOwnership, VuePomGeneratorPluginOptions } from "./types";
+import type { ExistingIdBehavior, MissingSemanticNameBehavior, PomNameCollisionBehavior, RouterModuleShimDefinition, VuePluginOwnership, VuePomGeneratorPluginOptions } from "./types";
 import { createVuePluginWithTestIds } from "./vue-plugin";
 
 import type { ElementMetadata } from "../metadata-collector";
@@ -26,6 +26,15 @@ function assertNonEmptyStringArray(value: string[] | undefined, name: string): a
   for (const [index, entry] of value.entries()) {
     assertNonEmptyString(entry, `${name}[${index}]`);
   }
+}
+
+function assertOneOf<T extends string>(value: T | undefined, allowed: readonly T[], name: string): asserts value is T {
+  if (!value)
+    return;
+  if (allowed.includes(value)) {
+    return;
+  }
+  throw new TypeError(`${name} must be one of: ${allowed.join(", ")}.`);
 }
 
 function assertRouterModuleShims(
@@ -222,6 +231,7 @@ export function createVuePomGeneratorPlugins(options: VuePomGeneratorPluginOptio
   const vuePluginOwnership: VuePluginOwnership = isNuxt ? "external" : (options.vuePluginOwnership ?? "internal");
   const usesExternalVuePlugin = vuePluginOwnership === "external";
   const csharp = generationOptions?.csharp;
+  const missingSemanticNameBehavior: MissingSemanticNameBehavior = generationOptions?.playwright?.missingSemanticNameBehavior ?? "ignore";
   const generateFixtures = generationOptions?.playwright?.fixtures;
   const customPoms = generationOptions?.playwright?.customPoms;
 
@@ -263,6 +273,7 @@ export function createVuePomGeneratorPlugins(options: VuePomGeneratorPluginOptio
 
       if (generationEnabled) {
         assertNonEmptyString(outDir, "[vue-pom-generator] generation.outDir");
+        assertOneOf(missingSemanticNameBehavior, ["ignore", "error"], "[vue-pom-generator] generation.playwright.missingSemanticNameBehavior");
         assertRouterModuleShims(routerModuleShims, "[vue-pom-generator] generation.router.moduleShims");
 
         if (generationOptions?.router && routerType === "vue-router") {
@@ -276,7 +287,7 @@ export function createVuePomGeneratorPlugins(options: VuePomGeneratorPluginOptio
 
       // Small but helpful diagnostics.
       loggerRef.current.info(`projectRoot=${projectRootRef.current}`);
-      loggerRef.current.info(`Active plugins: ${config.plugins.map(p => p.name).filter(n => n.includes('vue-pom')).join(', ')}`);
+      loggerRef.current.info(`Active plugins: ${(config.plugins ?? []).map(p => p.name).filter(n => n.includes('vue-pom')).join(', ')}`);
     }
   };
 
@@ -315,6 +326,7 @@ export function createVuePomGeneratorPlugins(options: VuePomGeneratorPluginOptio
     scanDirs,
     getWrapperSearchRoots: getWrapperSearchRootsAbs,
     nameCollisionBehavior,
+    missingSemanticNameBehavior,
     existingIdBehavior,
     outDir,
     emitLanguages,

--- a/plugin/support-plugins.ts
+++ b/plugin/support-plugins.ts
@@ -19,6 +19,7 @@ interface SupportFactoryOptions {
   scanDirs: string[];
   getWrapperSearchRoots: () => string[];
   nameCollisionBehavior?: PomNameCollisionBehavior;
+  missingSemanticNameBehavior?: "ignore" | "error";
   /** How to handle existing data-testid attributes in the source. */
   existingIdBehavior?: "preserve" | "overwrite" | "error";
 
@@ -61,6 +62,7 @@ export function createSupportPlugins(options: SupportFactoryOptions): PluginOpti
     scanDirs,
     getWrapperSearchRoots,
     nameCollisionBehavior = "suffix",
+    missingSemanticNameBehavior,
     existingIdBehavior,
     outDir,
     emitLanguages,
@@ -127,6 +129,7 @@ export function createSupportPlugins(options: SupportFactoryOptions): PluginOpti
     customPomImportNameCollisionBehavior,
     testIdAttribute,
     nameCollisionBehavior,
+    missingSemanticNameBehavior,
     existingIdBehavior,
     nativeWrappers,
     excludedComponents,
@@ -156,6 +159,7 @@ export function createSupportPlugins(options: SupportFactoryOptions): PluginOpti
     customPomImportAliases,
     customPomImportNameCollisionBehavior,
     nameCollisionBehavior,
+    missingSemanticNameBehavior,
     existingIdBehavior,
     testIdAttribute,
     routerAwarePoms,

--- a/plugin/support/build-plugin.ts
+++ b/plugin/support/build-plugin.ts
@@ -40,6 +40,7 @@ interface BuildProcessorOptions {
 
   /** How to handle POM member-name collisions. */
   nameCollisionBehavior?: PomNameCollisionBehavior;
+  missingSemanticNameBehavior?: "ignore" | "error";
   /** How to handle existing data-testid attributes. */
   existingIdBehavior?: "preserve" | "overwrite" | "error";
   /** Native wrapper component config. */
@@ -113,6 +114,7 @@ export function createBuildProcessorPlugin(options: BuildProcessorOptions): Plug
     customPomImportNameCollisionBehavior,
     testIdAttribute,
     nameCollisionBehavior,
+    missingSemanticNameBehavior,
     existingIdBehavior,
     nativeWrappers,
     excludedComponents,
@@ -252,6 +254,7 @@ export function createBuildProcessorPlugin(options: BuildProcessorOptions): Plug
                   existingIdBehavior: existingIdBehavior ?? "preserve",
                   testIdAttribute,
                   nameCollisionBehavior,
+                  missingSemanticNameBehavior,
                   warn: (message: string) => loggerRef.current.warn(message),
                   vueFilesPathMap,
                   wrapperSearchRoots: getWrapperSearchRoots(),

--- a/plugin/support/dev-plugin.ts
+++ b/plugin/support/dev-plugin.ts
@@ -39,6 +39,7 @@ interface DevProcessorOptions {
   customPomImportAliases?: Record<string, string>;
   customPomImportNameCollisionBehavior?: "error" | "alias";
   nameCollisionBehavior?: PomNameCollisionBehavior;
+  missingSemanticNameBehavior?: "ignore" | "error";
   /** How to handle existing data-testid attributes in the source. */
   existingIdBehavior?: "preserve" | "overwrite" | "error";
   testIdAttribute: string;
@@ -70,6 +71,7 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
     customPomImportAliases,
     customPomImportNameCollisionBehavior,
     nameCollisionBehavior = "suffix",
+    missingSemanticNameBehavior,
     existingIdBehavior,
     testIdAttribute,
     routerAwarePoms,
@@ -281,6 +283,7 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
               {
                 existingIdBehavior: existingIdBehavior ?? "preserve",
                 nameCollisionBehavior,
+                missingSemanticNameBehavior,
                 testIdAttribute,
                 warn: message => loggerRef.current.warn(message),
                 vueFilesPathMap: targetVuePathMap,

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -3,6 +3,7 @@ import type { NativeWrappersMap } from "../utils";
 
 export type ExistingIdBehavior = "preserve" | "overwrite" | "error";
 export type VuePluginOwnership = "internal" | "external";
+export type MissingSemanticNameBehavior = "ignore" | "error";
 
 /**
  * Controls what happens when the generator would emit duplicate POM member names within a single class.
@@ -235,6 +236,14 @@ export interface VuePomGeneratorPluginOptions {
 
     /** Playwright-specific generation features (fixtures + custom POM helpers). */
     playwright?: {
+      /**
+       * Controls what happens when an interactive wrapper action cannot yield a usable semantic name.
+       *
+       * - `"ignore"` (default): allow existing generic fallback behavior
+       * - `"error"`: fail generation and require a stable, nameable action signal
+       */
+      missingSemanticNameBehavior?: MissingSemanticNameBehavior;
+
       /**
        * Generate Playwright fixture helpers alongside generated POMs.
        *

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -4,10 +4,10 @@ import type { NativeWrappersMap } from "../utils";
 export type ExistingIdBehavior = "preserve" | "overwrite" | "error";
 export type VuePluginOwnership = "internal" | "external";
 export type MissingSemanticNameBehavior = "ignore" | "error";
-export interface PlaywrightErrorBehaviorOptions {
+export interface ErrorBehaviorOptions {
   missingSemanticNameBehavior?: MissingSemanticNameBehavior;
 }
-export type PlaywrightErrorBehavior = MissingSemanticNameBehavior | PlaywrightErrorBehaviorOptions;
+export type ErrorBehavior = MissingSemanticNameBehavior | ErrorBehaviorOptions;
 
 /**
  * Controls what happens when the generator would emit duplicate POM member names within a single class.
@@ -54,6 +54,19 @@ export interface VuePomGeneratorPluginOptions {
      */
     verbosity?: "silent" | "warn" | "info" | "debug";
   };
+
+  /**
+   * Controls strict/error behavior for generator checks.
+   *
+   * - `"ignore"` (default): keep current permissive defaults for all supported strictness checks
+   * - `"error"`: enable error-on-failure behavior for all supported strictness checks
+   * - `{ ... }`: override individual checks without enabling all of them
+   *
+   * Current scope: this first pass is intentionally narrow. The object form currently supports
+   * `missingSemanticNameBehavior`, which targets button-like wrappers with `:handler` during
+   * Playwright generation.
+   */
+  errorBehavior?: ErrorBehavior;
 
   /**
    * Configuration for injecting/deriving test ids from Vue templates.
@@ -240,15 +253,6 @@ export interface VuePomGeneratorPluginOptions {
 
     /** Playwright-specific generation features (fixtures + custom POM helpers). */
     playwright?: {
-      /**
-       * Controls strict/error behavior for Playwright generation.
-       *
-       * - `"ignore"` (default): keep current permissive defaults for all supported strictness checks
-       * - `"error"`: enable error-on-failure behavior for all supported strictness checks
-       * - `{ ... }`: override individual checks without enabling all of them
-       */
-      errorBehavior?: PlaywrightErrorBehavior;
-
       /**
        * Generate Playwright fixture helpers alongside generated POMs.
        *

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -4,6 +4,10 @@ import type { NativeWrappersMap } from "../utils";
 export type ExistingIdBehavior = "preserve" | "overwrite" | "error";
 export type VuePluginOwnership = "internal" | "external";
 export type MissingSemanticNameBehavior = "ignore" | "error";
+export interface PlaywrightErrorBehaviorOptions {
+  missingSemanticNameBehavior?: MissingSemanticNameBehavior;
+}
+export type PlaywrightErrorBehavior = MissingSemanticNameBehavior | PlaywrightErrorBehaviorOptions;
 
 /**
  * Controls what happens when the generator would emit duplicate POM member names within a single class.
@@ -237,12 +241,13 @@ export interface VuePomGeneratorPluginOptions {
     /** Playwright-specific generation features (fixtures + custom POM helpers). */
     playwright?: {
       /**
-       * Controls what happens when an interactive wrapper action cannot yield a usable semantic name.
+       * Controls strict/error behavior for Playwright generation.
        *
-       * - `"ignore"` (default): allow existing generic fallback behavior
-       * - `"error"`: fail generation and require a stable, nameable action signal
+       * - `"ignore"` (default): keep current permissive defaults for all supported strictness checks
+       * - `"error"`: enable error-on-failure behavior for all supported strictness checks
+       * - `{ ... }`: override individual checks without enabling all of them
        */
-      missingSemanticNameBehavior?: MissingSemanticNameBehavior;
+      errorBehavior?: PlaywrightErrorBehavior;
 
       /**
        * Generate Playwright fixture helpers alongside generated POMs.

--- a/tests/dev-plugin-options.test.ts
+++ b/tests/dev-plugin-options.test.ts
@@ -10,6 +10,7 @@ import type { IComponentDependencies, NativeWrappersMap } from "../utils";
 interface CreateTestIdTransformOptions {
   existingIdBehavior?: string;
   nameCollisionBehavior?: string;
+  missingSemanticNameBehavior?: string;
   testIdAttribute?: string;
   warn?: (message: string) => void;
   vueFilesPathMap?: Map<string, string>;
@@ -109,6 +110,7 @@ describe("dev processor option plumbing", () => {
         basePageClassPath,
         customPomAttachments: [],
         nameCollisionBehavior: "error",
+        missingSemanticNameBehavior: "error",
         testIdAttribute: "data-testid",
         routerAwarePoms: false,
         loggerRef: {
@@ -141,6 +143,7 @@ describe("dev processor option plumbing", () => {
       expect(transformOptions).toMatchObject({
         existingIdBehavior: "preserve",
         nameCollisionBehavior: "error",
+        missingSemanticNameBehavior: "error",
         testIdAttribute: "data-testid",
         wrapperSearchRoots,
       });

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -135,12 +135,27 @@ describe("createVuePomGeneratorPlugins options", () => {
     expect(names).toContain("vue-pom-generator-dev");
   });
 
-  it("accepts generation.playwright.missingSemanticNameBehavior", () => {
+  it("accepts generation.playwright.errorBehavior as a string", () => {
     const plugins = createVuePomGeneratorPlugins({
       generation: {
         outDir: "./tests/playwright/generated",
         playwright: {
-          missingSemanticNameBehavior: "error",
+          errorBehavior: "error",
+        },
+      },
+    });
+
+    expect(() => runConfigResolved(plugins)).not.toThrow();
+  });
+
+  it("accepts generation.playwright.errorBehavior as an object", () => {
+    const plugins = createVuePomGeneratorPlugins({
+      generation: {
+        outDir: "./tests/playwright/generated",
+        playwright: {
+          errorBehavior: {
+            missingSemanticNameBehavior: "error",
+          },
         },
       },
     });
@@ -176,17 +191,32 @@ describe("createVuePomGeneratorPlugins options", () => {
     expect(() => runConfigResolved(plugins)).toThrow("generation.router.entry");
   });
 
-  it("fails fast for invalid generation.playwright.missingSemanticNameBehavior", () => {
+  it("fails fast for invalid generation.playwright.errorBehavior string", () => {
     const plugins = createVuePomGeneratorPlugins({
       generation: {
         outDir: "tests/playwright/generated",
         playwright: {
-          missingSemanticNameBehavior: "strict" as "ignore",
+          errorBehavior: "strict" as "ignore",
         },
       },
     });
 
-    expect(() => runConfigResolved(plugins)).toThrow("generation.playwright.missingSemanticNameBehavior");
+    expect(() => runConfigResolved(plugins)).toThrow("generation.playwright.errorBehavior");
+  });
+
+  it("fails fast for invalid generation.playwright.errorBehavior object", () => {
+    const plugins = createVuePomGeneratorPlugins({
+      generation: {
+        outDir: "tests/playwright/generated",
+        playwright: {
+          errorBehavior: {
+            missingSemanticNameBehavior: "strict" as "ignore",
+          },
+        },
+      },
+    });
+
+    expect(() => runConfigResolved(plugins)).toThrow("generation.playwright.errorBehavior.missingSemanticNameBehavior");
   });
 
   it("fails fast when generation.router.moduleShims has an empty export list", () => {

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -135,28 +135,24 @@ describe("createVuePomGeneratorPlugins options", () => {
     expect(names).toContain("vue-pom-generator-dev");
   });
 
-  it("accepts generation.playwright.errorBehavior as a string", () => {
+  it("accepts root-level errorBehavior as a string", () => {
     const plugins = createVuePomGeneratorPlugins({
+      errorBehavior: "error",
       generation: {
         outDir: "./tests/playwright/generated",
-        playwright: {
-          errorBehavior: "error",
-        },
       },
     });
 
     expect(() => runConfigResolved(plugins)).not.toThrow();
   });
 
-  it("accepts generation.playwright.errorBehavior as an object", () => {
+  it("accepts root-level errorBehavior as an object", () => {
     const plugins = createVuePomGeneratorPlugins({
+      errorBehavior: {
+        missingSemanticNameBehavior: "error",
+      },
       generation: {
         outDir: "./tests/playwright/generated",
-        playwright: {
-          errorBehavior: {
-            missingSemanticNameBehavior: "error",
-          },
-        },
       },
     });
 
@@ -191,32 +187,28 @@ describe("createVuePomGeneratorPlugins options", () => {
     expect(() => runConfigResolved(plugins)).toThrow("generation.router.entry");
   });
 
-  it("fails fast for invalid generation.playwright.errorBehavior string", () => {
+  it("fails fast for invalid root-level errorBehavior string", () => {
     const plugins = createVuePomGeneratorPlugins({
+      errorBehavior: "strict" as "ignore",
       generation: {
         outDir: "tests/playwright/generated",
-        playwright: {
-          errorBehavior: "strict" as "ignore",
-        },
       },
     });
 
-    expect(() => runConfigResolved(plugins)).toThrow("generation.playwright.errorBehavior");
+    expect(() => runConfigResolved(plugins)).toThrow("errorBehavior");
   });
 
-  it("fails fast for invalid generation.playwright.errorBehavior object", () => {
+  it("fails fast for invalid root-level errorBehavior object", () => {
     const plugins = createVuePomGeneratorPlugins({
+      errorBehavior: {
+        missingSemanticNameBehavior: "strict" as "ignore",
+      },
       generation: {
         outDir: "tests/playwright/generated",
-        playwright: {
-          errorBehavior: {
-            missingSemanticNameBehavior: "strict" as "ignore",
-          },
-        },
       },
     });
 
-    expect(() => runConfigResolved(plugins)).toThrow("generation.playwright.errorBehavior.missingSemanticNameBehavior");
+    expect(() => runConfigResolved(plugins)).toThrow("errorBehavior.missingSemanticNameBehavior");
   });
 
   it("fails fast when generation.router.moduleShims has an empty export list", () => {
@@ -252,6 +244,9 @@ describe("createVuePomGeneratorPlugins options", () => {
 
   it("supports alias and typed config helper exports", () => {
     const config = defineVuePomGeneratorConfig({
+      errorBehavior: {
+        missingSemanticNameBehavior: "error",
+      },
       generation: false,
       vueOptions: {
         script: { defineModel: true },
@@ -261,6 +256,9 @@ describe("createVuePomGeneratorPlugins options", () => {
     const plugins = vuePomGenerator(config);
     expect(Array.isArray(plugins)).toBe(true);
     expect(plugins.length).toBeGreaterThan(0);
+    expect(config.errorBehavior).toEqual({
+      missingSemanticNameBehavior: "error",
+    });
   });
 
   it("patches the resolved vite:vue plugin for Nuxt projects", () => {

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -135,6 +135,19 @@ describe("createVuePomGeneratorPlugins options", () => {
     expect(names).toContain("vue-pom-generator-dev");
   });
 
+  it("accepts generation.playwright.missingSemanticNameBehavior", () => {
+    const plugins = createVuePomGeneratorPlugins({
+      generation: {
+        outDir: "./tests/playwright/generated",
+        playwright: {
+          missingSemanticNameBehavior: "error",
+        },
+      },
+    });
+
+    expect(() => runConfigResolved(plugins)).not.toThrow();
+  });
+
   it("fails fast for invalid injection.viewsDir", () => {
     const plugins = createVuePomGeneratorPlugins({
       injection: { viewsDir: "   " },
@@ -161,6 +174,19 @@ describe("createVuePomGeneratorPlugins options", () => {
     });
 
     expect(() => runConfigResolved(plugins)).toThrow("generation.router.entry");
+  });
+
+  it("fails fast for invalid generation.playwright.missingSemanticNameBehavior", () => {
+    const plugins = createVuePomGeneratorPlugins({
+      generation: {
+        outDir: "tests/playwright/generated",
+        playwright: {
+          missingSemanticNameBehavior: "strict" as "ignore",
+        },
+      },
+    });
+
+    expect(() => runConfigResolved(plugins)).toThrow("generation.playwright.missingSemanticNameBehavior");
   });
 
   it("fails fast when generation.router.moduleShims has an empty export list", () => {

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -720,6 +720,29 @@ describe('createTestIdTransform', () => {
     expect(deps?.generatedMethods?.has('clickRunDeploymentActionAssign')).toBe(true)
   })
 
+  it('fails fast for button-like wrapper handlers that cannot produce a semantic name when configured', () => {
+    const componentHierarchyMap = new Map<string, IComponentDependencies>()
+    const nativeWrappers: NativeWrappersMap = {
+      LoadButton: { role: 'button' },
+    }
+
+    expect(() => {
+      compileAndCaptureAst(
+        `
+          <LoadButton :handler="() => person && impersonateUser(person.userId!)">
+            Impersonate
+          </LoadButton>
+        `,
+        {
+          filename: '/src/views/RbacUserDetailsPage.vue',
+          nodeTransforms: [createTestIdTransform('RbacUserDetailsPage', componentHierarchyMap, nativeWrappers, [], '/src/views', {
+            missingSemanticNameBehavior: 'error',
+          })],
+        },
+      )
+    }).toThrow(/move complex inline logic into a named function/i)
+  })
+
   it('emits per-key click methods when v-for iterates a static literal list', () => {
     const componentHierarchyMap = new Map()
 

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -367,6 +367,15 @@ describe("utils.ts coverage", () => {
     expect(info?.semanticNameHint).toBe("SetShowModalTrue");
   });
 
+  it("does not derive a :handler semanticNameHint from logical-expression arrow bodies", () => {
+    const root = parseTemplate(`
+      <LoadButton :handler="() => person && impersonateUser(person.userId!)">Impersonate</LoadButton>
+    `);
+    const el = firstElement(root);
+
+    expect(nodeHandlerAttributeInfo(el)).toBeNull();
+  });
+
   it("handles :key extraction paths", () => {
     const ast = parseTemplate("<div :key=\"item.id\" />");
     const el = firstElement(ast);

--- a/transform.ts
+++ b/transform.ts
@@ -1303,7 +1303,7 @@ export function createTestIdTransform(
         + `Handler: ${handlerSource}\n\n`
         + `Fix: move complex inline logic into a named function (for example, const onAction = () => ...; then bind :handler="onAction"), `
         + `or simplify the handler to a direct identifier/call the generator can name. `
-        + `You can also set generation.playwright.missingSemanticNameBehavior = "ignore" to keep generic fallback behavior.`,
+        + `You can also set generation.playwright.errorBehavior = "ignore" to keep generic fallback behavior.`,
       );
     }
 

--- a/transform.ts
+++ b/transform.ts
@@ -874,6 +874,7 @@ export function createTestIdTransform(
     existingIdBehavior?: "preserve" | "overwrite" | "error";
     testIdAttribute?: string;
     nameCollisionBehavior?: "error" | "warn" | "suffix";
+    missingSemanticNameBehavior?: "ignore" | "error";
     warn?: (message: string) => void;
     vueFilesPathMap?: Map<string, string>;
     wrapperSearchRoots?: string[];
@@ -882,6 +883,7 @@ export function createTestIdTransform(
   const existingIdBehavior = options.existingIdBehavior ?? "preserve";
   const testIdAttribute = (options.testIdAttribute || "data-testid").trim() || "data-testid";
   const nameCollisionBehavior = options.nameCollisionBehavior ?? "suffix";
+  const missingSemanticNameBehavior = options.missingSemanticNameBehavior ?? "ignore";
   const warn = options.warn;
   const vueFilesPathMap = options.vueFilesPathMap;
   const wrapperSearchRoots = options.wrapperSearchRoots ?? [];
@@ -1276,6 +1278,34 @@ export function createTestIdTransform(
     // Inline the old nodeShouldBeIgnored gating logic, but compute signals incrementally.
     // Native wrapper detection + option-prefix needs are computed in one place to avoid duplicate checks.
     const { nativeWrappersValue, optionDataTestIdPrefixValue, semanticNameHint } = getNativeWrapperTransformInfo(element, componentName, nativeWrappers);
+    const handlerDirective = element.props.find((p): p is DirectiveNode => {
+      return p.type === NodeTypes.DIRECTIVE
+        && p.name === "bind"
+        && p.arg?.type === NodeTypes.SIMPLE_EXPRESSION
+        && p.arg.content === "handler"
+        && !!p.exp;
+    }) ?? null;
+    const handlerInfo = handlerDirective ? nodeHandlerAttributeInfo(element) : null;
+
+    if (
+      missingSemanticNameBehavior === "error"
+      && nativeWrappers[element.tag]?.role === "button"
+      && handlerDirective
+      && !handlerInfo
+    ) {
+      const loc = element.loc?.start;
+      const locationHint = loc ? `${loc.line}:${loc.column}` : "unknown";
+      const handlerSource = (handlerDirective.exp?.loc?.source ?? "").trim() || "<unknown>";
+
+      throw new Error(
+        `[vue-pom-generator] Could not derive a semantic POM action name for button-like wrapper in ${componentName} (${context.filename ?? "unknown"}:${locationHint}).\n`
+        + `Element: <${element.tag}>\n`
+        + `Handler: ${handlerSource}\n\n`
+        + `Fix: move complex inline logic into a named function (for example, const onAction = () => ...; then bind :handler="onAction"), `
+        + `or simplify the handler to a direct identifier/call the generator can name. `
+        + `You can also set generation.playwright.missingSemanticNameBehavior = "ignore" to keep generic fallback behavior.`,
+      );
+    }
 
     if (nativeWrappersValue) {
       // Some wrappers (e.g. option-driven selects) require the option prefix even when we have a
@@ -1440,7 +1470,6 @@ export function createTestIdTransform(
       return;
     }
 
-    const handlerInfo = nodeHandlerAttributeInfo(element);
     if (handlerInfo) {
       const testId = getHandlerAttributeValueDataTestId(handlerInfo.semanticNameHint);
 

--- a/transform.ts
+++ b/transform.ts
@@ -1303,7 +1303,7 @@ export function createTestIdTransform(
         + `Handler: ${handlerSource}\n\n`
         + `Fix: move complex inline logic into a named function (for example, const onAction = () => ...; then bind :handler="onAction"), `
         + `or simplify the handler to a direct identifier/call the generator can name. `
-        + `You can also set generation.playwright.errorBehavior = "ignore" to keep generic fallback behavior.`,
+        + `You can also set errorBehavior = "ignore" to keep generic fallback behavior.`,
       );
     }
 


### PR DESCRIPTION
## Summary
- add a root-level `errorBehavior` option with shorthand `"ignore"` / `"error"` modes plus an object form for granular overrides
- fail generation for button-like wrapper `:handler` bindings when the resolved error behavior enables the semantic-name check and the generator cannot derive a semantic action name
- document the new config shape and add regression coverage for config parsing, transform behavior, and the unsupported logical-expression handler shape

## Why
Complex inline wrapper handlers can currently degrade into generic generated APIs. A root-level strictness knob makes the config easier to discover and leaves room for broader generator-wide error handling without burying the setting under `generation.playwright`.

## Validation
- `npm run build`
- `npm test`

## Notes
- the object form currently supports `missingSemanticNameBehavior`; the string shorthand applies to all supported checks
- this first pass is intentionally narrow: it targets button-like wrapper `:handler` bindings and leaves existing model/value naming flows alone
- `npm run lint` still fails on the existing repository baseline in unrelated files, so it was not a meaningful gate for this change.