### PR TITLE
fix: support awaited handler wrappers

### DIFF
--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -725,6 +725,31 @@ describe('createTestIdTransform', () => {
     expect(deps?.generatedMethods?.has('clickRunDeploymentActionAssign')).toBe(true)
   })
 
+  it('accepts async await wrapper handlers in strict mode', () => {
+    const componentHierarchyMap = new Map<string, IComponentDependencies>()
+    const nativeWrappers: NativeWrappersMap = {
+      LoadButton: { role: 'button' },
+    }
+
+    expect(() => {
+      compileAndCaptureAst(
+        `
+          <LoadButton :handler="async () => await refreshOauthAccessToken(data.id)">
+            Refresh now
+          </LoadButton>
+        `,
+        {
+          filename: '/src/views/OauthAccessTokensListPage.vue',
+          nodeTransforms: [createTestIdTransform('OauthAccessTokensListPage', componentHierarchyMap, nativeWrappers, [], '/src/views')],
+        },
+      )
+    }).not.toThrow()
+
+    const deps = componentHierarchyMap.get('OauthAccessTokensListPage') as IComponentDependencies | undefined
+    expect(deps).toBeTruthy()
+    expect(deps?.generatedMethods?.has('clickRefreshOauthAccessToken')).toBe(true)
+  })
+
   it('fails fast for button-like wrapper handlers that cannot produce a semantic name by default', () => {
     const componentHierarchyMap = new Map<string, IComponentDependencies>()
     const nativeWrappers: NativeWrappersMap = {

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -338,6 +338,20 @@ describe("utils.ts coverage", () => {
     expect(info?.semanticNameHint).toBe("RunDeploymentActionAssignSuppress");
   });
 
+  it("derives :handler semanticNameHint from async await call lambdas", () => {
+    const root = parseTemplate(`
+      <LoadButton :handler="async () => await refreshOauthAccessToken(data.id)">
+        Refresh now
+      </LoadButton>
+    `);
+    const el = firstElement(root);
+
+    const info = nodeHandlerAttributeInfo(el);
+    expect(info).toBeTruthy();
+    expect(info?.semanticNameHint).toBe("RefreshOauthAccessToken");
+    expect(nodeHandlerAttributeValue(el)).toBe("RefreshOauthAccessToken");
+  });
+
   it("derives :handler semanticNameHint from assignment-bodied arrow functions", () => {
     const root = parseTemplate(`
       <LoadButton :handler="() => showResetLocalDatabaseModal = true">Reset</LoadButton>

--- a/utils.ts
+++ b/utils.ts
@@ -911,6 +911,12 @@ export function nodeHandlerAttributeInfo(node: ElementNode): HandlerAttributeInf
     const n = node as { callee?: object; arguments?: object[] };
     return typeof n.callee === "object" && n.callee !== null && Array.isArray(n.arguments);
   };
+  const isAwaitExpressionNode = (node: object | null): node is { type: "AwaitExpression"; argument: object } => {
+    if (!isNodeType(node, "AwaitExpression"))
+      return false;
+    const n = node as { argument?: object };
+    return typeof n.argument === "object" && n.argument !== null;
+  };
   const isAssignmentExpressionNode = (node: object | null): node is { type: "AssignmentExpression"; left: object; right: object } => {
     if (!isNodeType(node, "AssignmentExpression"))
       return false;
@@ -1175,14 +1181,17 @@ export function nodeHandlerAttributeInfo(node: ElementNode): HandlerAttributeInf
     const body = expr.body;
 
     const tryFromCallExpression = (call: object | null) => {
-      if (!isCallExpressionNode(call)) {
+      const resolvedCall = isAwaitExpressionNode(call)
+        ? call.argument
+        : call;
+      if (!isCallExpressionNode(resolvedCall)) {
         return null;
       }
-      const name = getLastIdentifierFromMemberChain(call.callee);
+      const name = getLastIdentifierFromMemberChain(resolvedCall.callee);
       if (!name) {
         return null;
       }
-      const suffix = getStableSuffixFromCall(call);
+      const suffix = getStableSuffixFromCall(resolvedCall);
       const semanticNameHint = suffix
         ? `${toPascalCase(name)}${suffix}`
         : toPascalCase(name);


### PR DESCRIPTION
## Summary
- teach handler semantic-name derivation to unwrap awaited call expressions
- add regression coverage for async/await inline wrapper handlers in the low-level parser and strict transform path

## Why
Strict handler naming already supports inline lambdas like `() => refreshOauthAccessToken(data.id)`, but it rejected the async/await form `async () => await refreshOauthAccessToken(data.id)`. That syntax shows up in Immybot and should resolve to the same semantic action name.

## Testing
- npm run typecheck
- npm test
- npm run build