### PR TITLE
fix: guard manual releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,12 @@ jobs:
     name: Release
     needs: test
     runs-on: ubuntu-latest
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor != 'github-actions[bot]') || github.event_name == 'workflow_dispatch'
+    if: >-
+      (github.event_name == 'push' &&
+       github.ref == 'refs/heads/main' &&
+       github.actor != 'github-actions[bot]') ||
+      (github.event_name == 'workflow_dispatch' &&
+       github.ref == 'refs/heads/main')
     permissions:
       contents: write
       id-token: write

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -769,6 +769,27 @@ describe('createTestIdTransform', () => {
     }).not.toThrow()
   })
 
+  it('keeps permissive wrapper handler fallback by default', () => {
+    const componentHierarchyMap = new Map<string, IComponentDependencies>()
+    const nativeWrappers: NativeWrappersMap = {
+      LoadButton: { role: 'button' },
+    }
+
+    expect(() => {
+      compileAndCaptureAst(
+        `
+          <LoadButton :handler="() => person && impersonateUser(person.userId!)">
+            Impersonate
+          </LoadButton>
+        `,
+        {
+          filename: '/src/views/RbacUserDetailsPage.vue',
+          nodeTransforms: [createTestIdTransform('RbacUserDetailsPage', componentHierarchyMap, nativeWrappers, [], '/src/views')],
+        },
+      )
+    }).not.toThrow()
+  })
+
   it('emits per-key click methods when v-for iterates a static literal list', () => {
     const componentHierarchyMap = new Map()
 

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -769,27 +769,6 @@ describe('createTestIdTransform', () => {
     }).not.toThrow()
   })
 
-  it('keeps permissive wrapper handler fallback by default', () => {
-    const componentHierarchyMap = new Map<string, IComponentDependencies>()
-    const nativeWrappers: NativeWrappersMap = {
-      LoadButton: { role: 'button' },
-    }
-
-    expect(() => {
-      compileAndCaptureAst(
-        `
-          <LoadButton :handler="() => person && impersonateUser(person.userId!)">
-            Impersonate
-          </LoadButton>
-        `,
-        {
-          filename: '/src/views/RbacUserDetailsPage.vue',
-          nodeTransforms: [createTestIdTransform('RbacUserDetailsPage', componentHierarchyMap, nativeWrappers, [], '/src/views')],
-        },
-      )
-    }).not.toThrow()
-  })
-
   it('emits per-key click methods when v-for iterates a static literal list', () => {
     const componentHierarchyMap = new Map()
 


### PR DESCRIPTION
## Summary
- restrict manual `workflow_dispatch` releases to `main`

## Why
This keeps ad-hoc release publishes aligned with the default branch instead of letting a manually dispatched run publish from some other ref.

## Testing
- npm run typecheck
- npm test
- npm run build