### PR TITLE
fix: preserve richer dev POM snapshots

### DIFF
--- a/plugin/support/dev-plugin.ts
+++ b/plugin/support/dev-plugin.ts
@@ -14,6 +14,7 @@ import { createTestIdTransform } from "../../transform";
 import type { IComponentDependencies, NativeWrappersMap, RouterIntrospectionResult } from "../../utils";
 import { setResolveToComponentNameFn, setRouteNameToComponentNameMap, toPascalCase } from "../../utils";
 import type { VuePomGeneratorLogger } from "../logger";
+import { getGenerationMetrics, isLessRich, type GenerationMetrics } from "./generation-metrics";
 import { resolveComponentNameFromPath } from "../path-utils";
 import type { PlaywrightOutputStructure, PomNameCollisionBehavior, RouterModuleShimDefinition } from "../types";
 
@@ -220,6 +221,11 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
       let snapshotHierarchy = new Map<string, IComponentDependencies>();
       let snapshotVuePathMap = new Map<string, string>();
       const filePathToComponentName = new Map<string, string>();
+      let lastGeneratedMetrics: GenerationMetrics = {
+        entryCount: 0,
+        selectorCount: 0,
+        generatedMethodCount: 0,
+      };
 
       const getComponentNameForFile = (filePath: string) => {
         const normalized = path.resolve(filePath);
@@ -331,6 +337,25 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
       };
 
       const generateAggregatedFromSnapshot = (reason: string) => {
+        const metrics = getGenerationMetrics(snapshotHierarchy);
+        if (metrics.selectorCount <= 0) {
+          logDebug(
+            `skip generate(${reason}): no selectors detected `
+            + `(entries=${metrics.entryCount} methods=${metrics.generatedMethodCount})`,
+          );
+          return;
+        }
+
+        if (isLessRich(metrics, lastGeneratedMetrics)) {
+          logDebug(
+            `skip generate(${reason}): snapshot less rich than previous `
+            + `(entries=${metrics.entryCount}/${lastGeneratedMetrics.entryCount} `
+            + `selectors=${metrics.selectorCount}/${lastGeneratedMetrics.selectorCount} `
+            + `methods=${metrics.generatedMethodCount}/${lastGeneratedMetrics.generatedMethodCount})`,
+          );
+          return;
+        }
+
         const t0 = performance.now();
         generateFiles(snapshotHierarchy, snapshotVuePathMap, normalizedBasePagePath, {
           outDir,
@@ -350,8 +375,13 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
           routerEntry: resolvedRouterEntry,
           routerType,
         });
+        lastGeneratedMetrics = metrics;
         const t1 = performance.now();
-        logInfo(`generate(${reason}): components=${snapshotHierarchy.size} in ${formatMs(t1 - t0)}`);
+        logInfo(
+          `generate(${reason}): components=${snapshotHierarchy.size} `
+          + `selectors=${metrics.selectorCount} methods=${metrics.generatedMethodCount} `
+          + `in ${formatMs(t1 - t0)}`,
+        );
       };
 
       let timer: NodeJS.Timeout | null = null;

--- a/plugin/support/dev-plugin.ts
+++ b/plugin/support/dev-plugin.ts
@@ -304,7 +304,7 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
         return { componentName, ms: performance.now() - started, compiled: true };
       };
 
-      const fullRebuildSnapshotFromFilesystem = () => {
+      const fullRebuildSnapshotFromFilesystem = (reason: string) => {
         const t0 = performance.now();
         const nextHierarchy = new Map<string, IComponentDependencies>();
         const nextVuePathMap = new Map<string, string>();
@@ -332,28 +332,25 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
         snapshotVuePathMap = nextVuePathMap;
 
         const t1 = performance.now();
-        logInfo(`initial scan: found ${totalVueFiles} .vue files in ${scanDirs.join(", ")}`);
-        logInfo(`initial compile: ${compiledCount}/${totalVueFiles} files in ${formatMs(t1 - t0)} (components=${snapshotHierarchy.size})`);
+        logInfo(`scan(${reason}): found ${totalVueFiles} .vue files in ${scanDirs.join(", ")}`);
+        logInfo(`compile(${reason}): ${compiledCount}/${totalVueFiles} files in ${formatMs(t1 - t0)} (components=${snapshotHierarchy.size})`);
       };
 
       const generateAggregatedFromSnapshot = (reason: string) => {
-        const metrics = getGenerationMetrics(snapshotHierarchy);
-        if (metrics.selectorCount <= 0) {
-          logDebug(
-            `skip generate(${reason}): no selectors detected `
-            + `(entries=${metrics.entryCount} methods=${metrics.generatedMethodCount})`,
-          );
-          return;
-        }
+        let metrics = getGenerationMetrics(snapshotHierarchy);
+        const shouldConfirmWithFilesystem = reason !== "startup"
+          && (metrics.selectorCount <= 0 || isLessRich(metrics, lastGeneratedMetrics));
 
-        if (isLessRich(metrics, lastGeneratedMetrics)) {
+        if (shouldConfirmWithFilesystem) {
           logDebug(
-            `skip generate(${reason}): snapshot less rich than previous `
+            `confirm generate(${reason}): incremental snapshot may be incomplete `
             + `(entries=${metrics.entryCount}/${lastGeneratedMetrics.entryCount} `
             + `selectors=${metrics.selectorCount}/${lastGeneratedMetrics.selectorCount} `
             + `methods=${metrics.generatedMethodCount}/${lastGeneratedMetrics.generatedMethodCount})`,
           );
-          return;
+
+          fullRebuildSnapshotFromFilesystem(`${reason}:filesystem-confirmation`);
+          metrics = getGenerationMetrics(snapshotHierarchy);
         }
 
         const t0 = performance.now();
@@ -392,7 +389,7 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
       const initialBuildPromise = (async () => {
         const t0 = performance.now();
         await routerInitPromise;
-        fullRebuildSnapshotFromFilesystem();
+        fullRebuildSnapshotFromFilesystem("startup");
         generateAggregatedFromSnapshot("startup");
         const t1 = performance.now();
         logInfo(`startup total: ${formatMs(t1 - t0)}`);

--- a/tests/build-serve-parity.test.ts
+++ b/tests/build-serve-parity.test.ts
@@ -10,9 +10,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import type { CompilerOptions } from "@vue/compiler-dom";
 import * as compilerDom from "@vue/compiler-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { generateFiles } from "../class-generation";
 import { createDevProcessorPlugin } from "../plugin/support/dev-plugin";
+import { getGenerationMetrics } from "../plugin/support/generation-metrics";
 
 // Mock generateFiles so the dev plugin doesn't try to write real files
 // (which would fail because base-page.ts doesn't exist in the temp dir).
@@ -51,6 +54,12 @@ function createDevServerStub(): DevServerStub {
     },
     restart: vi.fn(),
   };
+}
+
+function getWatcherHandler(server: DevServerStub, event: string) {
+  const call = server.watcher.on.mock.calls.find(([name]) => name === event);
+  expect(call).toBeTruthy();
+  return call![1] as (path: string) => void;
 }
 
 function createTmpProjectWithSfc(
@@ -110,9 +119,11 @@ function makeDevPlugin(
 
 describe("build–serve parity: dev plugin integration", () => {
   let compileSpy: ReturnType<typeof vi.spyOn>;
+  const realCompile = compilerDom.compile;
 
   beforeEach(() => {
     compileSpy = vi.spyOn(compilerDom, "compile");
+    vi.mocked(generateFiles).mockClear();
   });
 
   afterEach(() => {
@@ -277,6 +288,75 @@ export default defineComponent({
 
       // Should NOT throw.
       await (plugin as any).configureServer!(server);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("regenerates with fewer components when a vue file is legitimately deleted", async () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pom-parity-delete-"));
+    fs.mkdirSync(path.join(projectRoot, "src", "components"), { recursive: true });
+    fs.mkdirSync(path.join(projectRoot, "src", "views"), { recursive: true });
+
+    const alphaPath = path.join(projectRoot, "src", "components", "Alpha.vue");
+    const betaPath = path.join(projectRoot, "src", "components", "Beta.vue");
+    fs.writeFileSync(alphaPath, '<template><button @click="save()">Alpha</button></template>');
+    fs.writeFileSync(betaPath, '<template><button @click="save()">Beta</button></template>');
+
+    try {
+      const plugin = makeDevPlugin(projectRoot);
+      const server = createDevServerStub();
+      await (plugin as any).configureServer!(server);
+
+      const initialSnapshot = vi.mocked(generateFiles).mock.calls.at(-1)?.[0] as Map<string, unknown>;
+      expect(initialSnapshot.size).toBe(2);
+
+      fs.rmSync(betaPath);
+      const unlink = getWatcherHandler(server, "unlink");
+      unlink(betaPath);
+
+      await new Promise(resolve => setTimeout(resolve, 900));
+
+      const finalSnapshot = vi.mocked(generateFiles).mock.calls.at(-1)?.[0] as Map<string, unknown>;
+      expect(finalSnapshot.size).toBe(1);
+      expect(finalSnapshot.has("Alpha")).toBe(true);
+      expect(finalSnapshot.has("Beta")).toBe(false);
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("confirms suspicious incremental snapshots with a filesystem rebuild before emitting", async () => {
+    const { projectRoot, cleanup } = createTmpProjectWithSfc(
+      '<template><button @click="save()">Recover</button></template>',
+      "Recoverable.vue",
+    );
+
+    try {
+      const plugin = makeDevPlugin(projectRoot);
+      const server = createDevServerStub();
+      await (plugin as any).configureServer!(server);
+
+      const initialSnapshot = vi.mocked(generateFiles).mock.calls.at(-1)?.[0] as Map<string, any>;
+      const initialMetrics = getGenerationMetrics(initialSnapshot);
+      expect(initialMetrics.selectorCount).toBeGreaterThan(0);
+
+      let intercepted = false;
+      compileSpy.mockImplementation((template: string, options?: CompilerOptions) => {
+        if (!intercepted && (options as any)?.filename?.includes("Recoverable.vue")) {
+          intercepted = true;
+          return {} as any;
+        }
+
+        return realCompile(template, options as any);
+      });
+
+      await (plugin as any).handleHotUpdate({ file: path.join(projectRoot, "src", "components", "Recoverable.vue") });
+      await new Promise(resolve => setTimeout(resolve, 900));
+
+      const finalSnapshot = vi.mocked(generateFiles).mock.calls.at(-1)?.[0] as Map<string, any>;
+      const finalMetrics = getGenerationMetrics(finalSnapshot);
+      expect(finalMetrics).toEqual(initialMetrics);
     } finally {
       cleanup();
     }

--- a/tests/generation-metrics.test.ts
+++ b/tests/generation-metrics.test.ts
@@ -44,4 +44,17 @@ describe("generation metrics", () => {
     expect(isLessRich(smaller, richer)).toBe(true);
     expect(isLessRich(richer, smaller)).toBe(false);
   });
+
+  it("treats selector-less snapshots as less rich than previous generated output", () => {
+    const richer = getGenerationMetrics(new Map([
+      ["HomeIndex", makeDeps(["a", "b"], 2)],
+    ]));
+
+    const selectorLess = getGenerationMetrics(new Map([
+      ["HomeIndex", makeDeps([], 0)],
+    ]));
+
+    expect(selectorLess.selectorCount).toBe(0);
+    expect(isLessRich(selectorLess, richer)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- prevent the dev plugin from overwriting generated POMs with selector-less snapshots
- skip dev regeneration when the current snapshot is less rich than the last generated output
- add regression coverage for selector-less snapshots so the guard stays in place

## Why
During Nuxt dev startup, the dev plugin could observe an incomplete snapshot and overwrite previously rich generated C#/TS page objects with a nearly empty aggregate file. That breaks downstream Playwright builds even though the source pages still contain selectors.