### PR TITLE
fix: harden local app integration

### DIFF
--- a/.github/workflows/workflows/ci.yml
+++ b/.github/workflows/workflows/ci.yml
@@ -179,7 +179,8 @@ jobs:
           # VS Code/Electron expects a DBus session bus. In containerized runs (e.g. act) the
           # inherited DBUS_SESSION_BUS_ADDRESS can be invalid (e.g. macOS 'launchd:'), causing
           # VS Code to exit before emitting the test server readiness line.
-          xvfb-run --auto-servernum --server-args='-screen 0 1280x1024x24' npm run demo:pw
+          XVFB_SCREEN_SIZE="$(node ./scripts/playwright-video-settings.mjs screen-size)"
+          xvfb-run --auto-servernum --server-args="-screen 0 ${XVFB_SCREEN_SIZE}" npm run demo:pw
 
           # Re-arrange the recorded video(s) into a stable, shareable layout for artifact upload.
           #
@@ -255,6 +256,8 @@ jobs:
               --max 1 \
               --name demo.mp4 \
               --dedupe
+
+            bash ./scripts/normalize-playwright-videos.sh docs/pw-videos
           fi
 
       - name: Convert staged videos to MP4 (dedupe)
@@ -283,6 +286,8 @@ jobs:
             --pattern '*.webm' \
             --max "${#webms[@]}" \
             --dedupe
+
+          bash ./scripts/normalize-playwright-videos.sh videos
 
           echo "Converted MP4s:"
           ls -la videos/*.mp4 || true
@@ -568,7 +573,8 @@ jobs:
       - name: Run tests (Xvfb)
         shell: bash
         run: |
-          xvfb-run --auto-servernum --server-args='-screen 0 1280x1024x24' npm test
+          XVFB_SCREEN_SIZE="$(node ./scripts/playwright-video-settings.mjs screen-size)"
+          xvfb-run --auto-servernum --server-args="-screen 0 ${XVFB_SCREEN_SIZE}" npm test
         env:
           CI: true
           PW_VSCODE_TEST_TRACE: '1'
@@ -719,7 +725,8 @@ jobs:
         env:
           PW_VSCODE_WAIT_FOR_LINE_TIMEOUT_MS: '10000'
         run: |
-          dbus-run-session -- xvfb-run --auto-servernum --server-args='-screen 0 1280x1024x24' npm run demo:pw:update-readme
+          XVFB_SCREEN_SIZE="$(node ./scripts/playwright-video-settings.mjs screen-size)"
+          dbus-run-session -- xvfb-run --auto-servernum --server-args="-screen 0 ${XVFB_SCREEN_SIZE}" npm run demo:pw:update-readme
 
       - name: Generate Release Notes
         run: npm run release:notes

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ export class UserEditorPage extends BasePage {
   get SaveButton() { /* Playwright locator */ }
 
   async typeEmailAddress(text: string, annotationText = "") { /* ... */ }
-  async clickSave(wait: boolean = true) { /* ... */ }
+  async clickSave(wait: boolean = true, annotationText = "") { /* ... */ }
 }
 ```
 

--- a/method-generation.ts
+++ b/method-generation.ts
@@ -124,8 +124,15 @@ function generateClickMethod(
     const clickMethod = createAsyncMethod(
       name,
       hasParam(params, "key")
-        ? [...baseParameters, createInlineParameter("wait", { type: "boolean", initializer: "true" })]
-        : [createInlineParameter("wait", { type: "boolean", initializer: "true" })],
+        ? [
+            ...baseParameters,
+            createInlineParameter("wait", { type: "boolean", initializer: "true" }),
+            createInlineParameter("annotationText", { type: "string", initializer: "\"\"" }),
+          ]
+        : [
+            createInlineParameter("wait", { type: "boolean", initializer: "true" }),
+            createInlineParameter("annotationText", { type: "string", initializer: "\"\"" }),
+          ],
       (writer) => {
         writer.writeLine(`const candidates = [${candidatesExpr}] as const;`);
         writer.writeLine("let lastError: unknown;");
@@ -133,7 +140,7 @@ function generateClickMethod(
           writer.writeLine("const locator = this.locatorByTestId(testId);");
           writer.write("try ").block(() => {
             writer.write("if (await locator.count()) ").block(() => {
-              writer.writeLine("await this.clickLocator(locator, \"\", wait);");
+              writer.writeLine("await this.clickLocator(locator, annotationText, wait);");
               writer.writeLine("return;");
             });
           });
@@ -145,10 +152,12 @@ function generateClickMethod(
       },
     );
 
-    const noWaitArgs = argsForForward ? `${argsForForward}, false` : "false";
+    const noWaitArgs = argsForForward ? `${argsForForward}, false, annotationText` : "false, annotationText";
     const noWaitMethod = createAsyncMethod(
       noWaitName,
-      hasParam(params, "key") ? baseParameters : [],
+      hasParam(params, "key")
+        ? [...baseParameters, createInlineParameter("annotationText", { type: "string", initializer: "\"\"" })]
+        : [createInlineParameter("annotationText", { type: "string", initializer: "\"\"" })],
       (writer) => {
         writer.writeLine(`await this.${name}(${noWaitArgs});`);
       },
@@ -159,22 +168,45 @@ function generateClickMethod(
 
   if (hasParam(params, "key")) {
     return [
-      createAsyncMethod(name, [...baseParameters, createInlineParameter("wait", { type: "boolean", initializer: "true" })], (writer) => {
-        writer.writeLine(`await this.clickByTestId(\`${formattedDataTestId}\`, "", wait);`);
-      }),
-      createAsyncMethod(noWaitName, baseParameters, (writer) => {
-        writer.writeLine(`await this.${name}(${argsForForward}, false);`);
-      }),
+      createAsyncMethod(
+        name,
+        [
+          ...baseParameters,
+          createInlineParameter("wait", { type: "boolean", initializer: "true" }),
+          createInlineParameter("annotationText", { type: "string", initializer: "\"\"" }),
+        ],
+        (writer) => {
+          writer.writeLine(`await this.clickByTestId(\`${formattedDataTestId}\`, annotationText, wait);`);
+        },
+      ),
+      createAsyncMethod(
+        noWaitName,
+        [...baseParameters, createInlineParameter("annotationText", { type: "string", initializer: "\"\"" })],
+        (writer) => {
+          writer.writeLine(`await this.${name}(${argsForForward}, false, annotationText);`);
+        },
+      ),
     ];
   }
 
   return [
-    createAsyncMethod(name, [createInlineParameter("wait", { type: "boolean", initializer: "true" })], (writer) => {
-      writer.writeLine(`await this.clickByTestId("${formattedDataTestId}", "", wait);`);
-    }),
-    createAsyncMethod(noWaitName, [], (writer) => {
-      writer.writeLine(`await this.${name}(false);`);
-    }),
+    createAsyncMethod(
+      name,
+      [
+        createInlineParameter("wait", { type: "boolean", initializer: "true" }),
+        createInlineParameter("annotationText", { type: "string", initializer: "\"\"" }),
+      ],
+      (writer) => {
+        writer.writeLine(`await this.clickByTestId("${formattedDataTestId}", annotationText, wait);`);
+      },
+    ),
+    createAsyncMethod(
+      noWaitName,
+      [createInlineParameter("annotationText", { type: "string", initializer: "\"\"" })],
+      (writer) => {
+        writer.writeLine(`await this.${name}(false, annotationText);`);
+      },
+    ),
   ];
 }
 

--- a/playwright-video-dimensions.json
+++ b/playwright-video-dimensions.json
@@ -1,0 +1,5 @@
+{
+  "width": 1920,
+  "height": 1080,
+  "xvfbColorDepth": 24
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,17 @@
+import { readFileSync } from "node:fs";
 import { defineConfig } from "@playwright/test";
+
+const videoDimensions = JSON.parse(
+  readFileSync(new URL("./playwright-video-dimensions.json", import.meta.url), "utf8"),
+) as {
+  height: number;
+  width: number;
+};
+
+const playwrightVideoSize = {
+  width: videoDimensions.width,
+  height: videoDimensions.height,
+} as const;
 
 export default defineConfig({
   testDir: "./tests/playwright",
@@ -8,11 +21,11 @@ export default defineConfig({
     baseURL: "http://127.0.0.1:4173",
     screenshot: "only-on-failure",
     trace: "retain-on-failure",
-    video: "on",
-    viewport: {
-      width: 1280,
-      height: 720,
+    video: {
+      mode: "on",
+      size: playwrightVideoSize,
     },
+    viewport: playwrightVideoSize,
   },
   webServer: {
     command: "node ./tests/playwright/serve-fixtures.mjs",

--- a/plugin/nuxt-discovery.ts
+++ b/plugin/nuxt-discovery.ts
@@ -5,6 +5,25 @@ import { pathToFileURL } from "node:url";
 
 const requireFromModule = createRequire(import.meta.url);
 
+function resolveNuxtKitEntry(cwd: string): string {
+  const attemptResolvers = [
+    createRequire(path.resolve(cwd, "package.json")),
+    requireFromModule,
+  ];
+  let lastError: Error | undefined;
+
+  for (const resolver of attemptResolvers) {
+    try {
+      return resolver.resolve("@nuxt/kit");
+    }
+    catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+    }
+  }
+
+  throw lastError ?? new Error("Unknown module resolution error");
+}
+
 interface NuxtComponentDirLike {
   path?: string;
 }
@@ -213,7 +232,7 @@ export async function loadNuxtProjectDiscovery(cwd: string = process.cwd()): Pro
   let getLayerDirectories: GetLayerDirectoriesLike | undefined;
 
   try {
-    const nuxtKitEntry = requireFromModule.resolve("@nuxt/kit");
+    const nuxtKitEntry = resolveNuxtKitEntry(cwd);
     ({ loadNuxtConfig, getLayerDirectories } = await import(pathToFileURL(nuxtKitEntry).href) as {
       loadNuxtConfig?: (options: { cwd: string }) => Promise<LoadedNuxtOptionsLike>;
       getLayerDirectories?: GetLayerDirectoriesLike;

--- a/plugin/vue-plugin.ts
+++ b/plugin/vue-plugin.ts
@@ -34,6 +34,18 @@ interface InternalFactoryOptions {
   getProjectRoot: () => string;
 }
 
+type VueCompilerSfcNamespace = Awaited<typeof import("@vue/compiler-sfc")>;
+
+function resolveCompilerSfcParse(compilerSfc: VueCompilerSfcNamespace): VueCompilerSfcNamespace["parse"] {
+  const parse = compilerSfc.parse
+    ?? (compilerSfc as VueCompilerSfcNamespace & { default?: Partial<VueCompilerSfcNamespace> }).default?.parse;
+  if (typeof parse !== "function") {
+    throw new TypeError("[vue-pom-generator] Failed to resolve @vue/compiler-sfc.parse.");
+  }
+
+  return parse;
+}
+
 /**
  * Traverses the AST and extracts metadata from elements with data-testid attributes.
  * Since we run as a nodeTransform, we must use an exit hook on the ROOT node
@@ -298,7 +310,8 @@ export function createVuePluginWithTestIds(options: InternalFactoryOptions): {
       const componentName = getComponentNameFromPath(cleanPath);
       loggerRef.current.debug(`Collecting metadata for ${cleanPath} (component: ${componentName})`);
 
-      const { parse } = await import("@vue/compiler-sfc");
+      const compilerSfc = await import("@vue/compiler-sfc");
+      const parse = resolveCompilerSfcParse(compilerSfc);
       const compilerDom = await import("@vue/compiler-dom");
       const compile = compilerDom.compile as (template: string, options: object) => object;
       const { descriptor } = parse(code, { filename: cleanPath });

--- a/scripts/normalize-playwright-videos.sh
+++ b/scripts/normalize-playwright-videos.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+target_dir="${1:-}"
+
+if [ -z "$target_dir" ]; then
+  echo "Usage: bash ./scripts/normalize-playwright-videos.sh <directory>"
+  exit 1
+fi
+
+if [ ! -d "$target_dir" ]; then
+  echo "No ${target_dir} directory present; nothing to normalize."
+  exit 0
+fi
+
+shopt -s nullglob
+mp4s=("${target_dir}"/*.mp4)
+
+if [ "${#mp4s[@]}" -eq 0 ]; then
+  echo "No MP4s under ${target_dir}; nothing to normalize."
+  exit 0
+fi
+
+ffmpeg_scale="$(node ./scripts/playwright-video-settings.mjs ffmpeg-scale)"
+
+for mp4 in "${mp4s[@]}"; do
+  normalized="${mp4%.mp4}.normalized.mp4"
+
+  ffmpeg -y \
+    -i "$mp4" \
+    -map 0:v:0 \
+    -map 0:a? \
+    -vf "scale=${ffmpeg_scale}:flags=lanczos" \
+    -c:v libx264 \
+    -preset medium \
+    -crf 23 \
+    -pix_fmt yuv420p \
+    -c:a copy \
+    -movflags +faststart \
+    "$normalized" \
+    >/dev/null 2>&1
+
+  mv "$normalized" "$mp4"
+done

--- a/scripts/playwright-video-settings.mjs
+++ b/scripts/playwright-video-settings.mjs
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+
+const settingsPath = new URL("../playwright-video-dimensions.json", import.meta.url);
+const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+
+const commands = {
+  "ffmpeg-scale": `${settings.width}:${settings.height}`,
+  "screen-size": `${settings.width}x${settings.height}x${settings.xvfbColorDepth}`,
+};
+
+const command = process.argv[2];
+
+if (!command || !(command in commands)) {
+  console.error("Usage: node ./scripts/playwright-video-settings.mjs <ffmpeg-scale|screen-size>");
+  process.exit(1);
+}
+
+process.stdout.write(commands[command]);

--- a/tests/generated-tsc.test.ts
+++ b/tests/generated-tsc.test.ts
@@ -605,7 +605,7 @@ describe("generated output", () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set([childAEntry]),
-      generatedMethods: new Map([["clickOnlyInAButton", { params: "wait: boolean = true", argNames: ["wait"] }]]),
+      generatedMethods: new Map([["clickOnlyInAButton", { params: "wait: boolean = true, annotationText: string = \"\"", argNames: ["wait", "annotationText"] }]]),
       isView: false,
     };
 
@@ -614,7 +614,7 @@ describe("generated output", () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set([childBEntry]),
-      generatedMethods: new Map([["clickSomethingElseButton", { params: "wait: boolean = true", argNames: ["wait"] }]]),
+      generatedMethods: new Map([["clickSomethingElseButton", { params: "wait: boolean = true, annotationText: string = \"\"", argNames: ["wait", "annotationText"] }]]),
       isView: false,
     };
 

--- a/tests/nuxt-discovery.test.ts
+++ b/tests/nuxt-discovery.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment node
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { describe, expect, it } from "vitest";
 
-import { resolveNuxtProjectDiscovery } from "../plugin/nuxt-discovery";
+import { loadNuxtProjectDiscovery, resolveNuxtProjectDiscovery } from "../plugin/nuxt-discovery";
 
 describe("resolveNuxtProjectDiscovery", () => {
   it("derives custom page dirs and automatic component dirs from resolved Nuxt config", () => {
@@ -35,5 +39,63 @@ describe("resolveNuxtProjectDiscovery", () => {
       "/project/shared/components",
     ]);
     expect(discovery.wrapperSearchRoots).toEqual([]);
+  });
+
+  it("loads @nuxt/kit from the target project cwd when available locally", async () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vue-pom-generator-nuxt-load-"));
+
+    try {
+      fs.writeFileSync(
+        path.join(projectRoot, "package.json"),
+        JSON.stringify({ name: "nuxt-load-fixture", private: true }),
+        "utf8",
+      );
+
+      const nuxtKitDir = path.join(projectRoot, "node_modules", "@nuxt", "kit");
+      fs.mkdirSync(nuxtKitDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(nuxtKitDir, "package.json"),
+        JSON.stringify({
+          name: "@nuxt/kit",
+          type: "module",
+          exports: "./index.js",
+        }),
+        "utf8",
+      );
+      fs.writeFileSync(
+        path.join(nuxtKitDir, "index.js"),
+        [
+          "export async function loadNuxtConfig({ cwd }) {",
+          "  return {",
+          "    rootDir: cwd,",
+          "    srcDir: `${cwd}/app`,",
+          "    dir: { pages: 'custom-pages', layouts: 'custom-layouts' },",
+          "    components: [{ path: '~/components' }],",
+          "  };",
+          "}",
+          "export function getLayerDirectories(nuxt) {",
+          "  return [{",
+          "    root: `${nuxt.options.rootDir}/`,",
+          "    app: `${nuxt.options.srcDir}/`,",
+          "    appPages: `${nuxt.options.srcDir}/${nuxt.options.dir?.pages ?? 'pages'}/`,",
+          "    appLayouts: `${nuxt.options.srcDir}/${nuxt.options.dir?.layouts ?? 'layouts'}/`,",
+          "  }];",
+          "}",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const discovery = await loadNuxtProjectDiscovery(projectRoot);
+
+      expect(discovery.rootDir).toBe(projectRoot);
+      expect(discovery.srcDir).toBe(path.join(projectRoot, "app"));
+      expect(discovery.pageDirs).toEqual([path.join(projectRoot, "app", "custom-pages")]);
+      expect(discovery.layoutDirs).toEqual([path.join(projectRoot, "app", "custom-layouts")]);
+      expect(discovery.componentDirs).toEqual([path.join(projectRoot, "app", "components")]);
+      expect(discovery.wrapperSearchRoots).toEqual([]);
+    }
+    finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -623,7 +623,7 @@ describe('createTestIdTransform', () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set(),
-      generatedMethods: new Map([['clickShowMediaLibrary', { params: 'wait: boolean = true', argNames: ['wait'] }]]),
+      generatedMethods: new Map([['clickShowMediaLibrary', { params: 'wait: boolean = true, annotationText: string = ""', argNames: ['wait', 'annotationText'] }]]),
       reservedPomMemberNames: new Set(['ShowMediaLibraryButton', 'clickShowMediaLibrary']),
       isView: false,
     })
@@ -660,7 +660,7 @@ describe('createTestIdTransform', () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set(),
-      generatedMethods: new Map([['clickShowMediaLibrary', { params: 'wait: boolean = true', argNames: ['wait'] }]]),
+      generatedMethods: new Map([['clickShowMediaLibrary', { params: 'wait: boolean = true, annotationText: string = ""', argNames: ['wait', 'annotationText'] }]]),
       reservedPomMemberNames: new Set(['ShowMediaLibraryButton', 'clickShowMediaLibrary']),
       isView: false,
     })
@@ -701,7 +701,7 @@ describe('createTestIdTransform', () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set(),
-      generatedMethods: new Map([['clickRunDeploymentAction', { params: 'wait: boolean = true', argNames: ['wait'] }]]),
+      generatedMethods: new Map([['clickRunDeploymentAction', { params: 'wait: boolean = true, annotationText: string = ""', argNames: ['wait', 'annotationText'] }]]),
       reservedPomMemberNames: new Set(['RunDeploymentActionButton', 'clickRunDeploymentAction']),
       isView: false,
     })
@@ -809,12 +809,12 @@ describe('createTestIdTransform', () => {
     expect(deps).toBeTruthy()
 
     const sigOne = deps?.generatedMethods?.get('clickOneButton') as { params: string, argNames: string[] } | null | undefined
-    expect(sigOne?.params).toBe('wait: boolean = true')
-    expect(sigOne?.argNames).toEqual(['wait'])
+    expect(sigOne?.params).toBe('wait: boolean = true, annotationText: string = ""')
+    expect(sigOne?.argNames).toEqual(['wait', 'annotationText'])
 
     const sigTwo = deps?.generatedMethods?.get('clickTwoButton') as { params: string, argNames: string[] } | null | undefined
-    expect(sigTwo?.params).toBe('wait: boolean = true')
-    expect(sigTwo?.argNames).toEqual(['wait'])
+    expect(sigTwo?.params).toBe('wait: boolean = true, annotationText: string = ""')
+    expect(sigTwo?.argNames).toEqual(['wait', 'annotationText'])
 
     // With the IR-based generator, v-for static literal keys are represented as extra click method specs.
     const extras = deps?.pomExtraMethods ?? []
@@ -825,7 +825,7 @@ describe('createTestIdTransform', () => {
       kind: 'testId',
       formattedDataTestId: 'MyComp-${key}-Select-button',
     })
-    expect(one?.params).toEqual({ wait: 'boolean = true' })
+    expect(one?.params).toEqual({ wait: 'boolean = true', annotationText: 'string = ""' })
 
     const two = extras.find(m => m.kind === 'click' && m.name === 'clickTwoButton')
     expect(two).toBeTruthy()
@@ -834,7 +834,7 @@ describe('createTestIdTransform', () => {
       kind: 'testId',
       formattedDataTestId: 'MyComp-${key}-Select-button',
     })
-    expect(two?.params).toEqual({ wait: 'boolean = true' })
+    expect(two?.params).toEqual({ wait: 'boolean = true', annotationText: 'string = ""' })
   })
 
   it('treats v-for source with Math.random() as dynamic via constType', () => {

--- a/utils.ts
+++ b/utils.ts
@@ -3305,11 +3305,14 @@ export function applyResolvedDataTestId(args: {
           formattedDataTestId: formattedDataTestIdForPom,
         },
         keyLiteral: rawValue,
-        params: { wait: "boolean = true" },
+        params: { wait: "boolean = true", annotationText: "string = \"\"" },
       });
 
       if (added) {
-        registerGeneratedMethodSignature(generatedName, { params: `wait: boolean = true`, argNames: ["wait"] });
+        registerGeneratedMethodSignature(generatedName, {
+          params: `wait: boolean = true, annotationText: string = ""`,
+          argNames: ["wait", "annotationText"],
+        });
       }
     }
 


### PR DESCRIPTION
## Summary
- pass annotation text through generated click helpers and document the new signature
- resolve `@vue/compiler-sfc.parse` and `@nuxt/kit` from real consuming-app setups
- centralize Playwright video dimensions for local config and CI normalization
- add regression coverage for project-local Nuxt kit loading

## Validation
- npm run lint
- npm run typecheck
- npm run build
- npm test