### PR TITLE
fix: avoid reparsing generated test ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ That example is intentionally small, but it shows the real contract:
 The generator does not use one naming trick. It layers several signals.
 
 - **Click actions** prefer semantic handler names such as `save`, `openDetails`, or `runImport`.
+- **Click handlers are instrumented** so generated Playwright helpers can wait on deterministic `__testid_event__` runtime events.
 - **Inputs and wrapper components** prefer `v-model`, wrapper `valueAttribute`, or related model-like bindings.
 - **Native elements** also consider `id` / `name` attributes.
 - **Router links / `:to` bindings** can contribute route-based naming and typed navigation return types when the target can be resolved.
@@ -976,18 +977,6 @@ The sections below follow the actual `VuePomGeneratorPluginOptions` shape from `
 
   ```ts
   injection: { wrapperSearchRoots: ["../shared-ui/src/components"] }
-  ```
-
-#### `injection.clickInstrumentation`
-
-- **What it does:** Controls whether runtime `@click` handlers emit `__testid_event__`.
-- **Why it exists:** some teams want the generated event stream, while others only want template injection and POM generation.
-- **Benefit:** the historical default behavior stays on, but you can explicitly disable click wrapping when needed.
-- **Without it:** default is `true`.
-- **Example:**
-
-  ```ts
-  injection: { clickInstrumentation: false }
   ```
 
 #### `injection.existingIdBehavior`

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The generator does not use one naming trick. It layers several signals.
 - **Router links / `:to` bindings** can contribute route-based naming and typed navigation return types when the target can be resolved.
 - **Wrapper components** can be explicit (`nativeWrappers`) or inferred from simple local SFC templates.
 - **Fallback naming exists, but it is intentionally conservative.** That is why `generation.nameCollisionBehavior` exists.
-- **Wrapper-action generation fails fast by default.** The generator blocks button-like wrapper `:handler` expressions that it cannot turn into a semantic action name; set `errorBehavior: "ignore"` if you explicitly want the old permissive fallback.
+- **Wrapper-action generation fails fast.** The generator blocks button-like wrapper `:handler` expressions that it cannot turn into a semantic action name.
 
 Important limit: wrapper inference is helpful, not magical. The current implementation recursively inspects simple local SFC templates for the first inferable primitive (`input`, `textarea`, `select`, `button`, `vselect`, radio/checkbox inputs). It also recognizes some naming patterns like `*Button`. For anything more complex, configure `nativeWrappers` explicitly.
 
@@ -206,7 +206,6 @@ const pomConfig = defineVuePomGeneratorConfig({
     script: { defineModel: true, propsDestructure: true },
   },
   logging: { verbosity: "info" },
-  errorBehavior: "error",
   injection: {
     attribute: "data-testid",
     viewsDir: "src/views",
@@ -219,7 +218,7 @@ const pomConfig = defineVuePomGeneratorConfig({
       AppRadioGroup: { role: "radio", requiresOptionDataTestIdPrefix: true },
     },
     excludeComponents: ["LegacyWidget"],
-    existingIdBehavior: "preserve",
+    existingIdBehavior: "error",
   },
   generation: {
     emit: ["ts", "csharp"],
@@ -227,7 +226,7 @@ const pomConfig = defineVuePomGeneratorConfig({
       namespace: "MyProject.Tests.Generated",
     },
     outDir: "tests/playwright/__generated__",
-    nameCollisionBehavior: "suffix",
+    nameCollisionBehavior: "error",
     router: {
       entry: "src/router/index.ts",
       moduleShims: {
@@ -850,18 +849,6 @@ The sections below follow the actual `VuePomGeneratorPluginOptions` shape from `
   logging: { verbosity: "debug" }
   ```
 
-#### `errorBehavior`
-
-- **What it does:** Controls strict/error behavior for generator checks.
-- **Why it exists:** complex inline handlers can otherwise fall through to generic naming, which makes generated APIs harder to discover and review.
-- **Benefit:** fail-fast behavior is the default, while `"ignore"` or the object form let you opt back into only the permissive checks you want.
-- **Without it:** the default is `"error"`, so unsupported button-wrapper handlers stop generation instead of silently falling back.
-- **Accepted values:**
-  - `"ignore"` — keep permissive defaults for all supported checks
-  - `"error"` — enable error-on-failure behavior for all supported checks (default)
-  - `{ missingSemanticNameBehavior: "ignore" }` — opt out only of the button-wrapper semantic-name check
-- **Current scope:** this first pass is intentionally narrow. The object form currently supports `missingSemanticNameBehavior`, which targets button-like wrappers with `:handler`; value/model-driven wrappers still use their existing naming flow.
-
 ### `injection`
 
 `injection` controls compile-time test-id derivation and template rewriting.
@@ -984,7 +971,7 @@ The sections below follow the actual `VuePomGeneratorPluginOptions` shape from `
 - **What it does:** Chooses what happens when a template already has the target attribute.
 - **Why it exists:** migrations usually start from a mixed codebase with manual ids already present.
 - **Benefit:** lets you migrate gradually (`preserve`), force replacement (`overwrite`), or enforce cleanup (`error`).
-- **Without it:** default is `"preserve"`.
+- **Without it:** default is `"error"`.
 - **Current options:**
   - `"preserve"` — keep the existing attribute
   - `"overwrite"` — replace it with the generated one
@@ -1031,7 +1018,7 @@ Set `generation: false` to keep injection and `virtual:testids` but skip emitted
 - **What it does:** Controls what happens when two generated members inside the same class want the same name.
 - **Why it exists:** collisions happen in real templates, especially when multiple elements share the same handler or weak fallback signals.
 - **Benefit:** lets you decide between strictness and convenience.
-- **Without it:** the generator silently suffixes (`"suffix"`).
+- **Without it:** the generator fails fast (`"error"`).
 - **Current options:**
   - `"error"` — fail fast
   - `"warn"` — warn and suffix

--- a/README.md
+++ b/README.md
@@ -978,6 +978,18 @@ The sections below follow the actual `VuePomGeneratorPluginOptions` shape from `
   injection: { wrapperSearchRoots: ["../shared-ui/src/components"] }
   ```
 
+#### `injection.clickInstrumentation`
+
+- **What it does:** Controls whether runtime `@click` handlers emit `__testid_event__`.
+- **Why it exists:** some teams want the generated event stream, while others only want template injection and POM generation.
+- **Benefit:** the historical default behavior stays on, but you can explicitly disable click wrapping when needed.
+- **Without it:** default is `true`.
+- **Example:**
+
+  ```ts
+  injection: { clickInstrumentation: false }
+  ```
+
 #### `injection.existingIdBehavior`
 
 - **What it does:** Chooses what happens when a template already has the target attribute.

--- a/class-generation/base-page.ts
+++ b/class-generation/base-page.ts
@@ -1,5 +1,5 @@
 import type { PwLocator, PwPage } from "./playwright-types";
-import { TESTID_CLICK_EVENT_NAME, TESTID_CLICK_EVENT_STRICT_FLAG } from "../click-instrumentation";
+import { TESTID_CLICK_EVENT_NAME } from "../click-instrumentation";
 import type { TestIdClickEventDetail } from "../click-instrumentation";
 import { Callout } from "./callout";
 import type { CalloutRenderer } from "./callout";
@@ -118,6 +118,10 @@ export class BasePage {
     this.pointer = new Pointer(this.page, this.testIdAttribute, this.callout, pointerRenderer);
   }
 
+  public get screencast(): PwPage["screencast"] {
+    return this.page.screencast;
+  }
+
   private async waitForTestIdClickEventAfter(testId: string, options?: { timeoutMs?: number }): Promise<void> {
     if (!REQUIRE_CLICK_EVENT) {
       return;
@@ -135,22 +139,12 @@ export class BasePage {
     // In that scenario, the click already did its job; don't fail the test infra.
     try {
       await this.page.evaluate(
-        ({ eventName, strictFlagName, expectedTestId, timeoutMs, requireEvent, debug }) => {
+        ({ eventName, expectedTestId, timeoutMs, requireEvent, debug }) => {
           return new Promise<void>((resolve, reject) => {
             const g = globalThis;
             if (!g || typeof g.addEventListener !== "function") {
               reject(new Error(`Click instrumentation not available (no addEventListener) for '${expectedTestId}'`));
               return;
-            }
-
-            // Mark strict mode in the page so the injected click wrapper can
-            // fail fast (no fallback) when instrumentation is expected.
-            if (requireEvent) {
-              try {
-                type GlobalWithFlag = typeof globalThis & { [k: string]: boolean | undefined };
-                (g as GlobalWithFlag)[strictFlagName] = true;
-              }
-              catch { /* noop */ }
             }
 
             const cleanup = (timer: ReturnType<typeof setTimeout>, onEvent: (evt: Event) => void) => {
@@ -216,7 +210,6 @@ export class BasePage {
         },
         {
           eventName: TESTID_CLICK_EVENT_NAME,
-          strictFlagName: TESTID_CLICK_EVENT_STRICT_FLAG,
           expectedTestId: testId,
           timeoutMs,
           requireEvent,

--- a/class-generation/index.ts
+++ b/class-generation/index.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { generateViewObjectModelMembers, generateViewObjectModelMethodContent } from "../method-generation";
+import { inferPomPatternKindFromFormattedString, isParameterizedPomPattern, type PomPatternKind } from "../pom-patterns";
 import { introspectNuxtPages, parseRouterFileFromCwd } from "../router-introspection";
 import {
   addExportAll,
@@ -467,7 +468,7 @@ function generateExtraClickMethodMembers(spec: PomExtraClickMethodSpec): TypeScr
   const waitArg = hasWait ? "wait" : "true";
 
   if (spec.selector.kind === "testId") {
-    const needsTemplate = spec.selector.formattedDataTestId.includes("${");
+    const needsTemplate = isParameterizedPomPattern(spec.selector.patternKind);
     const testIdExpr = needsTemplate
       ? `\`${spec.selector.formattedDataTestId}\``
       : JSON.stringify(spec.selector.formattedDataTestId);
@@ -504,8 +505,8 @@ function generateExtraClickMethodMembers(spec: PomExtraClickMethodSpec): TypeScr
     ];
   }
 
-  const rootNeedsTemplate = spec.selector.rootFormattedDataTestId.includes("${");
-  const labelNeedsTemplate = spec.selector.formattedLabel.includes("${");
+  const rootNeedsTemplate = isParameterizedPomPattern(spec.selector.rootPatternKind);
+  const labelNeedsTemplate = isParameterizedPomPattern(spec.selector.labelPatternKind);
   const rootExpr = rootNeedsTemplate
     ? `\`${spec.selector.rootFormattedDataTestId}\``
     : JSON.stringify(spec.selector.rootFormattedDataTestId);
@@ -545,6 +546,7 @@ function generateMethodMembersFromPom(primary: PomPrimarySpec, targetPageObjectM
     targetPageObjectModelClass,
     primary.methodName,
     primary.nativeRole,
+    primary.selectorPatternKind,
     primary.formattedDataTestId,
     primary.alternateFormattedDataTestIds,
     primary.getterNameOverride,
@@ -569,13 +571,14 @@ function generateMethodsContentForDependencies(dependencies: IComponentDependenc
       ? Object.fromEntries(Object.entries(pom.params).sort((a, b) => a[0].localeCompare(b[0])))
       : undefined;
     const alternates = (pom.alternateFormattedDataTestIds ?? []).slice().sort();
-    const key = JSON.stringify({
-      role: pom.nativeRole,
-      methodName: pom.methodName,
-      getterNameOverride: pom.getterNameOverride ?? null,
-      testId: pom.formattedDataTestId,
-      alternateTestIds: alternates.length ? alternates : undefined,
-      params: stableParams,
+      const key = JSON.stringify({
+        role: pom.nativeRole,
+        methodName: pom.methodName,
+        getterNameOverride: pom.getterNameOverride ?? null,
+        selectorPatternKind: pom.selectorPatternKind,
+        testId: pom.formattedDataTestId,
+        alternateTestIds: alternates.length ? alternates : undefined,
+        params: stableParams,
       target: target ?? null,
       emitPrimary: pom.emitPrimary ?? true,
     });
@@ -1071,9 +1074,9 @@ function buildGeneratedGitAttributesFiles(generatedFilePaths: string[]): Generat
     });
 }
 
-function toCSharpTestIdExpression(formattedDataTestId: string): string {
+function toCSharpTestIdExpression(formattedDataTestId: string, patternKind: PomPatternKind): string {
   // Convert our `${var}` placeholder format into C# interpolated-string `{var}`.
-  const needsInterpolation = formattedDataTestId.includes("${");
+  const needsInterpolation = isParameterizedPomPattern(patternKind);
   if (!needsInterpolation) {
     return JSON.stringify(formattedDataTestId);
   }
@@ -1253,11 +1256,12 @@ function generateAggregatedCSharpFiles(
       const baseMethodName = upperFirst(pom.methodName);
       const baseGetterName = upperFirst(pom.getterNameOverride ?? pom.methodName);
       const locatorName = baseGetterName.endsWith(roleSuffix) ? baseGetterName : `${baseGetterName}${roleSuffix}`;
-      const testIdExpr = toCSharpTestIdExpression(pom.formattedDataTestId);
+      const selectorIsParameterized = isParameterizedPomPattern(pom.selectorPatternKind);
+      const testIdExpr = toCSharpTestIdExpression(pom.formattedDataTestId, pom.selectorPatternKind);
 
       // Ensure all template variables referenced in formattedDataTestId (e.g. `${key}`)
-      // appear in the C# method signature.  utils.ts may omit `key` for input/select
-      // elements even when the test ID is dynamic, causing CS0103 compile errors.
+      // appear in the C# method signature. Stale/manual IR can still omit `key` on
+      // parameterized selectors, which would otherwise cause CS0103 compile errors.
       const templateVarMatches = [...pom.formattedDataTestId.matchAll(/\$\{(\w+)\}/g)];
       const templateVars = templateVarMatches.map(m => m[1]);
       const augmentedParams: Record<string, string> = { ...pom.params };
@@ -1278,7 +1282,7 @@ function generateAggregatedCSharpFiles(
       const allTestIds = [pom.formattedDataTestId, ...(pom.alternateFormattedDataTestIds ?? [])]
         .filter((v, idx, arr) => v && arr.indexOf(v) === idx);
 
-      if (pom.formattedDataTestId.includes("${")) {
+      if (selectorIsParameterized) {
         chunks.push(`    public ILocator ${locatorName}(${signature}) => LocatorByTestId(${testIdExpr});`);
       }
       else {
@@ -1300,13 +1304,13 @@ function generateAggregatedCSharpFiles(
       if (target) {
         chunks.push(`    public async Task<${target}> ${actionName}(${sig})`);
         chunks.push("    {");
-        if (pom.formattedDataTestId.includes("${") || allTestIds.length <= 1) {
-          chunks.push(`        await ${locatorName}${pom.formattedDataTestId.includes("${") ? `(${args})` : ""}.ClickAsync();`);
+        if (selectorIsParameterized || allTestIds.length <= 1) {
+          chunks.push(`        await ${locatorName}${selectorIsParameterized ? `(${args})` : ""}.ClickAsync();`);
           chunks.push(`        return new ${target}(Page);`);
         }
         else {
           chunks.push("        Exception? lastError = null;");
-          chunks.push(`        foreach (var testId in new[] { ${allTestIds.map(toCSharpTestIdExpression).join(", ")} })`);
+          chunks.push(`        foreach (var testId in new[] { ${allTestIds.map(testId => toCSharpTestIdExpression(testId, inferPomPatternKindFromFormattedString(testId))).join(", ")} })`);
           chunks.push("        {");
           chunks.push("            try");
           chunks.push("            {");
@@ -1332,7 +1336,7 @@ function generateAggregatedCSharpFiles(
       chunks.push(`    public async Task ${actionName}(${sig})`);
       chunks.push("    {");
 
-      const callSuffix = pom.formattedDataTestId.includes("${") ? `(${args})` : "";
+      const callSuffix = selectorIsParameterized ? `(${args})` : "";
 
       const emitActionCall = (locatorAccess: string) => {
         if (pom.nativeRole === "input") {
@@ -1351,9 +1355,9 @@ function generateAggregatedCSharpFiles(
         }
       };
 
-      if (!pom.formattedDataTestId.includes("${") && allTestIds.length > 1) {
+      if (!selectorIsParameterized && allTestIds.length > 1) {
         chunks.push("        Exception? lastError = null;");
-        chunks.push(`        foreach (var testId in new[] { ${allTestIds.map(toCSharpTestIdExpression).join(", ")} })`);
+        chunks.push(`        foreach (var testId in new[] { ${allTestIds.map(testId => toCSharpTestIdExpression(testId, inferPomPatternKindFromFormattedString(testId))).join(", ")} })`);
         chunks.push("        {");
         chunks.push("            try");
         chunks.push("            {");
@@ -1417,8 +1421,8 @@ function generateAggregatedCSharpFiles(
       }
 
       if (extra.selector.kind === "testId") {
-        const needsTemplate = extra.selector.formattedDataTestId.includes("${");
-        const testIdExpr = toCSharpTestIdExpression(extra.selector.formattedDataTestId);
+        const needsTemplate = isParameterizedPomPattern(extra.selector.patternKind);
+        const testIdExpr = toCSharpTestIdExpression(extra.selector.formattedDataTestId, extra.selector.patternKind);
         if (needsTemplate) {
           chunks.push(`        var testId = ${testIdExpr};`);
           chunks.push("        await LocatorByTestId(testId).ClickAsync();");
@@ -1428,10 +1432,10 @@ function generateAggregatedCSharpFiles(
         }
       }
       else {
-        const rootNeedsTemplate = extra.selector.rootFormattedDataTestId.includes("${");
-        const labelNeedsTemplate = extra.selector.formattedLabel.includes("${");
-        const rootExpr = toCSharpTestIdExpression(extra.selector.rootFormattedDataTestId);
-        const labelExpr = toCSharpTestIdExpression(extra.selector.formattedLabel);
+        const rootNeedsTemplate = isParameterizedPomPattern(extra.selector.rootPatternKind);
+        const labelNeedsTemplate = isParameterizedPomPattern(extra.selector.labelPatternKind);
+        const rootExpr = toCSharpTestIdExpression(extra.selector.rootFormattedDataTestId, extra.selector.rootPatternKind);
+        const labelExpr = toCSharpTestIdExpression(extra.selector.formattedLabel, extra.selector.labelPatternKind);
         const exactArg = extra.selector.exact === false ? "false" : "true";
 
         if (rootNeedsTemplate) {

--- a/class-generation/index.ts
+++ b/class-generation/index.ts
@@ -10,6 +10,8 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { generateViewObjectModelMembers, generateViewObjectModelMethodContent } from "../method-generation";
 import {
+  bindCSharpPomPattern,
+  bindTypeScriptPomPattern,
   ensurePomPatternParameters,
   isParameterizedPomPattern,
   toCSharpPomPatternExpression,
@@ -477,11 +479,10 @@ function generateExtraClickMethodMembers(spec: PomExtraClickMethodSpec): TypeScr
   const waitArg = hasWait ? "wait" : "true";
 
   if (spec.selector.kind === "testId") {
-    const needsTemplate = isParameterizedPomPattern(spec.selector.testId.patternKind);
-    const testIdExpr = toTypeScriptPomPatternExpression(spec.selector.testId);
+    const testIdBinding = bindTypeScriptPomPattern(spec.selector.testId, "testId");
 
     const clickArgs: string[] = [];
-    clickArgs.push(needsTemplate ? "testId" : testIdExpr);
+    clickArgs.push(testIdBinding.expression);
 
     if (hasAnnotationText || hasWait) {
       clickArgs.push(annotationArg);
@@ -499,8 +500,8 @@ function generateExtraClickMethodMembers(spec: PomExtraClickMethodSpec): TypeScr
           if (spec.keyLiteral !== undefined) {
             writer.writeLine(`const key = ${JSON.stringify(spec.keyLiteral)};`);
           }
-          if (needsTemplate) {
-            writer.writeLine(`const testId = ${testIdExpr};`);
+          for (const statement of testIdBinding.setupStatements) {
+            writer.writeLine(statement);
           }
           writer.writeLine(`await this.clickByTestId(${clickArgs.join(", ")});`);
         },
@@ -508,13 +509,8 @@ function generateExtraClickMethodMembers(spec: PomExtraClickMethodSpec): TypeScr
     ];
   }
 
-  const rootNeedsTemplate = isParameterizedPomPattern(spec.selector.rootTestId.patternKind);
-  const labelNeedsTemplate = isParameterizedPomPattern(spec.selector.label.patternKind);
-  const rootExpr = toTypeScriptPomPatternExpression(spec.selector.rootTestId);
-  const labelExpr = toTypeScriptPomPatternExpression(spec.selector.label);
-
-  const rootArg = rootNeedsTemplate ? "rootTestId" : rootExpr;
-  const labelArg = labelNeedsTemplate ? "label" : labelExpr;
+  const rootBinding = bindTypeScriptPomPattern(spec.selector.rootTestId, "rootTestId");
+  const labelBinding = bindTypeScriptPomPattern(spec.selector.label, "label");
   return [
     createClassMethod({
       name: spec.name,
@@ -524,13 +520,13 @@ function generateExtraClickMethodMembers(spec: PomExtraClickMethodSpec): TypeScr
         if (spec.keyLiteral !== undefined) {
           writer.writeLine(`const key = ${JSON.stringify(spec.keyLiteral)};`);
         }
-        if (rootNeedsTemplate) {
-          writer.writeLine(`const rootTestId = ${rootExpr};`);
+        for (const statement of rootBinding.setupStatements) {
+          writer.writeLine(statement);
         }
-        if (labelNeedsTemplate) {
-          writer.writeLine(`const label = ${labelExpr};`);
+        for (const statement of labelBinding.setupStatements) {
+          writer.writeLine(statement);
         }
-        writer.writeLine(`await this.clickWithinTestIdByLabel(${rootArg}, ${labelArg}, ${annotationArg}, ${waitArg});`);
+        writer.writeLine(`await this.clickWithinTestIdByLabel(${rootBinding.expression}, ${labelBinding.expression}, ${annotationArg}, ${waitArg});`);
       },
     }),
   ];
@@ -1394,33 +1390,24 @@ function generateAggregatedCSharpFiles(
       }
 
       if (extra.selector.kind === "testId") {
-        const needsTemplate = isParameterizedPomPattern(extra.selector.testId.patternKind);
-        const testIdExpr = toCSharpPomPatternExpression(extra.selector.testId);
-        if (needsTemplate) {
-          chunks.push(`        var testId = ${testIdExpr};`);
-          chunks.push("        await LocatorByTestId(testId).ClickAsync();");
+        const testIdBinding = bindCSharpPomPattern(extra.selector.testId, "testId");
+        for (const statement of testIdBinding.setupStatements) {
+          chunks.push(`        ${statement}`);
         }
-        else {
-          chunks.push(`        await LocatorByTestId(${testIdExpr}).ClickAsync();`);
-        }
+        chunks.push(`        await LocatorByTestId(${testIdBinding.expression}).ClickAsync();`);
       }
       else {
-        const rootNeedsTemplate = isParameterizedPomPattern(extra.selector.rootTestId.patternKind);
-        const labelNeedsTemplate = isParameterizedPomPattern(extra.selector.label.patternKind);
-        const rootExpr = toCSharpPomPatternExpression(extra.selector.rootTestId);
-        const labelExpr = toCSharpPomPatternExpression(extra.selector.label);
+        const rootBinding = bindCSharpPomPattern(extra.selector.rootTestId, "rootTestId");
+        const labelBinding = bindCSharpPomPattern(extra.selector.label, "label");
         const exactArg = extra.selector.exact === false ? "false" : "true";
 
-        if (rootNeedsTemplate) {
-          chunks.push(`        var rootTestId = ${rootExpr};`);
+        for (const statement of rootBinding.setupStatements) {
+          chunks.push(`        ${statement}`);
         }
-        if (labelNeedsTemplate) {
-          chunks.push(`        var label = ${labelExpr};`);
+        for (const statement of labelBinding.setupStatements) {
+          chunks.push(`        ${statement}`);
         }
-
-        const rootArg = rootNeedsTemplate ? "rootTestId" : rootExpr;
-        const labelArg = labelNeedsTemplate ? "label" : labelExpr;
-        chunks.push(`        await ClickWithinTestIdByLabelAsync(${rootArg}, ${labelArg}, ${exactArg});`);
+        chunks.push(`        await ClickWithinTestIdByLabelAsync(${rootBinding.expression}, ${labelBinding.expression}, ${exactArg});`);
       }
       chunks.push("    }");
       chunks.push("");

--- a/class-generation/index.ts
+++ b/class-generation/index.ts
@@ -9,7 +9,7 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { generateViewObjectModelMembers, generateViewObjectModelMethodContent } from "../method-generation";
-import { inferPomPatternKindFromFormattedString, isParameterizedPomPattern, type PomPatternKind } from "../pom-patterns";
+import { isParameterizedPomPattern, uniquePomStringPatterns, type PomStringPattern } from "../pom-patterns";
 import { introspectNuxtPages, parseRouterFileFromCwd } from "../router-introspection";
 import {
   addExportAll,
@@ -468,10 +468,10 @@ function generateExtraClickMethodMembers(spec: PomExtraClickMethodSpec): TypeScr
   const waitArg = hasWait ? "wait" : "true";
 
   if (spec.selector.kind === "testId") {
-    const needsTemplate = isParameterizedPomPattern(spec.selector.patternKind);
+    const needsTemplate = isParameterizedPomPattern(spec.selector.testId.patternKind);
     const testIdExpr = needsTemplate
-      ? `\`${spec.selector.formattedDataTestId}\``
-      : JSON.stringify(spec.selector.formattedDataTestId);
+      ? `\`${spec.selector.testId.formatted}\``
+      : JSON.stringify(spec.selector.testId.formatted);
 
     if (needsTemplate) {
       // handled below
@@ -505,14 +505,14 @@ function generateExtraClickMethodMembers(spec: PomExtraClickMethodSpec): TypeScr
     ];
   }
 
-  const rootNeedsTemplate = isParameterizedPomPattern(spec.selector.rootPatternKind);
-  const labelNeedsTemplate = isParameterizedPomPattern(spec.selector.labelPatternKind);
+  const rootNeedsTemplate = isParameterizedPomPattern(spec.selector.rootTestId.patternKind);
+  const labelNeedsTemplate = isParameterizedPomPattern(spec.selector.label.patternKind);
   const rootExpr = rootNeedsTemplate
-    ? `\`${spec.selector.rootFormattedDataTestId}\``
-    : JSON.stringify(spec.selector.rootFormattedDataTestId);
+    ? `\`${spec.selector.rootTestId.formatted}\``
+    : JSON.stringify(spec.selector.rootTestId.formatted);
   const labelExpr = labelNeedsTemplate
-    ? `\`${spec.selector.formattedLabel}\``
-    : JSON.stringify(spec.selector.formattedLabel);
+    ? `\`${spec.selector.label.formatted}\``
+    : JSON.stringify(spec.selector.label.formatted);
 
   const rootArg = rootNeedsTemplate ? "rootTestId" : rootExpr;
   const labelArg = labelNeedsTemplate ? "label" : labelExpr;
@@ -546,9 +546,8 @@ function generateMethodMembersFromPom(primary: PomPrimarySpec, targetPageObjectM
     targetPageObjectModelClass,
     primary.methodName,
     primary.nativeRole,
-    primary.selectorPatternKind,
-    primary.formattedDataTestId,
-    primary.alternateFormattedDataTestIds,
+    primary.selector,
+    primary.alternateSelectors,
     primary.getterNameOverride,
     primary.params ?? {},
   );
@@ -570,15 +569,16 @@ function generateMethodsContentForDependencies(dependencies: IComponentDependenc
     const stableParams = pom.params
       ? Object.fromEntries(Object.entries(pom.params).sort((a, b) => a[0].localeCompare(b[0])))
       : undefined;
-    const alternates = (pom.alternateFormattedDataTestIds ?? []).slice().sort();
-      const key = JSON.stringify({
-        role: pom.nativeRole,
-        methodName: pom.methodName,
-        getterNameOverride: pom.getterNameOverride ?? null,
-        selectorPatternKind: pom.selectorPatternKind,
-        testId: pom.formattedDataTestId,
-        alternateTestIds: alternates.length ? alternates : undefined,
-        params: stableParams,
+    const alternates = (pom.alternateSelectors ?? [])
+      .slice()
+      .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+    const key = JSON.stringify({
+      role: pom.nativeRole,
+      methodName: pom.methodName,
+      getterNameOverride: pom.getterNameOverride ?? null,
+      selector: pom.selector,
+      alternateSelectors: alternates.length ? alternates : undefined,
+      params: stableParams,
       target: target ?? null,
       emitPrimary: pom.emitPrimary ?? true,
     });
@@ -1074,14 +1074,14 @@ function buildGeneratedGitAttributesFiles(generatedFilePaths: string[]): Generat
     });
 }
 
-function toCSharpTestIdExpression(formattedDataTestId: string, patternKind: PomPatternKind): string {
+function toCSharpTestIdExpression(pattern: PomStringPattern): string {
   // Convert our `${var}` placeholder format into C# interpolated-string `{var}`.
-  const needsInterpolation = isParameterizedPomPattern(patternKind);
+  const needsInterpolation = isParameterizedPomPattern(pattern.patternKind);
   if (!needsInterpolation) {
-    return JSON.stringify(formattedDataTestId);
+    return JSON.stringify(pattern.formatted);
   }
 
-  const inner = formattedDataTestId.replace(/\$\{/g, "{");
+  const inner = pattern.formatted.replace(/\$\{/g, "{");
   // Use verbatim JSON escaping for quotes/backslashes, then adapt to C# string literal.
   // JSON.stringify gives us a JS string literal with escapes, which is close enough for a C# normal string.
   const quoted = JSON.stringify(inner);
@@ -1256,13 +1256,13 @@ function generateAggregatedCSharpFiles(
       const baseMethodName = upperFirst(pom.methodName);
       const baseGetterName = upperFirst(pom.getterNameOverride ?? pom.methodName);
       const locatorName = baseGetterName.endsWith(roleSuffix) ? baseGetterName : `${baseGetterName}${roleSuffix}`;
-      const selectorIsParameterized = isParameterizedPomPattern(pom.selectorPatternKind);
-      const testIdExpr = toCSharpTestIdExpression(pom.formattedDataTestId, pom.selectorPatternKind);
+      const selectorIsParameterized = isParameterizedPomPattern(pom.selector.patternKind);
+      const testIdExpr = toCSharpTestIdExpression(pom.selector);
 
       // Ensure all template variables referenced in formattedDataTestId (e.g. `${key}`)
       // appear in the C# method signature. Stale/manual IR can still omit `key` on
       // parameterized selectors, which would otherwise cause CS0103 compile errors.
-      const templateVarMatches = [...pom.formattedDataTestId.matchAll(/\$\{(\w+)\}/g)];
+      const templateVarMatches = [...pom.selector.formatted.matchAll(/\$\{(\w+)\}/g)];
       const templateVars = templateVarMatches.map(m => m[1]);
       const augmentedParams: Record<string, string> = { ...pom.params };
       for (const v of templateVars) {
@@ -1279,8 +1279,7 @@ function generateAggregatedCSharpFiles(
       const { signature, argNames } = formatCSharpParams(orderedParams);
       const args = argNames.join(", ");
 
-      const allTestIds = [pom.formattedDataTestId, ...(pom.alternateFormattedDataTestIds ?? [])]
-        .filter((v, idx, arr) => v && arr.indexOf(v) === idx);
+      const allTestIds = uniquePomStringPatterns(pom.selector, pom.alternateSelectors);
 
       if (selectorIsParameterized) {
         chunks.push(`    public ILocator ${locatorName}(${signature}) => LocatorByTestId(${testIdExpr});`);
@@ -1310,7 +1309,7 @@ function generateAggregatedCSharpFiles(
         }
         else {
           chunks.push("        Exception? lastError = null;");
-          chunks.push(`        foreach (var testId in new[] { ${allTestIds.map(testId => toCSharpTestIdExpression(testId, inferPomPatternKindFromFormattedString(testId))).join(", ")} })`);
+          chunks.push(`        foreach (var testId in new[] { ${allTestIds.map(testId => toCSharpTestIdExpression(testId)).join(", ")} })`);
           chunks.push("        {");
           chunks.push("            try");
           chunks.push("            {");
@@ -1357,7 +1356,7 @@ function generateAggregatedCSharpFiles(
 
       if (!selectorIsParameterized && allTestIds.length > 1) {
         chunks.push("        Exception? lastError = null;");
-        chunks.push(`        foreach (var testId in new[] { ${allTestIds.map(testId => toCSharpTestIdExpression(testId, inferPomPatternKindFromFormattedString(testId))).join(", ")} })`);
+        chunks.push(`        foreach (var testId in new[] { ${allTestIds.map(testId => toCSharpTestIdExpression(testId)).join(", ")} })`);
         chunks.push("        {");
         chunks.push("            try");
         chunks.push("            {");
@@ -1421,8 +1420,8 @@ function generateAggregatedCSharpFiles(
       }
 
       if (extra.selector.kind === "testId") {
-        const needsTemplate = isParameterizedPomPattern(extra.selector.patternKind);
-        const testIdExpr = toCSharpTestIdExpression(extra.selector.formattedDataTestId, extra.selector.patternKind);
+        const needsTemplate = isParameterizedPomPattern(extra.selector.testId.patternKind);
+        const testIdExpr = toCSharpTestIdExpression(extra.selector.testId);
         if (needsTemplate) {
           chunks.push(`        var testId = ${testIdExpr};`);
           chunks.push("        await LocatorByTestId(testId).ClickAsync();");
@@ -1432,10 +1431,10 @@ function generateAggregatedCSharpFiles(
         }
       }
       else {
-        const rootNeedsTemplate = isParameterizedPomPattern(extra.selector.rootPatternKind);
-        const labelNeedsTemplate = isParameterizedPomPattern(extra.selector.labelPatternKind);
-        const rootExpr = toCSharpTestIdExpression(extra.selector.rootFormattedDataTestId, extra.selector.rootPatternKind);
-        const labelExpr = toCSharpTestIdExpression(extra.selector.formattedLabel, extra.selector.labelPatternKind);
+        const rootNeedsTemplate = isParameterizedPomPattern(extra.selector.rootTestId.patternKind);
+        const labelNeedsTemplate = isParameterizedPomPattern(extra.selector.label.patternKind);
+        const rootExpr = toCSharpTestIdExpression(extra.selector.rootTestId);
+        const labelExpr = toCSharpTestIdExpression(extra.selector.label);
         const exactArg = extra.selector.exact === false ? "false" : "true";
 
         if (rootNeedsTemplate) {
@@ -2830,10 +2829,10 @@ function getWidgetInstancesForView(
   };
 
   for (const dt of dataTestIdSet) {
-    const raw = dt.value;
+    const raw = dt.selectorValue.formatted;
 
-    // Skip keyed/dynamic test ids; instance fields can't represent those ergonomically.
-    if (raw.includes("${")) {
+    // Skip parameterized test ids; instance fields can't represent those ergonomically.
+    if (isParameterizedPomPattern(dt.selectorValue.patternKind)) {
       continue;
     }
 

--- a/class-generation/index.ts
+++ b/class-generation/index.ts
@@ -9,7 +9,12 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { generateViewObjectModelMembers, generateViewObjectModelMethodContent } from "../method-generation";
-import { isParameterizedPomPattern, uniquePomStringPatterns, type PomStringPattern } from "../pom-patterns";
+import {
+  ensurePomPatternParameters,
+  isParameterizedPomPattern,
+  uniquePomStringPatterns,
+  type PomStringPattern,
+} from "../pom-patterns";
 import { introspectNuxtPages, parseRouterFileFromCwd } from "../router-introspection";
 import {
   addExportAll,
@@ -450,44 +455,13 @@ function getSelectorPatterns(selector: PomSelectorSpec): PomStringPattern[] {
     : [selector.rootTestId, selector.label];
 }
 
-function ensureRequiredPatternParams(
-  params: Record<string, string> | undefined,
-  patterns: readonly PomStringPattern[],
-  options: { omit?: readonly string[] } = {},
-): Record<string, string> {
-  const currentParams = params ?? {};
-  const omitted = new Set(options.omit ?? []);
-  const orderedEntries: [string, string][] = [];
-  const seen = new Set<string>();
-
-  for (const pattern of patterns) {
-    for (const variableName of pattern.templateVariables) {
-      if (omitted.has(variableName) || seen.has(variableName)) {
-        continue;
-      }
-      seen.add(variableName);
-      orderedEntries.push([variableName, currentParams[variableName] ?? "string"]);
-    }
-  }
-
-  for (const [name, typeExpr] of Object.entries(currentParams)) {
-    if (seen.has(name)) {
-      continue;
-    }
-    seen.add(name);
-    orderedEntries.push([name, typeExpr]);
-  }
-
-  return Object.fromEntries(orderedEntries);
-}
-
 function generateExtraClickMethodMembers(spec: PomExtraClickMethodSpec): TypeScriptClassMember[] {
   if (spec.kind !== "click") {
     return [];
   }
 
   const selectorPatterns = getSelectorPatterns(spec.selector);
-  const params = ensureRequiredPatternParams(
+  const params = ensurePomPatternParameters(
     spec.params,
     selectorPatterns,
     { omit: spec.keyLiteral !== undefined ? ["key"] : [] },
@@ -1291,7 +1265,7 @@ function generateAggregatedCSharpFiles(
       const locatorName = baseGetterName.endsWith(roleSuffix) ? baseGetterName : `${baseGetterName}${roleSuffix}`;
       const selectorIsParameterized = isParameterizedPomPattern(pom.selector.patternKind);
       const testIdExpr = toCSharpTestIdExpression(pom.selector);
-      const orderedParams = ensureRequiredPatternParams(pom.params, [pom.selector]);
+      const orderedParams = ensurePomPatternParameters(pom.params, [pom.selector]);
 
       const { signature, argNames } = formatCSharpParams(orderedParams);
       const args = argNames.join(", ");
@@ -1426,7 +1400,7 @@ function generateAggregatedCSharpFiles(
     for (const extra of extras) {
       if (extra.kind !== "click")
         continue;
-      const extraParams = ensureRequiredPatternParams(
+      const extraParams = ensurePomPatternParameters(
         extra.params,
         getSelectorPatterns(extra.selector),
         { omit: extra.keyLiteral !== undefined ? ["key"] : [] },

--- a/class-generation/index.ts
+++ b/class-generation/index.ts
@@ -12,6 +12,8 @@ import { generateViewObjectModelMembers, generateViewObjectModelMethodContent } 
 import {
   ensurePomPatternParameters,
   isParameterizedPomPattern,
+  toCSharpPomPatternExpression,
+  toTypeScriptPomPatternExpression,
   uniquePomStringPatterns,
   type PomStringPattern,
 } from "../pom-patterns";
@@ -476,13 +478,7 @@ function generateExtraClickMethodMembers(spec: PomExtraClickMethodSpec): TypeScr
 
   if (spec.selector.kind === "testId") {
     const needsTemplate = isParameterizedPomPattern(spec.selector.testId.patternKind);
-    const testIdExpr = needsTemplate
-      ? `\`${spec.selector.testId.formatted}\``
-      : JSON.stringify(spec.selector.testId.formatted);
-
-    if (needsTemplate) {
-      // handled below
-    }
+    const testIdExpr = toTypeScriptPomPatternExpression(spec.selector.testId);
 
     const clickArgs: string[] = [];
     clickArgs.push(needsTemplate ? "testId" : testIdExpr);
@@ -514,12 +510,8 @@ function generateExtraClickMethodMembers(spec: PomExtraClickMethodSpec): TypeScr
 
   const rootNeedsTemplate = isParameterizedPomPattern(spec.selector.rootTestId.patternKind);
   const labelNeedsTemplate = isParameterizedPomPattern(spec.selector.label.patternKind);
-  const rootExpr = rootNeedsTemplate
-    ? `\`${spec.selector.rootTestId.formatted}\``
-    : JSON.stringify(spec.selector.rootTestId.formatted);
-  const labelExpr = labelNeedsTemplate
-    ? `\`${spec.selector.label.formatted}\``
-    : JSON.stringify(spec.selector.label.formatted);
+  const rootExpr = toTypeScriptPomPatternExpression(spec.selector.rootTestId);
+  const labelExpr = toTypeScriptPomPatternExpression(spec.selector.label);
 
   const rootArg = rootNeedsTemplate ? "rootTestId" : rootExpr;
   const labelArg = labelNeedsTemplate ? "label" : labelExpr;
@@ -1081,20 +1073,6 @@ function buildGeneratedGitAttributesFiles(generatedFilePaths: string[]): Generat
     });
 }
 
-function toCSharpTestIdExpression(pattern: PomStringPattern): string {
-  // Convert our `${var}` placeholder format into C# interpolated-string `{var}`.
-  const needsInterpolation = isParameterizedPomPattern(pattern.patternKind);
-  if (!needsInterpolation) {
-    return JSON.stringify(pattern.formatted);
-  }
-
-  const inner = pattern.formatted.replace(/\$\{/g, "{");
-  // Use verbatim JSON escaping for quotes/backslashes, then adapt to C# string literal.
-  // JSON.stringify gives us a JS string literal with escapes, which is close enough for a C# normal string.
-  const quoted = JSON.stringify(inner);
-  return `$${quoted}`;
-}
-
 function toCSharpParam(paramTypeExpr: string): { type: string; defaultExpr?: string } {
   const trimmed = (paramTypeExpr ?? "").trim();
 
@@ -1264,7 +1242,7 @@ function generateAggregatedCSharpFiles(
       const baseGetterName = upperFirst(pom.getterNameOverride ?? pom.methodName);
       const locatorName = baseGetterName.endsWith(roleSuffix) ? baseGetterName : `${baseGetterName}${roleSuffix}`;
       const selectorIsParameterized = isParameterizedPomPattern(pom.selector.patternKind);
-      const testIdExpr = toCSharpTestIdExpression(pom.selector);
+      const testIdExpr = toCSharpPomPatternExpression(pom.selector);
       const orderedParams = ensurePomPatternParameters(pom.params, [pom.selector]);
 
       const { signature, argNames } = formatCSharpParams(orderedParams);
@@ -1300,7 +1278,7 @@ function generateAggregatedCSharpFiles(
         }
         else {
           chunks.push("        Exception? lastError = null;");
-          chunks.push(`        foreach (var testId in new[] { ${allTestIds.map(testId => toCSharpTestIdExpression(testId)).join(", ")} })`);
+          chunks.push(`        foreach (var testId in new[] { ${allTestIds.map(testId => toCSharpPomPatternExpression(testId)).join(", ")} })`);
           chunks.push("        {");
           chunks.push("            try");
           chunks.push("            {");
@@ -1347,7 +1325,7 @@ function generateAggregatedCSharpFiles(
 
       if (!selectorIsParameterized && allTestIds.length > 1) {
         chunks.push("        Exception? lastError = null;");
-        chunks.push(`        foreach (var testId in new[] { ${allTestIds.map(testId => toCSharpTestIdExpression(testId)).join(", ")} })`);
+        chunks.push(`        foreach (var testId in new[] { ${allTestIds.map(testId => toCSharpPomPatternExpression(testId)).join(", ")} })`);
         chunks.push("        {");
         chunks.push("            try");
         chunks.push("            {");
@@ -1417,7 +1395,7 @@ function generateAggregatedCSharpFiles(
 
       if (extra.selector.kind === "testId") {
         const needsTemplate = isParameterizedPomPattern(extra.selector.testId.patternKind);
-        const testIdExpr = toCSharpTestIdExpression(extra.selector.testId);
+        const testIdExpr = toCSharpPomPatternExpression(extra.selector.testId);
         if (needsTemplate) {
           chunks.push(`        var testId = ${testIdExpr};`);
           chunks.push("        await LocatorByTestId(testId).ClickAsync();");
@@ -1429,8 +1407,8 @@ function generateAggregatedCSharpFiles(
       else {
         const rootNeedsTemplate = isParameterizedPomPattern(extra.selector.rootTestId.patternKind);
         const labelNeedsTemplate = isParameterizedPomPattern(extra.selector.label.patternKind);
-        const rootExpr = toCSharpTestIdExpression(extra.selector.rootTestId);
-        const labelExpr = toCSharpTestIdExpression(extra.selector.label);
+        const rootExpr = toCSharpPomPatternExpression(extra.selector.rootTestId);
+        const labelExpr = toCSharpPomPatternExpression(extra.selector.label);
         const exactArg = extra.selector.exact === false ? "false" : "true";
 
         if (rootNeedsTemplate) {

--- a/class-generation/index.ts
+++ b/class-generation/index.ts
@@ -21,8 +21,8 @@ import {
 import {
   bindCSharpPomPattern,
   bindTypeScriptPomPattern,
-  ensurePomPatternParameters,
   isParameterizedPomPattern,
+  orderPomPatternParameters,
   toCSharpPomPatternExpression,
   toTypeScriptPomPatternExpression,
   uniquePomStringPatterns,
@@ -141,6 +141,27 @@ interface CustomPomImportResolution {
   methodSignaturesByClass: Map<string, CustomPomMethodSignatureMap>;
   availableClassIdentifiers: Set<string>;
   importSpecifiersByClass: Record<string, ResolvedCustomPomImportSpecifier>;
+}
+
+function createMissingCustomPomDirectoryError(configuredDir: string, resolvedDir: string): VuePomGeneratorError {
+  return new VuePomGeneratorError(
+    `Custom POM directory "${configuredDir}" does not exist.\n`
+    + `Resolved path: ${resolvedDir}\n`
+    + "Create the directory, point generation.playwright.customPoms.dir at the correct location, "
+    + "or remove the customPoms configuration.",
+  );
+}
+
+function createMissingCustomPomAttachmentClassError(
+  missingClassNames: string[],
+  configuredDir: string,
+): VuePomGeneratorError {
+  const renderedClassNames = missingClassNames.map(name => `"${name}"`).join(", ");
+  return new VuePomGeneratorError(
+    `Custom POM attachments reference missing helper classes: ${renderedClassNames}.\n`
+    + `Expected matching helper files/exports under "${configuredDir}".\n`
+    + "Add the missing helper classes or remove the corresponding generation.playwright.customPoms.attachments entries.",
+  );
 }
 
 function createCustomPomImportCollisionError(exportName: string, requested: string): VuePomGeneratorError {
@@ -333,7 +354,7 @@ function generateExtraClickMethodMembers(spec: PomExtraClickMethodSpec): TypeScr
   }
 
   const selectorPatterns = getSelectorPatterns(spec.selector);
-  const signatureSpecs = ensurePomPatternParameters(
+  const signatureSpecs = orderPomPatternParameters(
     spec.parameters,
     selectorPatterns,
     { omit: spec.keyLiteral !== undefined ? ["key"] : [] },
@@ -501,6 +522,8 @@ export interface GenerateFilesOptions {
    * Defaults to <projectRoot>/tests/playwright/pom/custom.
    */
   customPomDir?: string;
+  /** When true, fail generation if the configured customPomDir does not exist. */
+  requireCustomPomDir?: boolean;
 
   /**
    * Optional import aliases for handwritten POM helpers.
@@ -570,6 +593,7 @@ interface BaseGenerateContentOptions {
 
   projectRoot?: string;
   customPomDir?: string;
+  requireCustomPomDir?: boolean;
   customPomImportAliases?: Record<string, string>;
   customPomClassIdentifierMap?: Record<string, string>;
   customPomAvailableClassIdentifiers?: Set<string>;
@@ -609,6 +633,7 @@ export async function generateFiles(
     customPomAttachments = [],
     projectRoot,
     customPomDir,
+    requireCustomPomDir,
     customPomImportAliases,
     customPomImportNameCollisionBehavior = "error",
     testIdAttribute,
@@ -651,6 +676,7 @@ export async function generateFiles(
         customPomAttachments,
         projectRoot,
         customPomDir,
+        requireCustomPomDir,
         customPomImportAliases,
         customPomImportNameCollisionBehavior,
         testIdAttribute,
@@ -661,6 +687,7 @@ export async function generateFiles(
         customPomAttachments,
         projectRoot,
         customPomDir,
+        requireCustomPomDir,
         customPomImportAliases,
         customPomImportNameCollisionBehavior,
         testIdAttribute,
@@ -709,6 +736,7 @@ async function generateSplitTypeScriptFiles(
     customPomAttachments?: GenerateFilesOptions["customPomAttachments"];
     projectRoot?: GenerateFilesOptions["projectRoot"];
     customPomDir?: GenerateFilesOptions["customPomDir"];
+    requireCustomPomDir?: GenerateFilesOptions["requireCustomPomDir"];
     customPomImportAliases?: GenerateFilesOptions["customPomImportAliases"];
     customPomImportNameCollisionBehavior?: GenerateFilesOptions["customPomImportNameCollisionBehavior"];
     testIdAttribute?: GenerateFilesOptions["testIdAttribute"];
@@ -744,9 +772,15 @@ async function generateSplitTypeScriptFiles(
 
   const customPomImportResolution = resolveCustomPomImportResolution(generatedClassNames, projectRoot, {
     customPomDir: options.customPomDir,
+    requireCustomPomDir: options.requireCustomPomDir,
     customPomImportAliases: options.customPomImportAliases,
     customPomImportNameCollisionBehavior: options.customPomImportNameCollisionBehavior,
   });
+  assertCustomPomAttachmentsResolved(
+    options.customPomAttachments ?? [],
+    customPomImportResolution.classIdentifierMap,
+    options.customPomDir ?? "tests/playwright/pom/custom",
+  );
 
   const runtimeBasePagePath = path.join(base, "_pom-runtime", "class-generation", "base-page.ts");
   const files: GeneratedFileOutput[] = [];
@@ -1091,7 +1125,7 @@ function generateAggregatedCSharpFiles(
       const locatorName = baseGetterName.endsWith(roleSuffix) ? baseGetterName : `${baseGetterName}${roleSuffix}`;
       const selectorIsParameterized = isParameterizedPomPattern(pom.selector.patternKind);
       const testIdExpr = toCSharpPomPatternExpression(pom.selector);
-      const orderedParams = ensurePomPatternParameters(pom.parameters, [pom.selector]);
+      const orderedParams = orderPomPatternParameters(pom.parameters, [pom.selector]);
 
       const { signature, argNames } = formatCSharpParams(orderedParams);
       const args = argNames.join(", ");
@@ -1226,7 +1260,7 @@ function generateAggregatedCSharpFiles(
     for (const extra of extras) {
       if (extra.kind !== "click")
         continue;
-      const extraParams = ensurePomPatternParameters(
+      const extraParams = orderPomPatternParameters(
         extra.parameters,
         getSelectorPatterns(extra.selector),
         { omit: extra.keyLiteral !== undefined ? ["key"] : [] },
@@ -2239,6 +2273,7 @@ function resolveCustomPomImportResolution(
   projectRoot: string,
   options: {
     customPomDir?: GenerateFilesOptions["customPomDir"];
+    requireCustomPomDir?: GenerateFilesOptions["requireCustomPomDir"];
     customPomImportAliases?: GenerateFilesOptions["customPomImportAliases"];
     customPomImportNameCollisionBehavior?: GenerateFilesOptions["customPomImportNameCollisionBehavior"];
   } = {},
@@ -2279,6 +2314,9 @@ function resolveCustomPomImportResolution(
     : path.resolve(projectRoot, customDirRelOrAbs);
 
   if (!fs.existsSync(customDirAbs)) {
+    if (options.requireCustomPomDir) {
+      throw createMissingCustomPomDirectoryError(customDirRelOrAbs, customDirAbs);
+    }
     return {
       classIdentifierMap,
       methodSignaturesByClass,
@@ -2330,6 +2368,21 @@ function resolveCustomPomImportResolution(
     availableClassIdentifiers: new Set(Object.values(classIdentifierMap)),
     importSpecifiersByClass,
   };
+}
+
+function assertCustomPomAttachmentsResolved(
+  attachments: readonly CustomPomAttachment[],
+  classIdentifierMap: Record<string, string>,
+  configuredDir: string,
+): void {
+  const missingClassNames = Array.from(new Set(
+    attachments
+      .map(attachment => attachment.className)
+      .filter(className => !Object.prototype.hasOwnProperty.call(classIdentifierMap, className)),
+  )).sort((left, right) => left.localeCompare(right));
+  if (missingClassNames.length > 0) {
+    throw createMissingCustomPomAttachmentClassError(missingClassNames, configuredDir);
+  }
 }
 
 function getComposedStubBody(
@@ -2428,6 +2481,7 @@ async function generateAggregatedFiles(
     customPomAttachments?: GenerateFilesOptions["customPomAttachments"];
     projectRoot?: GenerateFilesOptions["projectRoot"];
     customPomDir?: GenerateFilesOptions["customPomDir"];
+    requireCustomPomDir?: GenerateFilesOptions["requireCustomPomDir"];
     customPomImportAliases?: GenerateFilesOptions["customPomImportAliases"];
     customPomImportNameCollisionBehavior?: GenerateFilesOptions["customPomImportNameCollisionBehavior"];
     testIdAttribute?: GenerateFilesOptions["testIdAttribute"];
@@ -2473,9 +2527,15 @@ async function generateAggregatedFiles(
 
     const customPomImportResolution = resolveCustomPomImportResolution(generatedClassNames, projectRoot, {
       customPomDir: options.customPomDir,
+      requireCustomPomDir: options.requireCustomPomDir,
       customPomImportAliases: options.customPomImportAliases,
       customPomImportNameCollisionBehavior: options.customPomImportNameCollisionBehavior,
     });
+    assertCustomPomAttachmentsResolved(
+      options.customPomAttachments ?? [],
+      customPomImportResolution.classIdentifierMap,
+      options.customPomDir ?? "tests/playwright/pom/custom",
+    );
     const customPomClassIdentifierMap = customPomImportResolution.classIdentifierMap;
     const customPomMethodSignaturesByClass = customPomImportResolution.methodSignaturesByClass;
     const customPomAvailableClassIdentifiers = customPomImportResolution.availableClassIdentifiers;

--- a/class-generation/index.ts
+++ b/class-generation/index.ts
@@ -9,7 +9,13 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { generateViewObjectModelMembers, generateViewObjectModelMethodContent } from "../method-generation";
-import { formatTypeScriptPomParameters, normalizePomParameters, type PomParameterSpec } from "../pom-params";
+import {
+  formatTypeScriptPomParameters,
+  getPomParameterNames,
+  normalizePomParameters,
+  type PomMethodSignature,
+  type PomParameterSpec,
+} from "../pom-params";
 import {
   bindCSharpPomPattern,
   bindTypeScriptPomPattern,
@@ -453,16 +459,16 @@ function generateExtraClickMethodMembers(spec: PomExtraClickMethodSpec): TypeScr
   }
 
   const selectorPatterns = getSelectorPatterns(spec.selector);
-  const params = ensurePomPatternParameters(
-    spec.params,
+  const signatureSpecs = ensurePomPatternParameters(
+    spec.parameters,
     selectorPatterns,
     { omit: spec.keyLiteral !== undefined ? ["key"] : [] },
   );
-  const signatureParams = formatTypeScriptPomParameters(params);
+  const signatureParams = formatTypeScriptPomParameters(signatureSpecs);
   const parameters = parseParameterSignatures(signatureParams);
 
-  const hasAnnotationText = Object.prototype.hasOwnProperty.call(params, "annotationText");
-  const hasWait = Object.prototype.hasOwnProperty.call(params, "wait");
+  const hasAnnotationText = signatureSpecs.some(param => param.name === "annotationText");
+  const hasWait = signatureSpecs.some(param => param.name === "wait");
   const annotationArg = hasAnnotationText ? "annotationText" : "\"\"";
   const waitArg = hasWait ? "wait" : "true";
 
@@ -532,7 +538,7 @@ function generateMethodMembersFromPom(primary: PomPrimarySpec, targetPageObjectM
     primary.selector,
     primary.alternateSelectors,
     primary.getterNameOverride,
-    primary.params ?? {},
+    primary.parameters,
   );
 }
 
@@ -549,9 +555,6 @@ function generateMethodsContentForDependencies(dependencies: IComponentDependenc
   // When we emit from IR, we must de-dupe here to avoid duplicate getters/methods.
   const seenPrimaryKeys = new Set<string>();
   const primarySpecs = primarySpecsAll.filter(({ pom, target }) => {
-    const stableParams = pom.params
-      ? Object.fromEntries(Object.entries(pom.params).sort((a, b) => a[0].localeCompare(b[0])))
-      : undefined;
     const alternates = (pom.alternateSelectors ?? [])
       .slice()
       .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
@@ -561,7 +564,7 @@ function generateMethodsContentForDependencies(dependencies: IComponentDependenc
       getterNameOverride: pom.getterNameOverride ?? null,
       selector: pom.selector,
       alternateSelectors: alternates.length ? alternates : undefined,
-      params: stableParams,
+      parameters: pom.parameters,
       target: target ?? null,
       emitPrimary: pom.emitPrimary ?? true,
     });
@@ -1091,7 +1094,7 @@ function toCSharpParam(param: PomParameterSpec): { type: string; defaultExpr?: s
   return { type, defaultExpr };
 }
 
-function formatCSharpParams(params: Record<string, string> | undefined): { signature: string; argNames: string[] } {
+function formatCSharpParams(params: readonly PomParameterSpec[] | undefined): { signature: string; argNames: string[] } {
   const normalizedParams = normalizePomParameters(params);
   if (!normalizedParams.length)
     return { signature: "", argNames: [] };
@@ -1215,7 +1218,7 @@ function generateAggregatedCSharpFiles(
       const locatorName = baseGetterName.endsWith(roleSuffix) ? baseGetterName : `${baseGetterName}${roleSuffix}`;
       const selectorIsParameterized = isParameterizedPomPattern(pom.selector.patternKind);
       const testIdExpr = toCSharpPomPatternExpression(pom.selector);
-      const orderedParams = ensurePomPatternParameters(pom.params, [pom.selector]);
+      const orderedParams = ensurePomPatternParameters(pom.parameters, [pom.selector]);
 
       const { signature, argNames } = formatCSharpParams(orderedParams);
       const args = argNames.join(", ");
@@ -1351,7 +1354,7 @@ function generateAggregatedCSharpFiles(
       if (extra.kind !== "click")
         continue;
       const extraParams = ensurePomPatternParameters(
-        extra.params,
+        extra.parameters,
         getSelectorPatterns(extra.selector),
         { omit: extra.keyLiteral !== undefined ? ["key"] : [] },
       );
@@ -1937,10 +1940,10 @@ function getViewPassthroughMethods(
   componentHierarchyMap: Map<string, IComponentDependencies>,
   blockedMethodNames: Set<string> = new Set(),
 ) {
-  const existingOnView = viewDependencies.generatedMethods ?? new Map<string, { params: string; argNames: string[] } | null>();
+  const existingOnView = viewDependencies.generatedMethods ?? new Map<string, PomMethodSignature | null>();
 
   // methodName -> candidates
-  const methodToChildren = new Map<string, Array<{ childProp: string; params: string; argNames: string[] }>>();
+  const methodToChildren = new Map<string, Array<{ childProp: string; signature: PomMethodSignature }>>();
 
   for (const child of childrenComponentSet) {
     const childDeps = componentHierarchyMap.get(child);
@@ -1963,7 +1966,7 @@ function getViewPassthroughMethods(
         continue;
 
       const list = methodToChildren.get(name) ?? [];
-      list.push({ childProp, params: sig.params, argNames: sig.argNames });
+      list.push({ childProp, signature: sig });
       methodToChildren.set(name, list);
     }
   }
@@ -1975,12 +1978,12 @@ function getViewPassthroughMethods(
   }
 
   return passthroughs.map(([methodName, candidates]) => {
-    const { childProp, params, argNames } = candidates[0];
-    const callArgs = argNames.join(", ");
+    const { childProp, signature } = candidates[0];
+    const callArgs = getPomParameterNames(signature.parameters).join(", ");
     return createClassMethod({
       name: methodName,
       isAsync: true,
-      parameters: parseParameterSignatures(params),
+      parameters: parseParameterSignatures(formatTypeScriptPomParameters(signature.parameters)),
       statements: [
         `return await this.${childProp}.${methodName}(${callArgs});`,
       ],
@@ -1998,8 +2001,8 @@ function getAttachmentPassthroughMethods(
     return [];
   }
 
-  const existingOnClass = ownerDependencies.generatedMethods ?? new Map<string, { params: string; argNames: string[] } | null>();
-  const methodToAttachments = new Map<string, Array<{ propertyName: string; params: string; argNames: string[] }>>();
+  const existingOnClass = ownerDependencies.generatedMethods ?? new Map<string, PomMethodSignature | null>();
+  const methodToAttachments = new Map<string, Array<{ propertyName: string; signature: CustomPomMethodSignature }>>();
 
   for (const attachment of attachmentsForThisClass) {
     if (!attachment.flatten) {
@@ -2014,8 +2017,7 @@ function getAttachmentPassthroughMethods(
       const list = methodToAttachments.get(methodName) ?? [];
       list.push({
         propertyName: attachment.propertyName,
-        params: signature.params,
-        argNames: signature.argNames,
+        signature,
       });
       methodToAttachments.set(methodName, list);
     }
@@ -2028,14 +2030,14 @@ function getAttachmentPassthroughMethods(
   }
 
   return passthroughs.map(([methodName, candidates]) => {
-    const { propertyName, params, argNames } = candidates[0];
-    const callArgs = argNames.join(", ");
+    const { propertyName, signature } = candidates[0];
+    const callArgs = signature.argNames.join(", ");
     const invocation = callArgs
       ? `this.${propertyName}.${methodName}(${callArgs})`
       : `this.${propertyName}.${methodName}()`;
     return createClassMethod({
       name: methodName,
-      parameters: parseParameterSignatures(params),
+      parameters: parseParameterSignatures(signature.params),
       statements: [
         `return ${invocation};`,
       ],
@@ -2454,7 +2456,7 @@ function getComposedStubBody(
   if (!childClassNames.length)
     return undefined;
 
-  const methodToChildren = new Map<string, Array<{ child: string; params: string; argNames: string[] }>>();
+  const methodToChildren = new Map<string, Array<{ child: string; signature: PomMethodSignature }>>();
   for (const child of childClassNames) {
     const childDeps = depsByClassName.get(child);
     const methods = childDeps?.generatedMethods;
@@ -2465,7 +2467,7 @@ function getComposedStubBody(
       if (!sig)
         continue;
       const list = methodToChildren.get(name) ?? [];
-      list.push({ child, params: sig.params, argNames: sig.argNames });
+      list.push({ child, signature: sig });
       methodToChildren.set(name, list);
     }
   }
@@ -2475,13 +2477,13 @@ function getComposedStubBody(
     if (candidatesForMethod.length !== 1 || methodName === "constructor")
       continue;
 
-    const { child, params, argNames } = candidatesForMethod[0];
-    const callArgs = argNames.join(", ");
+    const { child, signature } = candidatesForMethod[0];
+    const callArgs = getPomParameterNames(signature.parameters).join(", ");
 
     passthroughMembers.push(createClassMethod({
       name: methodName,
       isAsync: true,
-      parameters: parseParameterSignatures(params),
+      parameters: parseParameterSignatures(formatTypeScriptPomParameters(signature.parameters)),
       statements: [
         `return await this.${child}.${methodName}(${callArgs});`,
       ],

--- a/class-generation/index.ts
+++ b/class-generation/index.ts
@@ -10,9 +10,11 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { generateViewObjectModelMembers, generateViewObjectModelMethodContent } from "../method-generation";
 import {
-  formatTypeScriptPomParameters,
-  getPomParameterNames,
+  createPomMethodSignature,
+  createPomParameterSpec,
+  getPomParameterArgumentNames,
   normalizePomParameters,
+  toTypeScriptPomParameterStructures,
   type PomMethodSignature,
   type PomParameterSpec,
 } from "../pom-params";
@@ -42,7 +44,6 @@ import {
   type GetAccessorDeclarationStructure,
   type MethodDeclarationStructure,
   type OptionalKind,
-  type ParameterDeclarationStructure,
   type PropertyDeclarationStructure,
   type TypeScriptClassMember,
   type TypeScriptSourceFile,
@@ -79,128 +80,6 @@ class VuePomGeneratorError extends Error {
   }
 }
 
-function splitParameterList(parameters: string): string[] {
-  const parts: string[] = [];
-  let current = "";
-  let braceDepth = 0;
-  let bracketDepth = 0;
-  let parenDepth = 0;
-  let angleDepth = 0;
-  let inSingleQuote = false;
-  let inDoubleQuote = false;
-  let inTemplateString = false;
-
-  for (let index = 0; index < parameters.length; index += 1) {
-    const char = parameters[index];
-    const previous = index > 0 ? parameters[index - 1] : "";
-
-    if (char === "'" && !inDoubleQuote && !inTemplateString && previous !== "\\") {
-      inSingleQuote = !inSingleQuote;
-      current += char;
-      continue;
-    }
-    if (char === "\"" && !inSingleQuote && !inTemplateString && previous !== "\\") {
-      inDoubleQuote = !inDoubleQuote;
-      current += char;
-      continue;
-    }
-    if (char === "`" && !inSingleQuote && !inDoubleQuote && previous !== "\\") {
-      inTemplateString = !inTemplateString;
-      current += char;
-      continue;
-    }
-
-    if (inSingleQuote || inDoubleQuote || inTemplateString) {
-      current += char;
-      continue;
-    }
-
-    switch (char) {
-      case "{":
-        braceDepth += 1;
-        break;
-      case "}":
-        braceDepth -= 1;
-        break;
-      case "[":
-        bracketDepth += 1;
-        break;
-      case "]":
-        bracketDepth -= 1;
-        break;
-      case "(":
-        parenDepth += 1;
-        break;
-      case ")":
-        parenDepth -= 1;
-        break;
-      case "<":
-        angleDepth += 1;
-        break;
-      case ">":
-        angleDepth -= 1;
-        break;
-      case ",":
-        if (braceDepth === 0 && bracketDepth === 0 && parenDepth === 0 && angleDepth === 0) {
-          const trimmed = current.trim();
-          if (trimmed) {
-            parts.push(trimmed);
-          }
-          current = "";
-          continue;
-        }
-        break;
-      default:
-        break;
-    }
-
-    current += char;
-  }
-
-  const trimmed = current.trim();
-  if (trimmed) {
-    parts.push(trimmed);
-  }
-
-  return parts;
-}
-
-function parseParameterSignature(parameter: string): OptionalKind<ParameterDeclarationStructure> {
-  const colonIndex = parameter.indexOf(":");
-  if (colonIndex < 0) {
-    return { name: parameter.trim() };
-  }
-
-  const rawName = parameter.slice(0, colonIndex).trim();
-  const hasQuestionToken = rawName.endsWith("?");
-  const name = hasQuestionToken ? rawName.slice(0, -1).trim() : rawName;
-  const remainder = parameter.slice(colonIndex + 1).trim();
-  const initializerIndex = remainder.lastIndexOf("=");
-
-  if (initializerIndex < 0) {
-    return {
-      name,
-      hasQuestionToken,
-      type: remainder || undefined,
-    };
-  }
-
-  return {
-    name,
-    hasQuestionToken,
-    type: remainder.slice(0, initializerIndex).trim() || undefined,
-    initializer: remainder.slice(initializerIndex + 1).trim() || undefined,
-  };
-}
-
-function parseParameterSignatures(parameters: string): OptionalKind<ParameterDeclarationStructure>[] {
-  const trimmed = parameters.trim();
-  if (!trimmed) {
-    return [];
-  }
-  return splitParameterList(trimmed).map(parseParameterSignature);
-}
-
 function toPosixRelativePath(fromDir: string, toFile: string): string {
   let rel = path.relative(fromDir, toFile).replace(/\\/g, "/");
   if (!rel.startsWith(".")) {
@@ -232,12 +111,7 @@ interface RouteMeta {
   template: string;
 }
 
-interface CustomPomMethodSignature {
-  params: string;
-  argNames: string[];
-}
-
-type CustomPomMethodSignatureMap = Map<string, CustomPomMethodSignature>;
+type CustomPomMethodSignatureMap = Map<string, PomMethodSignature>;
 
 interface CustomPomAttachment {
   className: string;
@@ -464,8 +338,7 @@ function generateExtraClickMethodMembers(spec: PomExtraClickMethodSpec): TypeScr
     selectorPatterns,
     { omit: spec.keyLiteral !== undefined ? ["key"] : [] },
   );
-  const signatureParams = formatTypeScriptPomParameters(signatureSpecs);
-  const parameters = parseParameterSignatures(signatureParams);
+  const parameters = toTypeScriptPomParameterStructures(signatureSpecs);
 
   const hasAnnotationText = signatureSpecs.some(param => param.name === "annotationText");
   const hasWait = signatureSpecs.some(param => param.name === "wait");
@@ -1062,7 +935,7 @@ function buildGeneratedGitAttributesFiles(generatedFilePaths: string[]): Generat
 
 function toCSharpParam(param: PomParameterSpec): { type: string; defaultExpr?: string } {
   // Collapse union types to their widest practical type.
-  const typePart = param.type.includes("|") ? "string" : param.type;
+  const typePart = param.type?.includes("|") ? "string" : (param.type ?? "string");
 
   let type = "string";
   if (/(?:^|\s)boolean(?:\s|$)/.test(typePart))
@@ -1732,8 +1605,8 @@ function prepareViewObjectModelClass(
       propertyName: a.propertyName,
       flatten: a.flatten ?? false,
       methodSignatures: a.flatten
-        ? (customPomMethodSignaturesByClass.get(a.className) ?? new Map<string, CustomPomMethodSignature>())
-        : new Map<string, CustomPomMethodSignature>(),
+        ? (customPomMethodSignaturesByClass.get(a.className) ?? new Map<string, PomMethodSignature>())
+        : new Map<string, PomMethodSignature>(),
     }));
 
   const widgetInstances = isView
@@ -1979,11 +1852,11 @@ function getViewPassthroughMethods(
 
   return passthroughs.map(([methodName, candidates]) => {
     const { childProp, signature } = candidates[0];
-    const callArgs = getPomParameterNames(signature.parameters).join(", ");
+    const callArgs = getPomParameterArgumentNames(signature.parameters).join(", ");
     return createClassMethod({
       name: methodName,
       isAsync: true,
-      parameters: parseParameterSignatures(formatTypeScriptPomParameters(signature.parameters)),
+      parameters: toTypeScriptPomParameterStructures(signature.parameters),
       statements: [
         `return await this.${childProp}.${methodName}(${callArgs});`,
       ],
@@ -2002,7 +1875,7 @@ function getAttachmentPassthroughMethods(
   }
 
   const existingOnClass = ownerDependencies.generatedMethods ?? new Map<string, PomMethodSignature | null>();
-  const methodToAttachments = new Map<string, Array<{ propertyName: string; signature: CustomPomMethodSignature }>>();
+  const methodToAttachments = new Map<string, Array<{ propertyName: string; signature: PomMethodSignature }>>();
 
   for (const attachment of attachmentsForThisClass) {
     if (!attachment.flatten) {
@@ -2031,13 +1904,13 @@ function getAttachmentPassthroughMethods(
 
   return passthroughs.map(([methodName, candidates]) => {
     const { propertyName, signature } = candidates[0];
-    const callArgs = signature.argNames.join(", ");
+    const callArgs = getPomParameterArgumentNames(signature.parameters).join(", ");
     const invocation = callArgs
       ? `this.${propertyName}.${methodName}(${callArgs})`
       : `this.${propertyName}.${methodName}()`;
     return createClassMethod({
       name: methodName,
-      parameters: parseParameterSignatures(signature.params),
+      parameters: toTypeScriptPomParameterStructures(signature.parameters),
       statements: [
         `return ${invocation};`,
       ],
@@ -2054,17 +1927,57 @@ function sliceNodeSource(source: string, node: { start?: number | null; end?: nu
   return snippet.length ? snippet : null;
 }
 
-function getCustomPomCallArgumentName(param: ClassMethod["params"][number]): string | null {
+function getTypeAnnotationSource(
+  source: string,
+  node: { typeAnnotation?: unknown },
+): string | undefined {
+  const rawTypeAnnotation = node.typeAnnotation;
+  if (!rawTypeAnnotation || typeof rawTypeAnnotation !== "object" || !("type" in rawTypeAnnotation) || rawTypeAnnotation.type !== "TSTypeAnnotation" || !("typeAnnotation" in rawTypeAnnotation)) {
+    return undefined;
+  }
+
+  const typeAnnotation = rawTypeAnnotation.typeAnnotation;
+  return typeAnnotation && typeof typeAnnotation === "object"
+    ? sliceNodeSource(source, typeAnnotation as { start?: number | null; end?: number | null }) ?? undefined
+    : undefined;
+}
+
+function getCustomPomParameterSpec(source: string, param: ClassMethod["params"][number]): PomParameterSpec | null {
   if (param.type === "Identifier") {
-    return param.name;
+    return createPomParameterSpec(param.name, getTypeAnnotationSource(source, param), {
+      hasQuestionToken: !!param.optional,
+    });
   }
 
   if (param.type === "AssignmentPattern") {
-    return param.left.type === "Identifier" ? param.left.name : null;
+    if (param.left.type !== "Identifier") {
+      return null;
+    }
+
+    const initializer = sliceNodeSource(source, param.right);
+    if (!initializer) {
+      return null;
+    }
+
+    return createPomParameterSpec(param.left.name, getTypeAnnotationSource(source, param.left), {
+      initializer,
+      hasQuestionToken: !!param.left.optional,
+    });
   }
 
   if (param.type === "RestElement") {
-    return param.argument.type === "Identifier" ? `...${param.argument.name}` : null;
+    if (param.argument.type !== "Identifier") {
+      return null;
+    }
+
+    const typeExpression = getTypeAnnotationSource(
+      source,
+      param,
+    ) ?? getTypeAnnotationSource(source, param.argument);
+
+    return createPomParameterSpec(param.argument.name, typeExpression, {
+      isRestParameter: true,
+    });
   }
 
   return null;
@@ -2107,8 +2020,7 @@ function extractCustomPomMethodSignatures(source: string, exportName: string): C
         continue;
       }
 
-      const params: string[] = [];
-      const argNames: string[] = [];
+      const parameters: PomParameterSpec[] = [];
       let supported = true;
 
       member.params.forEach((param) => {
@@ -2116,25 +2028,20 @@ function extractCustomPomMethodSignatures(source: string, exportName: string): C
           return;
         }
 
-        const paramSource = sliceNodeSource(source, param);
-        const argName = getCustomPomCallArgumentName(param);
-        if (!paramSource || !argName) {
+        const parameter = getCustomPomParameterSpec(source, param);
+        if (!parameter) {
           supported = false;
           return;
         }
 
-        params.push(paramSource);
-        argNames.push(argName);
+        parameters.push(parameter);
       });
 
       if (!supported) {
         continue;
       }
 
-      signatures.set(member.key.name, {
-        params: params.join(", "),
-        argNames,
-      });
+      signatures.set(member.key.name, createPomMethodSignature(parameters));
     }
   }
 
@@ -2478,12 +2385,12 @@ function getComposedStubBody(
       continue;
 
     const { child, signature } = candidatesForMethod[0];
-    const callArgs = getPomParameterNames(signature.parameters).join(", ");
+    const callArgs = getPomParameterArgumentNames(signature.parameters).join(", ");
 
     passthroughMembers.push(createClassMethod({
       name: methodName,
       isAsync: true,
-      parameters: parseParameterSignatures(formatTypeScriptPomParameters(signature.parameters)),
+      parameters: toTypeScriptPomParameterStructures(signature.parameters),
       statements: [
         `return await this.${child}.${methodName}(${callArgs});`,
       ],

--- a/class-generation/index.ts
+++ b/class-generation/index.ts
@@ -36,6 +36,7 @@ import {
   IDataTestId,
   PomExtraClickMethodSpec,
   PomPrimarySpec,
+  PomSelectorSpec,
   toPascalCase,
   upperFirst,
 } from "../utils";
@@ -434,23 +435,50 @@ function formatMethodParams(params: Record<string, string> | undefined): string 
   if (!params)
     return "";
 
-  // Keep output stable and somewhat intuitive.
-  const preferredOrder = ["key", "value", "text", "timeOut", "annotationText", "wait"];
-
   const entries = Object.entries(params);
   if (!entries.length)
     return "";
 
-  const score = (name: string) => {
-    const idx = preferredOrder.indexOf(name);
-    return idx < 0 ? 999 : idx;
-  };
-
   return entries
-    .slice()
-    .sort((a, b) => score(a[0]) - score(b[0]) || a[0].localeCompare(b[0]))
     .map(([name, typeExpr]) => `${name}: ${typeExpr}`)
     .join(", ");
+}
+
+function getSelectorPatterns(selector: PomSelectorSpec): PomStringPattern[] {
+  return selector.kind === "testId"
+    ? [selector.testId]
+    : [selector.rootTestId, selector.label];
+}
+
+function ensureRequiredPatternParams(
+  params: Record<string, string> | undefined,
+  patterns: readonly PomStringPattern[],
+  options: { omit?: readonly string[] } = {},
+): Record<string, string> {
+  const currentParams = params ?? {};
+  const omitted = new Set(options.omit ?? []);
+  const orderedEntries: [string, string][] = [];
+  const seen = new Set<string>();
+
+  for (const pattern of patterns) {
+    for (const variableName of pattern.templateVariables) {
+      if (omitted.has(variableName) || seen.has(variableName)) {
+        continue;
+      }
+      seen.add(variableName);
+      orderedEntries.push([variableName, currentParams[variableName] ?? "string"]);
+    }
+  }
+
+  for (const [name, typeExpr] of Object.entries(currentParams)) {
+    if (seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    orderedEntries.push([name, typeExpr]);
+  }
+
+  return Object.fromEntries(orderedEntries);
 }
 
 function generateExtraClickMethodMembers(spec: PomExtraClickMethodSpec): TypeScriptClassMember[] {
@@ -458,7 +486,12 @@ function generateExtraClickMethodMembers(spec: PomExtraClickMethodSpec): TypeScr
     return [];
   }
 
-  const params = spec.params ?? {};
+  const selectorPatterns = getSelectorPatterns(spec.selector);
+  const params = ensureRequiredPatternParams(
+    spec.params,
+    selectorPatterns,
+    { omit: spec.keyLiteral !== undefined ? ["key"] : [] },
+  );
   const signatureParams = formatMethodParams(params);
   const parameters = parseParameterSignatures(signatureParams);
 
@@ -1258,23 +1291,7 @@ function generateAggregatedCSharpFiles(
       const locatorName = baseGetterName.endsWith(roleSuffix) ? baseGetterName : `${baseGetterName}${roleSuffix}`;
       const selectorIsParameterized = isParameterizedPomPattern(pom.selector.patternKind);
       const testIdExpr = toCSharpTestIdExpression(pom.selector);
-
-      // Ensure all template variables referenced in formattedDataTestId (e.g. `${key}`)
-      // appear in the C# method signature. Stale/manual IR can still omit `key` on
-      // parameterized selectors, which would otherwise cause CS0103 compile errors.
-      const templateVarMatches = [...pom.selector.formatted.matchAll(/\$\{(\w+)\}/g)];
-      const templateVars = templateVarMatches.map(m => m[1]);
-      const augmentedParams: Record<string, string> = { ...pom.params };
-      for (const v of templateVars) {
-        if (!Object.prototype.hasOwnProperty.call(augmentedParams, v)) {
-          augmentedParams[v] = "string";
-        }
-      }
-      // Place template vars first so they precede text/value/annotationText.
-      const orderedParams: Record<string, string> = Object.fromEntries([
-        ...templateVars.map(v => [v, augmentedParams[v]] as [string, string]),
-        ...Object.entries(augmentedParams).filter(([k]) => !templateVars.includes(k)),
-      ]);
+      const orderedParams = ensureRequiredPatternParams(pom.params, [pom.selector]);
 
       const { signature, argNames } = formatCSharpParams(orderedParams);
       const args = argNames.join(", ");
@@ -1409,7 +1426,12 @@ function generateAggregatedCSharpFiles(
     for (const extra of extras) {
       if (extra.kind !== "click")
         continue;
-      const { signature } = formatCSharpParams(extra.params);
+      const extraParams = ensureRequiredPatternParams(
+        extra.params,
+        getSelectorPatterns(extra.selector),
+        { omit: extra.keyLiteral !== undefined ? ["key"] : [] },
+      );
+      const { signature } = formatCSharpParams(extraParams);
 
       const extraName = upperFirst(extra.name);
 

--- a/class-generation/index.ts
+++ b/class-generation/index.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { generateViewObjectModelMembers, generateViewObjectModelMethodContent } from "../method-generation";
+import { formatTypeScriptPomParameters, normalizePomParameters, type PomParameterSpec } from "../pom-params";
 import {
   bindCSharpPomPattern,
   bindTypeScriptPomPattern,
@@ -440,19 +441,6 @@ function generateGoToSelfMethod(componentName: string): TypeScriptClassMember[] 
   ];
 }
 
-function formatMethodParams(params: Record<string, string> | undefined): string {
-  if (!params)
-    return "";
-
-  const entries = Object.entries(params);
-  if (!entries.length)
-    return "";
-
-  return entries
-    .map(([name, typeExpr]) => `${name}: ${typeExpr}`)
-    .join(", ");
-}
-
 function getSelectorPatterns(selector: PomSelectorSpec): PomStringPattern[] {
   return selector.kind === "testId"
     ? [selector.testId]
@@ -470,7 +458,7 @@ function generateExtraClickMethodMembers(spec: PomExtraClickMethodSpec): TypeScr
     selectorPatterns,
     { omit: spec.keyLiteral !== undefined ? ["key"] : [] },
   );
-  const signatureParams = formatMethodParams(params);
+  const signatureParams = formatTypeScriptPomParameters(params);
   const parameters = parseParameterSignatures(signatureParams);
 
   const hasAnnotationText = Object.prototype.hasOwnProperty.call(params, "annotationText");
@@ -1069,16 +1057,9 @@ function buildGeneratedGitAttributesFiles(generatedFilePaths: string[]): Generat
     });
 }
 
-function toCSharpParam(paramTypeExpr: string): { type: string; defaultExpr?: string } {
-  const trimmed = (paramTypeExpr ?? "").trim();
-
-  // Handle default values: "boolean = true", "string = \"\"", "timeOut = 500".
-  const eqIdx = trimmed.indexOf("=");
-  const left = eqIdx >= 0 ? trimmed.slice(0, eqIdx).trim() : trimmed;
-  const right = eqIdx >= 0 ? trimmed.slice(eqIdx + 1).trim() : undefined;
-
+function toCSharpParam(param: PomParameterSpec): { type: string; defaultExpr?: string } {
   // Collapse union types to their widest practical type.
-  const typePart = left.includes("|") ? "string" : left;
+  const typePart = param.type.includes("|") ? "string" : param.type;
 
   let type = "string";
   if (/(?:^|\s)boolean(?:\s|$)/.test(typePart))
@@ -1087,23 +1068,21 @@ function toCSharpParam(paramTypeExpr: string): { type: string; defaultExpr?: str
     type = "string";
   else if (/(?:^|\s)number(?:\s|$)/.test(typePart))
     type = "int";
-  else if (/\d+/.test(typePart) && typePart === "")
-    type = "int";
   else if (/\btimeOut\b/i.test(typePart))
     type = "int";
 
   let defaultExpr: string | undefined;
-  if (right !== undefined) {
+  if (param.initializer !== undefined) {
     if (type === "bool") {
-      defaultExpr = right.includes("true") ? "true" : right.includes("false") ? "false" : undefined;
+      defaultExpr = param.initializer.includes("true") ? "true" : param.initializer.includes("false") ? "false" : undefined;
     }
     else if (type === "int") {
-      const m = right.match(/\d+/);
+      const m = param.initializer.match(/\d+/);
       defaultExpr = m ? m[0] : undefined;
     }
     else {
       // string defaults, keep empty string if detected.
-      if (right === "\"\"" || right === "\"\"" || right === "''") {
+      if (param.initializer === "\"\"" || param.initializer === "''") {
         defaultExpr = "\"\"";
       }
     }
@@ -1113,20 +1092,17 @@ function toCSharpParam(paramTypeExpr: string): { type: string; defaultExpr?: str
 }
 
 function formatCSharpParams(params: Record<string, string> | undefined): { signature: string; argNames: string[] } {
-  if (!params)
-    return { signature: "", argNames: [] };
-
-  const entries = Object.entries(params);
-  if (!entries.length)
+  const normalizedParams = normalizePomParameters(params);
+  if (!normalizedParams.length)
     return { signature: "", argNames: [] };
 
   const signatureParts: string[] = [];
   const argNames: string[] = [];
 
-  for (const [name, typeExpr] of entries) {
-    const { type, defaultExpr } = toCSharpParam(typeExpr);
-    argNames.push(name);
-    signatureParts.push(defaultExpr !== undefined ? `${type} ${name} = ${defaultExpr}` : `${type} ${name}`);
+  for (const param of normalizedParams) {
+    const { type, defaultExpr } = toCSharpParam(param);
+    argNames.push(param.name);
+    signatureParts.push(defaultExpr !== undefined ? `${type} ${param.name} = ${defaultExpr}` : `${type} ${param.name}`);
   }
 
   return { signature: signatureParts.join(", "), argNames };

--- a/class-generation/playwright-types.ts
+++ b/class-generation/playwright-types.ts
@@ -1,4 +1,4 @@
-import type { Locator as PwLocator, Page as PwPage } from "@playwright/test";
+import type { Locator as PwLocator, Page as PwPage } from "playwright";
 
 export type { PwLocator, PwPage };
 

--- a/click-instrumentation.ts
+++ b/click-instrumentation.ts
@@ -3,10 +3,6 @@
 
 export const TESTID_CLICK_EVENT_NAME = "__testid_event__";
 
-// When strict mode is enabled, the injected click wrapper will fail fast if it
-// cannot emit the expected event.
-export const TESTID_CLICK_EVENT_STRICT_FLAG = "__testid_click_event_strict__";
-
 export interface TestIdClickEventDetail {
   testId?: string;
   phase?: "before" | "after" | "error" | string;

--- a/method-generation.ts
+++ b/method-generation.ts
@@ -13,7 +13,7 @@ import {
   type TypeScriptClassMember,
   type WriterFunction,
 } from "./typescript-codegen";
-import { getPomParameterNames, normalizePomParameters } from "./pom-params";
+import { getPomParameter, getPomParameterNames, normalizePomParameters, type PomParameterSpec } from "./pom-params";
 import {
   ensurePomPatternParameters,
   getIndexedPomPatternVariable,
@@ -30,7 +30,7 @@ function upperFirst(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
-function createParameters(params: Record<string, string>): OptionalKind<ParameterDeclarationStructure>[] {
+function createParameters(params: readonly PomParameterSpec[]): OptionalKind<ParameterDeclarationStructure>[] {
   return normalizePomParameters(params).map(({ name, type, initializer }) => ({
     name,
     type: type || undefined,
@@ -77,11 +77,11 @@ function generateClickMethod(
   methodName: string,
   selector: PomStringPattern,
   alternateSelectors: PomStringPattern[] | undefined,
-  params: Record<string, string>,
+  parameters: PomParameterSpec[],
 ): TypeScriptClassMember[] {
   const name = `click${methodName}`;
   const noWaitName = `${name}NoWait`;
-  const selectorParams = ensurePomPatternParameters(params, [selector]);
+  const selectorParams = ensurePomPatternParameters(parameters, [selector]);
   const hasSelectorVariables = hasPomPatternVariables(selector);
   const baseParameters = createParameters(selectorParams);
   const argsForForward = getPomParameterNames(selectorParams).join(", ");
@@ -150,15 +150,15 @@ function generateClickMethod(
 function generateRadioMethod(
   methodName: string,
   selector: PomStringPattern,
-  params: Record<string, string>,
+  parameters: PomParameterSpec[],
 ): TypeScriptClassMember[] {
   const name = `select${methodName}`;
-  const selectorParams = ensurePomPatternParameters(params, [selector]);
-  const parameters = createParameters(selectorParams);
+  const selectorParams = ensurePomPatternParameters(parameters, [selector]);
+  const methodParameters = createParameters(selectorParams);
   const testIdExpr = toTypeScriptPomPatternExpression(selector);
 
   return [
-    createAsyncMethod(name, parameters, (writer) => {
+    createAsyncMethod(name, methodParameters, (writer) => {
       writer.writeLine(`await this.clickByTestId(${testIdExpr}, annotationText);`);
     }),
   ];
@@ -167,10 +167,10 @@ function generateRadioMethod(
 function generateSelectMethod(
   methodName: string,
   selector: PomStringPattern,
-  params: Record<string, string>,
+  parameters: PomParameterSpec[],
 ): TypeScriptClassMember[] {
   const name = `select${methodName}`;
-  const selectorParams = ensurePomPatternParameters(params, [selector]);
+  const selectorParams = ensurePomPatternParameters(parameters, [selector]);
   const selectorExpr = `this.selectorForTestId(${toTypeScriptPomPatternExpression(selector)})`;
 
   return [
@@ -189,10 +189,10 @@ function generateSelectMethod(
 function generateVSelectMethod(
   methodName: string,
   selector: PomStringPattern,
-  params: Record<string, string>,
+  parameters: PomParameterSpec[],
 ): TypeScriptClassMember[] {
   const name = `select${methodName}`;
-  const selectorParams = ensurePomPatternParameters(params, [selector]);
+  const selectorParams = ensurePomPatternParameters(parameters, [selector]);
 
   return [
     createAsyncMethod(
@@ -208,10 +208,10 @@ function generateVSelectMethod(
 function generateTypeMethod(
   methodName: string,
   selector: PomStringPattern,
-  params: Record<string, string>,
+  parameters: PomParameterSpec[],
 ): TypeScriptClassMember[] {
   const name = `type${methodName}`;
-  const selectorParams = ensurePomPatternParameters(params, [selector]);
+  const selectorParams = ensurePomPatternParameters(parameters, [selector]);
 
   return [
     createAsyncMethod(
@@ -241,18 +241,18 @@ function generateGetElementByDataTestId(
   selector: PomStringPattern,
   alternateSelectors: PomStringPattern[] | undefined,
   getterNameOverride: string | undefined,
-  params: Record<string, string>,
+  parameters: PomParameterSpec[],
 ): TypeScriptClassMember[] {
   const roleSuffix = upperFirst(nativeRole || "Element");
   const baseName = upperFirst(methodName);
   const numericSuffix = baseName.startsWith(roleSuffix) ? baseName.slice(roleSuffix.length) : "";
   const hasRoleSuffix = baseName.endsWith(roleSuffix) || (baseName.startsWith(roleSuffix) && isAllDigits(numericSuffix));
   const propertyName = hasRoleSuffix ? `${baseName}` : `${baseName}${roleSuffix}`;
-  const selectorParams = ensurePomPatternParameters(params, [selector]);
+  const selectorParams = ensurePomPatternParameters(parameters, [selector]);
   const indexedVariable = getIndexedPomPatternVariable(selector);
 
   if (indexedVariable) {
-    const keyType = selectorParams[indexedVariable] || "string";
+    const keyType = getPomParameter(selectorParams, indexedVariable)?.typeExpression || "string";
     const keyedPropertyName = getterNameOverride ?? removeByKeySegment(propertyName);
     return [
       createClassGetter({
@@ -293,25 +293,25 @@ function generateNavigationMethod(args: {
   baseMethodName: string;
   selector: PomStringPattern;
   alternateSelectors?: PomStringPattern[];
-  params: Record<string, string>;
+  parameters: PomParameterSpec[];
 }): TypeScriptClassMember[] {
-  const { targetPageObjectModelClass: target, baseMethodName, selector, alternateSelectors, params } = args;
+  const { targetPageObjectModelClass: target, baseMethodName, selector, alternateSelectors, parameters } = args;
 
   const methodName = baseMethodName
     ? `goTo${upperFirst(baseMethodName)}`
     : `goTo${target.endsWith("Page") ? target.slice(0, -"Page".length) : target}`;
 
-  const selectorParams = ensurePomPatternParameters(params, [selector]);
-  const parameters = createParameters(selectorParams);
+  const selectorParams = ensurePomPatternParameters(parameters, [selector]);
+  const methodParameters = createParameters(selectorParams);
   const alternates = uniquePomStringPatterns(selector, alternateSelectors).slice(1);
   const candidatesExpr = [toTypeScriptPomPatternExpression(selector), ...alternates.map(id => toTypeScriptPomPatternExpression(id))].join(", ");
 
   if (alternates.length > 0) {
     return [
-      createClassMethod({
-        name: methodName,
-        parameters,
-        returnType: `Fluent<${target}>`,
+        createClassMethod({
+          name: methodName,
+          parameters: methodParameters,
+          returnType: `Fluent<${target}>`,
         statements: (writer) => {
           writer.write("return this.fluent(async () => ").block(() => {
             writer.writeLine(`const candidates = [${candidatesExpr}] as const;`);
@@ -339,7 +339,7 @@ function generateNavigationMethod(args: {
   return [
     createClassMethod({
       name: methodName,
-      parameters,
+      parameters: methodParameters,
       returnType: `Fluent<${target}>`,
       statements: (writer) => {
         writer.write("return this.fluent(async () => ").block(() => {
@@ -359,7 +359,7 @@ export function generateViewObjectModelMembers(
   selector: PomStringPattern,
   alternateSelectors: PomStringPattern[] | undefined,
   getterNameOverride: string | undefined,
-  params: Record<string, string>,
+  parameters: PomParameterSpec[],
 ): TypeScriptClassMember[] {
   const baseMethodName = (nativeRole === "radio")
     ? (methodName || "Radio")
@@ -371,7 +371,7 @@ export function generateViewObjectModelMembers(
     selector,
     alternateSelectors,
     getterNameOverride,
-    params,
+    parameters,
   );
 
   if (targetPageObjectModelClass) {
@@ -382,25 +382,25 @@ export function generateViewObjectModelMembers(
         baseMethodName,
         selector,
         alternateSelectors,
-        params,
+        parameters,
       }),
     ];
   }
 
   if (nativeRole === "select") {
-    return [...members, ...generateSelectMethod(baseMethodName, selector, params)];
+    return [...members, ...generateSelectMethod(baseMethodName, selector, parameters)];
   }
   if (nativeRole === "vselect") {
-    return [...members, ...generateVSelectMethod(baseMethodName, selector, params)];
+    return [...members, ...generateVSelectMethod(baseMethodName, selector, parameters)];
   }
   if (nativeRole === "input") {
-    return [...members, ...generateTypeMethod(baseMethodName, selector, params)];
+    return [...members, ...generateTypeMethod(baseMethodName, selector, parameters)];
   }
   if (nativeRole === "radio") {
-    return [...members, ...generateRadioMethod(baseMethodName || "Radio", selector, params)];
+    return [...members, ...generateRadioMethod(baseMethodName || "Radio", selector, parameters)];
   }
 
-  return [...members, ...generateClickMethod(baseMethodName, selector, alternateSelectors, params)];
+  return [...members, ...generateClickMethod(baseMethodName, selector, alternateSelectors, parameters)];
 }
 
 export function generateViewObjectModelMethodContent(
@@ -410,7 +410,7 @@ export function generateViewObjectModelMethodContent(
   selector: PomStringPattern,
   alternateSelectors: PomStringPattern[] | undefined,
   getterNameOverride: string | undefined,
-  params: Record<string, string>,
+  parameters: PomParameterSpec[],
 ) {
   return renderClassMembers(
     generateViewObjectModelMembers(
@@ -420,7 +420,7 @@ export function generateViewObjectModelMethodContent(
       selector,
       alternateSelectors,
       getterNameOverride,
-      params,
+      parameters,
     ),
   );
 }

--- a/method-generation.ts
+++ b/method-generation.ts
@@ -13,7 +13,13 @@ import {
   type TypeScriptClassMember,
   type WriterFunction,
 } from "./typescript-codegen";
-import { isParameterizedPomPattern, uniquePomStringPatterns, type PomStringPattern } from "./pom-patterns";
+import {
+  ensurePomPatternParameters,
+  getIndexedPomPatternVariable,
+  isParameterizedPomPattern,
+  uniquePomStringPatterns,
+  type PomStringPattern,
+} from "./pom-patterns";
 
 function upperFirst(value: string): string {
   if (!value) {
@@ -76,42 +82,6 @@ function testIdExpression(pattern: PomStringPattern): string {
     : JSON.stringify(pattern.formatted);
 }
 
-function ensureSelectorParameters(params: Record<string, string>, selector: PomStringPattern): Record<string, string> {
-  if (!isParameterizedPomPattern(selector.patternKind) || selector.templateVariables.length === 0) {
-    return params;
-  }
-
-  const orderedEntries: [string, string][] = [];
-  const seen = new Set<string>();
-  for (const variableName of selector.templateVariables) {
-    seen.add(variableName);
-    orderedEntries.push([variableName, params[variableName] ?? "string"]);
-  }
-  for (const [name, typeExpression] of Object.entries(params)) {
-    if (seen.has(name)) {
-      continue;
-    }
-    seen.add(name);
-    orderedEntries.push([name, typeExpression]);
-  }
-  return Object.fromEntries(orderedEntries);
-}
-
-function getIndexedSelectorVariable(selector: PomStringPattern): string | null {
-  if (!isParameterizedPomPattern(selector.patternKind)) {
-    return null;
-  }
-
-  if (selector.templateVariables.length !== 1) {
-    throw new Error(
-      `[vue-pom-generator] Parameterized locator getters require exactly one template variable; `
-      + `got ${selector.templateVariables.length} in ${JSON.stringify(selector.formatted)}.`,
-    );
-  }
-
-  return selector.templateVariables[0];
-}
-
 function createAsyncMethod(
   name: string,
   parameters: OptionalKind<ParameterDeclarationStructure>[],
@@ -133,7 +103,7 @@ function generateClickMethod(
 ): TypeScriptClassMember[] {
   const name = `click${methodName}`;
   const noWaitName = `${name}NoWait`;
-  const selectorParams = ensureSelectorParameters(params, selector);
+  const selectorParams = ensurePomPatternParameters(params, [selector]);
   const hasSelectorVariables = selector.templateVariables.length > 0;
   const baseParameters = createParameters(selectorParams);
   const argsForForward = Object.keys(selectorParams).join(", ");
@@ -205,7 +175,7 @@ function generateRadioMethod(
   params: Record<string, string>,
 ): TypeScriptClassMember[] {
   const name = `select${methodName}`;
-  const selectorParams = ensureSelectorParameters(params, selector);
+  const selectorParams = ensurePomPatternParameters(params, [selector]);
   const parameters = createParameters(selectorParams);
   const testIdExpr = testIdExpression(selector);
 
@@ -222,7 +192,7 @@ function generateSelectMethod(
   params: Record<string, string>,
 ): TypeScriptClassMember[] {
   const name = `select${methodName}`;
-  const selectorParams = ensureSelectorParameters(params, selector);
+  const selectorParams = ensurePomPatternParameters(params, [selector]);
   const selectorExpr = `this.selectorForTestId(${testIdExpression(selector)})`;
 
   return [
@@ -244,7 +214,7 @@ function generateVSelectMethod(
   params: Record<string, string>,
 ): TypeScriptClassMember[] {
   const name = `select${methodName}`;
-  const selectorParams = ensureSelectorParameters(params, selector);
+  const selectorParams = ensurePomPatternParameters(params, [selector]);
 
   return [
     createAsyncMethod(
@@ -263,7 +233,7 @@ function generateTypeMethod(
   params: Record<string, string>,
 ): TypeScriptClassMember[] {
   const name = `type${methodName}`;
-  const selectorParams = ensureSelectorParameters(params, selector);
+  const selectorParams = ensurePomPatternParameters(params, [selector]);
 
   return [
     createAsyncMethod(
@@ -300,8 +270,8 @@ function generateGetElementByDataTestId(
   const numericSuffix = baseName.startsWith(roleSuffix) ? baseName.slice(roleSuffix.length) : "";
   const hasRoleSuffix = baseName.endsWith(roleSuffix) || (baseName.startsWith(roleSuffix) && isAllDigits(numericSuffix));
   const propertyName = hasRoleSuffix ? `${baseName}` : `${baseName}${roleSuffix}`;
-  const selectorParams = ensureSelectorParameters(params, selector);
-  const indexedVariable = getIndexedSelectorVariable(selector);
+  const selectorParams = ensurePomPatternParameters(params, [selector]);
+  const indexedVariable = getIndexedPomPatternVariable(selector);
 
   if (indexedVariable) {
     const keyType = selectorParams[indexedVariable] || "string";
@@ -353,7 +323,7 @@ function generateNavigationMethod(args: {
     ? `goTo${upperFirst(baseMethodName)}`
     : `goTo${target.endsWith("Page") ? target.slice(0, -"Page".length) : target}`;
 
-  const selectorParams = ensureSelectorParameters(params, selector);
+  const selectorParams = ensurePomPatternParameters(params, [selector]);
   const parameters = createParameters(selectorParams);
   const alternates = uniquePomStringPatterns(selector, alternateSelectors).slice(1);
   const candidatesExpr = [testIdExpression(selector), ...alternates.map(id => testIdExpression(id))].join(", ");

--- a/method-generation.ts
+++ b/method-generation.ts
@@ -20,9 +20,9 @@ import {
   type PomParameterSpec,
 } from "./pom-params";
 import {
-  ensurePomPatternParameters,
   getIndexedPomPatternVariable,
   hasPomPatternVariables,
+  orderPomPatternParameters,
   toTypeScriptPomPatternExpression,
   uniquePomStringPatterns,
   type PomStringPattern,
@@ -82,7 +82,7 @@ function generateClickMethod(
 ): TypeScriptClassMember[] {
   const name = `click${methodName}`;
   const noWaitName = `${name}NoWait`;
-  const selectorParams = ensurePomPatternParameters(parameters, [selector]);
+  const selectorParams = orderPomPatternParameters(parameters, [selector]);
   const hasSelectorVariables = hasPomPatternVariables(selector);
   const baseParameters = createParameters(selectorParams);
   const argsForForward = getPomParameterNames(selectorParams).join(", ");
@@ -154,7 +154,7 @@ function generateRadioMethod(
   parameters: PomParameterSpec[],
 ): TypeScriptClassMember[] {
   const name = `select${methodName}`;
-  const selectorParams = ensurePomPatternParameters(parameters, [selector]);
+  const selectorParams = orderPomPatternParameters(parameters, [selector]);
   const methodParameters = createParameters(selectorParams);
   const testIdExpr = toTypeScriptPomPatternExpression(selector);
 
@@ -171,7 +171,7 @@ function generateSelectMethod(
   parameters: PomParameterSpec[],
 ): TypeScriptClassMember[] {
   const name = `select${methodName}`;
-  const selectorParams = ensurePomPatternParameters(parameters, [selector]);
+  const selectorParams = orderPomPatternParameters(parameters, [selector]);
   const selectorExpr = `this.selectorForTestId(${toTypeScriptPomPatternExpression(selector)})`;
 
   return [
@@ -193,7 +193,7 @@ function generateVSelectMethod(
   parameters: PomParameterSpec[],
 ): TypeScriptClassMember[] {
   const name = `select${methodName}`;
-  const selectorParams = ensurePomPatternParameters(parameters, [selector]);
+  const selectorParams = orderPomPatternParameters(parameters, [selector]);
 
   return [
     createAsyncMethod(
@@ -212,7 +212,7 @@ function generateTypeMethod(
   parameters: PomParameterSpec[],
 ): TypeScriptClassMember[] {
   const name = `type${methodName}`;
-  const selectorParams = ensurePomPatternParameters(parameters, [selector]);
+  const selectorParams = orderPomPatternParameters(parameters, [selector]);
 
   return [
     createAsyncMethod(
@@ -249,7 +249,7 @@ function generateGetElementByDataTestId(
   const numericSuffix = baseName.startsWith(roleSuffix) ? baseName.slice(roleSuffix.length) : "";
   const hasRoleSuffix = baseName.endsWith(roleSuffix) || (baseName.startsWith(roleSuffix) && isAllDigits(numericSuffix));
   const propertyName = hasRoleSuffix ? `${baseName}` : `${baseName}${roleSuffix}`;
-  const selectorParams = ensurePomPatternParameters(parameters, [selector]);
+  const selectorParams = orderPomPatternParameters(parameters, [selector]);
   const indexedVariable = getIndexedPomPatternVariable(selector);
 
   if (indexedVariable) {
@@ -302,7 +302,7 @@ function generateNavigationMethod(args: {
     ? `goTo${upperFirst(baseMethodName)}`
     : `goTo${target.endsWith("Page") ? target.slice(0, -"Page".length) : target}`;
 
-  const selectorParams = ensurePomPatternParameters(parameters, [selector]);
+  const selectorParams = orderPomPatternParameters(parameters, [selector]);
   const methodParameters = createParameters(selectorParams);
   const alternates = uniquePomStringPatterns(selector, alternateSelectors).slice(1);
   const candidatesExpr = [toTypeScriptPomPatternExpression(selector), ...alternates.map(id => toTypeScriptPomPatternExpression(id))].join(", ");

--- a/method-generation.ts
+++ b/method-generation.ts
@@ -16,6 +16,7 @@ import {
 import {
   ensurePomPatternParameters,
   getIndexedPomPatternVariable,
+  hasPomPatternVariables,
   isParameterizedPomPattern,
   toTypeScriptPomPatternExpression,
   uniquePomStringPatterns,
@@ -99,7 +100,7 @@ function generateClickMethod(
   const name = `click${methodName}`;
   const noWaitName = `${name}NoWait`;
   const selectorParams = ensurePomPatternParameters(params, [selector]);
-  const hasSelectorVariables = selector.templateVariables.length > 0;
+  const hasSelectorVariables = hasPomPatternVariables(selector);
   const baseParameters = createParameters(selectorParams);
   const argsForForward = Object.keys(selectorParams).join(", ");
   const alternates = uniquePomStringPatterns(selector, alternateSelectors).slice(1);

--- a/method-generation.ts
+++ b/method-generation.ts
@@ -13,7 +13,12 @@ import {
   type TypeScriptClassMember,
   type WriterFunction,
 } from "./typescript-codegen";
-import { getPomParameter, getPomParameterNames, normalizePomParameters, type PomParameterSpec } from "./pom-params";
+import {
+  getPomParameter,
+  getPomParameterNames,
+  toTypeScriptPomParameterStructures,
+  type PomParameterSpec,
+} from "./pom-params";
 import {
   ensurePomPatternParameters,
   getIndexedPomPatternVariable,
@@ -31,11 +36,7 @@ function upperFirst(value: string): string {
 }
 
 function createParameters(params: readonly PomParameterSpec[]): OptionalKind<ParameterDeclarationStructure>[] {
-  return normalizePomParameters(params).map(({ name, type, initializer }) => ({
-    name,
-    type: type || undefined,
-    initializer,
-  }));
+  return toTypeScriptPomParameterStructures(params);
 }
 
 function createInlineParameter(

--- a/method-generation.ts
+++ b/method-generation.ts
@@ -13,11 +13,11 @@ import {
   type TypeScriptClassMember,
   type WriterFunction,
 } from "./typescript-codegen";
+import { getPomParameterNames, normalizePomParameters } from "./pom-params";
 import {
   ensurePomPatternParameters,
   getIndexedPomPatternVariable,
   hasPomPatternVariables,
-  isParameterizedPomPattern,
   toTypeScriptPomPatternExpression,
   uniquePomStringPatterns,
   type PomStringPattern,
@@ -30,30 +30,12 @@ function upperFirst(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
-function splitTypeAndInitializer(typeExpression: string): { type: string; initializer?: string } {
-  const trimmed = typeExpression.trim();
-  const initializerIndex = trimmed.lastIndexOf("=");
-  if (initializerIndex < 0) {
-    return { type: trimmed };
-  }
-
-  return {
-    type: trimmed.slice(0, initializerIndex).trim(),
-    initializer: trimmed.slice(initializerIndex + 1).trim(),
-  };
-}
-
-function createParameter(name: string, typeExpression: string): OptionalKind<ParameterDeclarationStructure> {
-  const { type, initializer } = splitTypeAndInitializer(typeExpression);
-  return {
+function createParameters(params: Record<string, string>): OptionalKind<ParameterDeclarationStructure>[] {
+  return normalizePomParameters(params).map(({ name, type, initializer }) => ({
     name,
     type: type || undefined,
     initializer,
-  };
-}
-
-function createParameters(params: Record<string, string>): OptionalKind<ParameterDeclarationStructure>[] {
-  return Object.entries(params).map(([name, typeExpression]) => createParameter(name, typeExpression));
+  }));
 }
 
 function createInlineParameter(
@@ -102,7 +84,7 @@ function generateClickMethod(
   const selectorParams = ensurePomPatternParameters(params, [selector]);
   const hasSelectorVariables = hasPomPatternVariables(selector);
   const baseParameters = createParameters(selectorParams);
-  const argsForForward = Object.keys(selectorParams).join(", ");
+  const argsForForward = getPomParameterNames(selectorParams).join(", ");
   const alternates = uniquePomStringPatterns(selector, alternateSelectors).slice(1);
   const primaryTestIdExpr = toTypeScriptPomPatternExpression(selector);
 

--- a/method-generation.ts
+++ b/method-generation.ts
@@ -13,7 +13,7 @@ import {
   type TypeScriptClassMember,
   type WriterFunction,
 } from "./typescript-codegen";
-import { inferPomPatternKindFromFormattedString, isParameterizedPomPattern, type PomPatternKind } from "./pom-patterns";
+import { isParameterizedPomPattern, uniquePomStringPatterns, type PomStringPattern } from "./pom-patterns";
 
 function upperFirst(value: string): string {
   if (!value) {
@@ -74,34 +74,14 @@ function removeByKeySegment(value: string): string {
   return value.slice(0, idx) + value.slice(idx + "ByKey".length);
 }
 
-function uniqueAlternates(primary: string, alternates: string[] | undefined): string[] {
-  const out: string[] = [];
-  const seen = new Set<string>();
-  seen.add(primary);
-  for (const a of alternates ?? []) {
-    if (!a) {
-      continue;
-    }
-    if (seen.has(a)) {
-      continue;
-    }
-    seen.add(a);
-    out.push(a);
-  }
-  return out;
+function testIdExpression(pattern: PomStringPattern): string {
+  return isParameterizedPomPattern(pattern.patternKind)
+    ? `\`${pattern.formatted}\``
+    : JSON.stringify(pattern.formatted);
 }
 
-function testIdExpression(formattedDataTestId: string, patternKind?: PomPatternKind): string {
-  // Callers without structured metadata (currently alternate selector strings) only use this
-  // fallback to decide quote/backtick rendering. API shape comes from selectorPatternKind.
-  const needsTemplate = patternKind
-    ? isParameterizedPomPattern(patternKind)
-    : isParameterizedPomPattern(inferPomPatternKindFromFormattedString(formattedDataTestId));
-  return needsTemplate ? `\`${formattedDataTestId}\`` : JSON.stringify(formattedDataTestId);
-}
-
-function ensureSelectorParameters(params: Record<string, string>, selectorPatternKind: PomPatternKind): Record<string, string> {
-  if (!isParameterizedPomPattern(selectorPatternKind) || hasParam(params, "key")) {
+function ensureSelectorParameters(params: Record<string, string>, selector: PomStringPattern): Record<string, string> {
+  if (!isParameterizedPomPattern(selector.patternKind) || hasParam(params, "key")) {
     return params;
   }
 
@@ -123,18 +103,17 @@ function createAsyncMethod(
 
 function generateClickMethod(
   methodName: string,
-  formattedDataTestId: string,
-  alternateFormattedDataTestIds: string[] | undefined,
+  selector: PomStringPattern,
+  alternateSelectors: PomStringPattern[] | undefined,
   params: Record<string, string>,
-  selectorPatternKind: PomPatternKind,
 ): TypeScriptClassMember[] {
   const name = `click${methodName}`;
   const noWaitName = `${name}NoWait`;
-  const selectorParams = ensureSelectorParameters(params, selectorPatternKind);
+  const selectorParams = ensureSelectorParameters(params, selector);
   const baseParameters = createParameters(selectorParams);
   const argsForForward = Object.keys(selectorParams).join(", ");
-  const alternates = uniqueAlternates(formattedDataTestId, alternateFormattedDataTestIds);
-  const primaryTestIdExpr = testIdExpression(formattedDataTestId, selectorPatternKind);
+  const alternates = uniquePomStringPatterns(selector, alternateSelectors).slice(1);
+  const primaryTestIdExpr = testIdExpression(selector);
 
   if (alternates.length > 0) {
     const candidatesExpr = [primaryTestIdExpr, ...alternates.map(id => testIdExpression(id))].join(", ");
@@ -197,14 +176,13 @@ function generateClickMethod(
 
 function generateRadioMethod(
   methodName: string,
-  formattedDataTestId: string,
+  selector: PomStringPattern,
   params: Record<string, string>,
-  selectorPatternKind: PomPatternKind,
 ): TypeScriptClassMember[] {
   const name = `select${methodName}`;
-  const selectorParams = ensureSelectorParameters(params, selectorPatternKind);
+  const selectorParams = ensureSelectorParameters(params, selector);
   const parameters = createParameters(selectorParams);
-  const testIdExpr = testIdExpression(formattedDataTestId, selectorPatternKind);
+  const testIdExpr = testIdExpression(selector);
 
   return [
     createAsyncMethod(name, parameters, (writer) => {
@@ -215,13 +193,12 @@ function generateRadioMethod(
 
 function generateSelectMethod(
   methodName: string,
-  formattedDataTestId: string,
+  selector: PomStringPattern,
   params: Record<string, string>,
-  selectorPatternKind: PomPatternKind,
 ): TypeScriptClassMember[] {
   const name = `select${methodName}`;
-  const selectorParams = ensureSelectorParameters(params, selectorPatternKind);
-  const selectorExpr = `this.selectorForTestId(${testIdExpression(formattedDataTestId, selectorPatternKind)})`;
+  const selectorParams = ensureSelectorParameters(params, selector);
+  const selectorExpr = `this.selectorForTestId(${testIdExpression(selector)})`;
 
   return [
     createAsyncMethod(
@@ -238,19 +215,18 @@ function generateSelectMethod(
 
 function generateVSelectMethod(
   methodName: string,
-  formattedDataTestId: string,
+  selector: PomStringPattern,
   params: Record<string, string>,
-  selectorPatternKind: PomPatternKind,
 ): TypeScriptClassMember[] {
   const name = `select${methodName}`;
-  const selectorParams = ensureSelectorParameters(params, selectorPatternKind);
+  const selectorParams = ensureSelectorParameters(params, selector);
 
   return [
     createAsyncMethod(
       name,
       createParameters(selectorParams),
       (writer) => {
-        writer.writeLine(`await this.selectVSelectByTestId(${testIdExpression(formattedDataTestId, selectorPatternKind)}, value, timeOut, annotationText);`);
+        writer.writeLine(`await this.selectVSelectByTestId(${testIdExpression(selector)}, value, timeOut, annotationText);`);
       },
     ),
   ];
@@ -258,19 +234,18 @@ function generateVSelectMethod(
 
 function generateTypeMethod(
   methodName: string,
-  formattedDataTestId: string,
+  selector: PomStringPattern,
   params: Record<string, string>,
-  selectorPatternKind: PomPatternKind,
 ): TypeScriptClassMember[] {
   const name = `type${methodName}`;
-  const selectorParams = ensureSelectorParameters(params, selectorPatternKind);
+  const selectorParams = ensureSelectorParameters(params, selector);
 
   return [
     createAsyncMethod(
       name,
       createParameters(selectorParams),
       (writer) => {
-        writer.writeLine(`await this.fillInputByTestId(${testIdExpression(formattedDataTestId, selectorPatternKind)}, text, annotationText);`);
+        writer.writeLine(`await this.fillInputByTestId(${testIdExpression(selector)}, text, annotationText);`);
       },
     ),
   ];
@@ -290,19 +265,18 @@ function isAllDigits(value: string): boolean {
 function generateGetElementByDataTestId(
   methodName: string,
   nativeRole: string,
-  formattedDataTestId: string,
-  alternateFormattedDataTestIds: string[] | undefined,
+  selector: PomStringPattern,
+  alternateSelectors: PomStringPattern[] | undefined,
   getterNameOverride: string | undefined,
   params: Record<string, string>,
-  selectorPatternKind: PomPatternKind,
 ): TypeScriptClassMember[] {
   const roleSuffix = upperFirst(nativeRole || "Element");
   const baseName = upperFirst(methodName);
   const numericSuffix = baseName.startsWith(roleSuffix) ? baseName.slice(roleSuffix.length) : "";
   const hasRoleSuffix = baseName.endsWith(roleSuffix) || (baseName.startsWith(roleSuffix) && isAllDigits(numericSuffix));
   const propertyName = hasRoleSuffix ? `${baseName}` : `${baseName}${roleSuffix}`;
-  const selectorParams = ensureSelectorParameters(params, selectorPatternKind);
-  const needsKey = isParameterizedPomPattern(selectorPatternKind);
+  const selectorParams = ensureSelectorParameters(params, selector);
+  const needsKey = isParameterizedPomPattern(selector.patternKind);
 
   if (needsKey) {
     const keyType = selectorParams.key || "string";
@@ -311,16 +285,16 @@ function generateGetElementByDataTestId(
       createClassGetter({
         name: keyedPropertyName,
         statements: [
-          `return this.keyedLocators((key: ${keyType}) => this.locatorByTestId(${testIdExpression(formattedDataTestId, selectorPatternKind)}));`,
+          `return this.keyedLocators((key: ${keyType}) => this.locatorByTestId(${testIdExpression(selector)}));`,
         ],
       }),
     ];
   }
 
   const finalPropertyName = getterNameOverride ?? propertyName;
-  const alternates = uniqueAlternates(formattedDataTestId, alternateFormattedDataTestIds);
+  const alternates = uniquePomStringPatterns(selector, alternateSelectors).slice(1);
   if (alternates.length > 0) {
-    const all = [formattedDataTestId, ...alternates];
+    const all = [selector, ...alternates];
     const locatorExpr = all
       .map(id => `this.locatorByTestId(${testIdExpression(id)})`)
       .reduce((acc, next) => `${acc}.or(${next})`);
@@ -336,7 +310,7 @@ function generateGetElementByDataTestId(
   return [
     createClassGetter({
       name: finalPropertyName,
-      statements: [`return this.locatorByTestId("${formattedDataTestId}");`],
+      statements: [`return this.locatorByTestId(${testIdExpression(selector)});`],
     }),
   ];
 }
@@ -344,21 +318,20 @@ function generateGetElementByDataTestId(
 function generateNavigationMethod(args: {
   targetPageObjectModelClass: string;
   baseMethodName: string;
-  formattedDataTestId: string;
-  selectorPatternKind: PomPatternKind;
-  alternateFormattedDataTestIds?: string[];
+  selector: PomStringPattern;
+  alternateSelectors?: PomStringPattern[];
   params: Record<string, string>;
 }): TypeScriptClassMember[] {
-  const { targetPageObjectModelClass: target, baseMethodName, formattedDataTestId, selectorPatternKind, alternateFormattedDataTestIds, params } = args;
+  const { targetPageObjectModelClass: target, baseMethodName, selector, alternateSelectors, params } = args;
 
   const methodName = baseMethodName
     ? `goTo${upperFirst(baseMethodName)}`
     : `goTo${target.endsWith("Page") ? target.slice(0, -"Page".length) : target}`;
 
-  const selectorParams = ensureSelectorParameters(params, selectorPatternKind);
+  const selectorParams = ensureSelectorParameters(params, selector);
   const parameters = createParameters(selectorParams);
-  const alternates = uniqueAlternates(formattedDataTestId, alternateFormattedDataTestIds);
-  const candidatesExpr = [testIdExpression(formattedDataTestId, selectorPatternKind), ...alternates.map(id => testIdExpression(id))].join(", ");
+  const alternates = uniquePomStringPatterns(selector, alternateSelectors).slice(1);
+  const candidatesExpr = [testIdExpression(selector), ...alternates.map(id => testIdExpression(id))].join(", ");
 
   if (alternates.length > 0) {
     return [
@@ -397,7 +370,7 @@ function generateNavigationMethod(args: {
       returnType: `Fluent<${target}>`,
       statements: (writer) => {
         writer.write("return this.fluent(async () => ").block(() => {
-          writer.writeLine(`await this.clickByTestId(${testIdExpression(formattedDataTestId, selectorPatternKind)});`);
+          writer.writeLine(`await this.clickByTestId(${testIdExpression(selector)});`);
           writer.writeLine(`return new ${target}(this.page);`);
         });
         writer.writeLine(");");
@@ -410,9 +383,8 @@ export function generateViewObjectModelMembers(
   targetPageObjectModelClass: string | undefined,
   methodName: string,
   nativeRole: string,
-  selectorPatternKind: PomPatternKind,
-  formattedDataTestId: string,
-  alternateFormattedDataTestIds: string[] | undefined,
+  selector: PomStringPattern,
+  alternateSelectors: PomStringPattern[] | undefined,
   getterNameOverride: string | undefined,
   params: Record<string, string>,
 ): TypeScriptClassMember[] {
@@ -423,11 +395,10 @@ export function generateViewObjectModelMembers(
   const members = generateGetElementByDataTestId(
     baseMethodName,
     nativeRole,
-    formattedDataTestId,
-    alternateFormattedDataTestIds,
+    selector,
+    alternateSelectors,
     getterNameOverride,
     params,
-    selectorPatternKind,
   );
 
   if (targetPageObjectModelClass) {
@@ -436,37 +407,35 @@ export function generateViewObjectModelMembers(
       ...generateNavigationMethod({
         targetPageObjectModelClass,
         baseMethodName,
-        formattedDataTestId,
-        selectorPatternKind,
-        alternateFormattedDataTestIds,
+        selector,
+        alternateSelectors,
         params,
       }),
     ];
   }
 
   if (nativeRole === "select") {
-    return [...members, ...generateSelectMethod(baseMethodName, formattedDataTestId, params, selectorPatternKind)];
+    return [...members, ...generateSelectMethod(baseMethodName, selector, params)];
   }
   if (nativeRole === "vselect") {
-    return [...members, ...generateVSelectMethod(baseMethodName, formattedDataTestId, params, selectorPatternKind)];
+    return [...members, ...generateVSelectMethod(baseMethodName, selector, params)];
   }
   if (nativeRole === "input") {
-    return [...members, ...generateTypeMethod(baseMethodName, formattedDataTestId, params, selectorPatternKind)];
+    return [...members, ...generateTypeMethod(baseMethodName, selector, params)];
   }
   if (nativeRole === "radio") {
-    return [...members, ...generateRadioMethod(baseMethodName || "Radio", formattedDataTestId, params, selectorPatternKind)];
+    return [...members, ...generateRadioMethod(baseMethodName || "Radio", selector, params)];
   }
 
-  return [...members, ...generateClickMethod(baseMethodName, formattedDataTestId, alternateFormattedDataTestIds, params, selectorPatternKind)];
+  return [...members, ...generateClickMethod(baseMethodName, selector, alternateSelectors, params)];
 }
 
 export function generateViewObjectModelMethodContent(
   targetPageObjectModelClass: string | undefined,
   methodName: string,
   nativeRole: string,
-  selectorPatternKind: PomPatternKind,
-  formattedDataTestId: string,
-  alternateFormattedDataTestIds: string[] | undefined,
+  selector: PomStringPattern,
+  alternateSelectors: PomStringPattern[] | undefined,
   getterNameOverride: string | undefined,
   params: Record<string, string>,
 ) {
@@ -475,9 +444,8 @@ export function generateViewObjectModelMethodContent(
       targetPageObjectModelClass,
       methodName,
       nativeRole,
-      selectorPatternKind,
-      formattedDataTestId,
-      alternateFormattedDataTestIds,
+      selector,
+      alternateSelectors,
       getterNameOverride,
       params,
     ),

--- a/method-generation.ts
+++ b/method-generation.ts
@@ -17,6 +17,7 @@ import {
   ensurePomPatternParameters,
   getIndexedPomPatternVariable,
   isParameterizedPomPattern,
+  toTypeScriptPomPatternExpression,
   uniquePomStringPatterns,
   type PomStringPattern,
 } from "./pom-patterns";
@@ -76,12 +77,6 @@ function removeByKeySegment(value: string): string {
   return value.slice(0, idx) + value.slice(idx + "ByKey".length);
 }
 
-function testIdExpression(pattern: PomStringPattern): string {
-  return isParameterizedPomPattern(pattern.patternKind)
-    ? `\`${pattern.formatted}\``
-    : JSON.stringify(pattern.formatted);
-}
-
 function createAsyncMethod(
   name: string,
   parameters: OptionalKind<ParameterDeclarationStructure>[],
@@ -108,10 +103,10 @@ function generateClickMethod(
   const baseParameters = createParameters(selectorParams);
   const argsForForward = Object.keys(selectorParams).join(", ");
   const alternates = uniquePomStringPatterns(selector, alternateSelectors).slice(1);
-  const primaryTestIdExpr = testIdExpression(selector);
+  const primaryTestIdExpr = toTypeScriptPomPatternExpression(selector);
 
   if (alternates.length > 0) {
-    const candidatesExpr = [primaryTestIdExpr, ...alternates.map(id => testIdExpression(id))].join(", ");
+    const candidatesExpr = [primaryTestIdExpr, ...alternates.map(id => toTypeScriptPomPatternExpression(id))].join(", ");
     const clickMethod = createAsyncMethod(
       name,
       hasSelectorVariables
@@ -177,7 +172,7 @@ function generateRadioMethod(
   const name = `select${methodName}`;
   const selectorParams = ensurePomPatternParameters(params, [selector]);
   const parameters = createParameters(selectorParams);
-  const testIdExpr = testIdExpression(selector);
+  const testIdExpr = toTypeScriptPomPatternExpression(selector);
 
   return [
     createAsyncMethod(name, parameters, (writer) => {
@@ -193,7 +188,7 @@ function generateSelectMethod(
 ): TypeScriptClassMember[] {
   const name = `select${methodName}`;
   const selectorParams = ensurePomPatternParameters(params, [selector]);
-  const selectorExpr = `this.selectorForTestId(${testIdExpression(selector)})`;
+  const selectorExpr = `this.selectorForTestId(${toTypeScriptPomPatternExpression(selector)})`;
 
   return [
     createAsyncMethod(
@@ -221,7 +216,7 @@ function generateVSelectMethod(
       name,
       createParameters(selectorParams),
       (writer) => {
-        writer.writeLine(`await this.selectVSelectByTestId(${testIdExpression(selector)}, value, timeOut, annotationText);`);
+        writer.writeLine(`await this.selectVSelectByTestId(${toTypeScriptPomPatternExpression(selector)}, value, timeOut, annotationText);`);
       },
     ),
   ];
@@ -240,7 +235,7 @@ function generateTypeMethod(
       name,
       createParameters(selectorParams),
       (writer) => {
-        writer.writeLine(`await this.fillInputByTestId(${testIdExpression(selector)}, text, annotationText);`);
+        writer.writeLine(`await this.fillInputByTestId(${toTypeScriptPomPatternExpression(selector)}, text, annotationText);`);
       },
     ),
   ];
@@ -280,7 +275,7 @@ function generateGetElementByDataTestId(
       createClassGetter({
         name: keyedPropertyName,
         statements: [
-          `return this.keyedLocators((${indexedVariable}: ${keyType}) => this.locatorByTestId(${testIdExpression(selector)}));`,
+          `return this.keyedLocators((${indexedVariable}: ${keyType}) => this.locatorByTestId(${toTypeScriptPomPatternExpression(selector)}));`,
         ],
       }),
     ];
@@ -291,7 +286,7 @@ function generateGetElementByDataTestId(
   if (alternates.length > 0) {
     const all = [selector, ...alternates];
     const locatorExpr = all
-      .map(id => `this.locatorByTestId(${testIdExpression(id)})`)
+      .map(id => `this.locatorByTestId(${toTypeScriptPomPatternExpression(id)})`)
       .reduce((acc, next) => `${acc}.or(${next})`);
 
     return [
@@ -305,7 +300,7 @@ function generateGetElementByDataTestId(
   return [
     createClassGetter({
       name: finalPropertyName,
-      statements: [`return this.locatorByTestId(${testIdExpression(selector)});`],
+      statements: [`return this.locatorByTestId(${toTypeScriptPomPatternExpression(selector)});`],
     }),
   ];
 }
@@ -326,7 +321,7 @@ function generateNavigationMethod(args: {
   const selectorParams = ensurePomPatternParameters(params, [selector]);
   const parameters = createParameters(selectorParams);
   const alternates = uniquePomStringPatterns(selector, alternateSelectors).slice(1);
-  const candidatesExpr = [testIdExpression(selector), ...alternates.map(id => testIdExpression(id))].join(", ");
+  const candidatesExpr = [toTypeScriptPomPatternExpression(selector), ...alternates.map(id => toTypeScriptPomPatternExpression(id))].join(", ");
 
   if (alternates.length > 0) {
     return [
@@ -365,7 +360,7 @@ function generateNavigationMethod(args: {
       returnType: `Fluent<${target}>`,
       statements: (writer) => {
         writer.write("return this.fluent(async () => ").block(() => {
-          writer.writeLine(`await this.clickByTestId(${testIdExpression(selector)});`);
+          writer.writeLine(`await this.clickByTestId(${toTypeScriptPomPatternExpression(selector)});`);
           writer.writeLine(`return new ${target}(this.page);`);
         });
         writer.writeLine(");");

--- a/method-generation.ts
+++ b/method-generation.ts
@@ -13,6 +13,7 @@ import {
   type TypeScriptClassMember,
   type WriterFunction,
 } from "./typescript-codegen";
+import { inferPomPatternKindFromFormattedString, isParameterizedPomPattern, type PomPatternKind } from "./pom-patterns";
 
 function upperFirst(value: string): string {
   if (!value) {
@@ -90,8 +91,21 @@ function uniqueAlternates(primary: string, alternates: string[] | undefined): st
   return out;
 }
 
-function testIdExpression(formattedDataTestId: string): string {
-  return formattedDataTestId.includes("${") ? `\`${formattedDataTestId}\`` : JSON.stringify(formattedDataTestId);
+function testIdExpression(formattedDataTestId: string, patternKind?: PomPatternKind): string {
+  // Callers without structured metadata (currently alternate selector strings) only use this
+  // fallback to decide quote/backtick rendering. API shape comes from selectorPatternKind.
+  const needsTemplate = patternKind
+    ? isParameterizedPomPattern(patternKind)
+    : isParameterizedPomPattern(inferPomPatternKindFromFormattedString(formattedDataTestId));
+  return needsTemplate ? `\`${formattedDataTestId}\`` : JSON.stringify(formattedDataTestId);
+}
+
+function ensureSelectorParameters(params: Record<string, string>, selectorPatternKind: PomPatternKind): Record<string, string> {
+  if (!isParameterizedPomPattern(selectorPatternKind) || hasParam(params, "key")) {
+    return params;
+  }
+
+  return { key: "string", ...params };
 }
 
 function createAsyncMethod(
@@ -112,18 +126,21 @@ function generateClickMethod(
   formattedDataTestId: string,
   alternateFormattedDataTestIds: string[] | undefined,
   params: Record<string, string>,
+  selectorPatternKind: PomPatternKind,
 ): TypeScriptClassMember[] {
   const name = `click${methodName}`;
   const noWaitName = `${name}NoWait`;
-  const baseParameters = createParameters(params);
-  const argsForForward = Object.keys(params).join(", ");
+  const selectorParams = ensureSelectorParameters(params, selectorPatternKind);
+  const baseParameters = createParameters(selectorParams);
+  const argsForForward = Object.keys(selectorParams).join(", ");
   const alternates = uniqueAlternates(formattedDataTestId, alternateFormattedDataTestIds);
+  const primaryTestIdExpr = testIdExpression(formattedDataTestId, selectorPatternKind);
 
   if (alternates.length > 0) {
-    const candidatesExpr = [formattedDataTestId, ...alternates].map(testIdExpression).join(", ");
+    const candidatesExpr = [primaryTestIdExpr, ...alternates.map(id => testIdExpression(id))].join(", ");
     const clickMethod = createAsyncMethod(
       name,
-      hasParam(params, "key")
+      hasParam(selectorParams, "key")
         ? [...baseParameters, createInlineParameter("wait", { type: "boolean", initializer: "true" })]
         : [createInlineParameter("wait", { type: "boolean", initializer: "true" })],
       (writer) => {
@@ -148,7 +165,7 @@ function generateClickMethod(
     const noWaitArgs = argsForForward ? `${argsForForward}, false` : "false";
     const noWaitMethod = createAsyncMethod(
       noWaitName,
-      hasParam(params, "key") ? baseParameters : [],
+      hasParam(selectorParams, "key") ? baseParameters : [],
       (writer) => {
         writer.writeLine(`await this.${name}(${noWaitArgs});`);
       },
@@ -157,10 +174,10 @@ function generateClickMethod(
     return [clickMethod, noWaitMethod];
   }
 
-  if (hasParam(params, "key")) {
+  if (hasParam(selectorParams, "key")) {
     return [
       createAsyncMethod(name, [...baseParameters, createInlineParameter("wait", { type: "boolean", initializer: "true" })], (writer) => {
-        writer.writeLine(`await this.clickByTestId(\`${formattedDataTestId}\`, "", wait);`);
+        writer.writeLine(`await this.clickByTestId(${primaryTestIdExpr}, "", wait);`);
       }),
       createAsyncMethod(noWaitName, baseParameters, (writer) => {
         writer.writeLine(`await this.${name}(${argsForForward}, false);`);
@@ -170,7 +187,7 @@ function generateClickMethod(
 
   return [
     createAsyncMethod(name, [createInlineParameter("wait", { type: "boolean", initializer: "true" })], (writer) => {
-      writer.writeLine(`await this.clickByTestId("${formattedDataTestId}", "", wait);`);
+      writer.writeLine(`await this.clickByTestId(${primaryTestIdExpr}, "", wait);`);
     }),
     createAsyncMethod(noWaitName, [], (writer) => {
       writer.writeLine(`await this.${name}(false);`);
@@ -178,16 +195,16 @@ function generateClickMethod(
   ];
 }
 
-function generateRadioMethod(methodName: string, formattedDataTestId: string): TypeScriptClassMember[] {
+function generateRadioMethod(
+  methodName: string,
+  formattedDataTestId: string,
+  params: Record<string, string>,
+  selectorPatternKind: PomPatternKind,
+): TypeScriptClassMember[] {
   const name = `select${methodName}`;
-  const hasKey = formattedDataTestId.includes("${key}");
-  const parameters = hasKey
-    ? [
-        createInlineParameter("key", { type: "string" }),
-        createInlineParameter("annotationText", { type: "string", initializer: "\"\"" }),
-      ]
-    : [createInlineParameter("annotationText", { type: "string", initializer: "\"\"" })];
-  const testIdExpr = hasKey ? `\`${formattedDataTestId}\`` : `"${formattedDataTestId}"`;
+  const selectorParams = ensureSelectorParameters(params, selectorPatternKind);
+  const parameters = createParameters(selectorParams);
+  const testIdExpr = testIdExpression(formattedDataTestId, selectorPatternKind);
 
   return [
     createAsyncMethod(name, parameters, (writer) => {
@@ -196,20 +213,20 @@ function generateRadioMethod(methodName: string, formattedDataTestId: string): T
   ];
 }
 
-function generateSelectMethod(methodName: string, formattedDataTestId: string): TypeScriptClassMember[] {
+function generateSelectMethod(
+  methodName: string,
+  formattedDataTestId: string,
+  params: Record<string, string>,
+  selectorPatternKind: PomPatternKind,
+): TypeScriptClassMember[] {
   const name = `select${methodName}`;
-  const needsKey = formattedDataTestId.includes("${key}");
-  const selectorExpr = needsKey
-    ? `this.selectorForTestId(\`${formattedDataTestId}\`)`
-    : `this.selectorForTestId("${formattedDataTestId}")`;
+  const selectorParams = ensureSelectorParameters(params, selectorPatternKind);
+  const selectorExpr = `this.selectorForTestId(${testIdExpression(formattedDataTestId, selectorPatternKind)})`;
 
   return [
     createAsyncMethod(
       name,
-      [
-        createInlineParameter("value", { type: "string" }),
-        createInlineParameter("annotationText", { type: "string", initializer: "\"\"" }),
-      ],
+      createParameters(selectorParams),
       (writer) => {
         writer.writeLine(`const selector = ${selectorExpr};`);
         writer.writeLine("await this.animateCursorToElement(selector, false, 500, annotationText);");
@@ -219,36 +236,41 @@ function generateSelectMethod(methodName: string, formattedDataTestId: string): 
   ];
 }
 
-function generateVSelectMethod(methodName: string, formattedDataTestId: string): TypeScriptClassMember[] {
+function generateVSelectMethod(
+  methodName: string,
+  formattedDataTestId: string,
+  params: Record<string, string>,
+  selectorPatternKind: PomPatternKind,
+): TypeScriptClassMember[] {
   const name = `select${methodName}`;
+  const selectorParams = ensureSelectorParameters(params, selectorPatternKind);
 
   return [
     createAsyncMethod(
       name,
-      [
-        createInlineParameter("value", { type: "string" }),
-        createInlineParameter("timeOut", { type: "number", initializer: "500" }),
-        createInlineParameter("annotationText", { type: "string", initializer: "\"\"" }),
-      ],
+      createParameters(selectorParams),
       (writer) => {
-        writer.writeLine(`await this.selectVSelectByTestId("${formattedDataTestId}", value, timeOut, annotationText);`);
+        writer.writeLine(`await this.selectVSelectByTestId(${testIdExpression(formattedDataTestId, selectorPatternKind)}, value, timeOut, annotationText);`);
       },
     ),
   ];
 }
 
-function generateTypeMethod(methodName: string, formattedDataTestId: string): TypeScriptClassMember[] {
+function generateTypeMethod(
+  methodName: string,
+  formattedDataTestId: string,
+  params: Record<string, string>,
+  selectorPatternKind: PomPatternKind,
+): TypeScriptClassMember[] {
   const name = `type${methodName}`;
+  const selectorParams = ensureSelectorParameters(params, selectorPatternKind);
 
   return [
     createAsyncMethod(
       name,
-      [
-        createInlineParameter("text", { type: "string" }),
-        createInlineParameter("annotationText", { type: "string", initializer: "\"\"" }),
-      ],
+      createParameters(selectorParams),
       (writer) => {
-        writer.writeLine(`await this.fillInputByTestId("${formattedDataTestId}", text, annotationText);`);
+        writer.writeLine(`await this.fillInputByTestId(${testIdExpression(formattedDataTestId, selectorPatternKind)}, text, annotationText);`);
       },
     ),
   ];
@@ -272,22 +294,24 @@ function generateGetElementByDataTestId(
   alternateFormattedDataTestIds: string[] | undefined,
   getterNameOverride: string | undefined,
   params: Record<string, string>,
+  selectorPatternKind: PomPatternKind,
 ): TypeScriptClassMember[] {
   const roleSuffix = upperFirst(nativeRole || "Element");
   const baseName = upperFirst(methodName);
   const numericSuffix = baseName.startsWith(roleSuffix) ? baseName.slice(roleSuffix.length) : "";
   const hasRoleSuffix = baseName.endsWith(roleSuffix) || (baseName.startsWith(roleSuffix) && isAllDigits(numericSuffix));
   const propertyName = hasRoleSuffix ? `${baseName}` : `${baseName}${roleSuffix}`;
-  const needsKey = hasParam(params, "key") || formattedDataTestId.includes("${key}");
+  const selectorParams = ensureSelectorParameters(params, selectorPatternKind);
+  const needsKey = isParameterizedPomPattern(selectorPatternKind);
 
   if (needsKey) {
-    const keyType = params.key || "string";
+    const keyType = selectorParams.key || "string";
     const keyedPropertyName = getterNameOverride ?? removeByKeySegment(propertyName);
     return [
       createClassGetter({
         name: keyedPropertyName,
         statements: [
-          `return this.keyedLocators((key: ${keyType}) => this.locatorByTestId(\`${formattedDataTestId}\`));`,
+          `return this.keyedLocators((key: ${keyType}) => this.locatorByTestId(${testIdExpression(formattedDataTestId, selectorPatternKind)}));`,
         ],
       }),
     ];
@@ -321,18 +345,20 @@ function generateNavigationMethod(args: {
   targetPageObjectModelClass: string;
   baseMethodName: string;
   formattedDataTestId: string;
+  selectorPatternKind: PomPatternKind;
   alternateFormattedDataTestIds?: string[];
   params: Record<string, string>;
 }): TypeScriptClassMember[] {
-  const { targetPageObjectModelClass: target, baseMethodName, formattedDataTestId, alternateFormattedDataTestIds, params } = args;
+  const { targetPageObjectModelClass: target, baseMethodName, formattedDataTestId, selectorPatternKind, alternateFormattedDataTestIds, params } = args;
 
   const methodName = baseMethodName
     ? `goTo${upperFirst(baseMethodName)}`
     : `goTo${target.endsWith("Page") ? target.slice(0, -"Page".length) : target}`;
 
-  const parameters = createParameters(params);
+  const selectorParams = ensureSelectorParameters(params, selectorPatternKind);
+  const parameters = createParameters(selectorParams);
   const alternates = uniqueAlternates(formattedDataTestId, alternateFormattedDataTestIds);
-  const candidatesExpr = [formattedDataTestId, ...alternates].map(testIdExpression).join(", ");
+  const candidatesExpr = [testIdExpression(formattedDataTestId, selectorPatternKind), ...alternates.map(id => testIdExpression(id))].join(", ");
 
   if (alternates.length > 0) {
     return [
@@ -371,7 +397,7 @@ function generateNavigationMethod(args: {
       returnType: `Fluent<${target}>`,
       statements: (writer) => {
         writer.write("return this.fluent(async () => ").block(() => {
-          writer.writeLine(`await this.clickByTestId(\`${formattedDataTestId}\`);`);
+          writer.writeLine(`await this.clickByTestId(${testIdExpression(formattedDataTestId, selectorPatternKind)});`);
           writer.writeLine(`return new ${target}(this.page);`);
         });
         writer.writeLine(");");
@@ -384,6 +410,7 @@ export function generateViewObjectModelMembers(
   targetPageObjectModelClass: string | undefined,
   methodName: string,
   nativeRole: string,
+  selectorPatternKind: PomPatternKind,
   formattedDataTestId: string,
   alternateFormattedDataTestIds: string[] | undefined,
   getterNameOverride: string | undefined,
@@ -400,6 +427,7 @@ export function generateViewObjectModelMembers(
     alternateFormattedDataTestIds,
     getterNameOverride,
     params,
+    selectorPatternKind,
   );
 
   if (targetPageObjectModelClass) {
@@ -409,6 +437,7 @@ export function generateViewObjectModelMembers(
         targetPageObjectModelClass,
         baseMethodName,
         formattedDataTestId,
+        selectorPatternKind,
         alternateFormattedDataTestIds,
         params,
       }),
@@ -416,25 +445,26 @@ export function generateViewObjectModelMembers(
   }
 
   if (nativeRole === "select") {
-    return [...members, ...generateSelectMethod(baseMethodName, formattedDataTestId)];
+    return [...members, ...generateSelectMethod(baseMethodName, formattedDataTestId, params, selectorPatternKind)];
   }
   if (nativeRole === "vselect") {
-    return [...members, ...generateVSelectMethod(baseMethodName, formattedDataTestId)];
+    return [...members, ...generateVSelectMethod(baseMethodName, formattedDataTestId, params, selectorPatternKind)];
   }
   if (nativeRole === "input") {
-    return [...members, ...generateTypeMethod(baseMethodName, formattedDataTestId)];
+    return [...members, ...generateTypeMethod(baseMethodName, formattedDataTestId, params, selectorPatternKind)];
   }
   if (nativeRole === "radio") {
-    return [...members, ...generateRadioMethod(baseMethodName || "Radio", formattedDataTestId)];
+    return [...members, ...generateRadioMethod(baseMethodName || "Radio", formattedDataTestId, params, selectorPatternKind)];
   }
 
-  return [...members, ...generateClickMethod(baseMethodName, formattedDataTestId, alternateFormattedDataTestIds, params)];
+  return [...members, ...generateClickMethod(baseMethodName, formattedDataTestId, alternateFormattedDataTestIds, params, selectorPatternKind)];
 }
 
 export function generateViewObjectModelMethodContent(
   targetPageObjectModelClass: string | undefined,
   methodName: string,
   nativeRole: string,
+  selectorPatternKind: PomPatternKind,
   formattedDataTestId: string,
   alternateFormattedDataTestIds: string[] | undefined,
   getterNameOverride: string | undefined,
@@ -445,6 +475,7 @@ export function generateViewObjectModelMethodContent(
       targetPageObjectModelClass,
       methodName,
       nativeRole,
+      selectorPatternKind,
       formattedDataTestId,
       alternateFormattedDataTestIds,
       getterNameOverride,

--- a/method-generation.ts
+++ b/method-generation.ts
@@ -22,10 +22,6 @@ function upperFirst(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
-function hasParam(params: Record<string, string>, name: string) {
-  return Object.prototype.hasOwnProperty.call(params, name);
-}
-
 function splitTypeAndInitializer(typeExpression: string): { type: string; initializer?: string } {
   const trimmed = typeExpression.trim();
   const initializerIndex = trimmed.lastIndexOf("=");
@@ -81,11 +77,39 @@ function testIdExpression(pattern: PomStringPattern): string {
 }
 
 function ensureSelectorParameters(params: Record<string, string>, selector: PomStringPattern): Record<string, string> {
-  if (!isParameterizedPomPattern(selector.patternKind) || hasParam(params, "key")) {
+  if (!isParameterizedPomPattern(selector.patternKind) || selector.templateVariables.length === 0) {
     return params;
   }
 
-  return { key: "string", ...params };
+  const orderedEntries: [string, string][] = [];
+  const seen = new Set<string>();
+  for (const variableName of selector.templateVariables) {
+    seen.add(variableName);
+    orderedEntries.push([variableName, params[variableName] ?? "string"]);
+  }
+  for (const [name, typeExpression] of Object.entries(params)) {
+    if (seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    orderedEntries.push([name, typeExpression]);
+  }
+  return Object.fromEntries(orderedEntries);
+}
+
+function getIndexedSelectorVariable(selector: PomStringPattern): string | null {
+  if (!isParameterizedPomPattern(selector.patternKind)) {
+    return null;
+  }
+
+  if (selector.templateVariables.length !== 1) {
+    throw new Error(
+      `[vue-pom-generator] Parameterized locator getters require exactly one template variable; `
+      + `got ${selector.templateVariables.length} in ${JSON.stringify(selector.formatted)}.`,
+    );
+  }
+
+  return selector.templateVariables[0];
 }
 
 function createAsyncMethod(
@@ -110,6 +134,7 @@ function generateClickMethod(
   const name = `click${methodName}`;
   const noWaitName = `${name}NoWait`;
   const selectorParams = ensureSelectorParameters(params, selector);
+  const hasSelectorVariables = selector.templateVariables.length > 0;
   const baseParameters = createParameters(selectorParams);
   const argsForForward = Object.keys(selectorParams).join(", ");
   const alternates = uniquePomStringPatterns(selector, alternateSelectors).slice(1);
@@ -119,7 +144,7 @@ function generateClickMethod(
     const candidatesExpr = [primaryTestIdExpr, ...alternates.map(id => testIdExpression(id))].join(", ");
     const clickMethod = createAsyncMethod(
       name,
-      hasParam(selectorParams, "key")
+      hasSelectorVariables
         ? [...baseParameters, createInlineParameter("wait", { type: "boolean", initializer: "true" })]
         : [createInlineParameter("wait", { type: "boolean", initializer: "true" })],
       (writer) => {
@@ -144,7 +169,7 @@ function generateClickMethod(
     const noWaitArgs = argsForForward ? `${argsForForward}, false` : "false";
     const noWaitMethod = createAsyncMethod(
       noWaitName,
-      hasParam(selectorParams, "key") ? baseParameters : [],
+      hasSelectorVariables ? baseParameters : [],
       (writer) => {
         writer.writeLine(`await this.${name}(${noWaitArgs});`);
       },
@@ -153,7 +178,7 @@ function generateClickMethod(
     return [clickMethod, noWaitMethod];
   }
 
-  if (hasParam(selectorParams, "key")) {
+  if (hasSelectorVariables) {
     return [
       createAsyncMethod(name, [...baseParameters, createInlineParameter("wait", { type: "boolean", initializer: "true" })], (writer) => {
         writer.writeLine(`await this.clickByTestId(${primaryTestIdExpr}, "", wait);`);
@@ -276,16 +301,16 @@ function generateGetElementByDataTestId(
   const hasRoleSuffix = baseName.endsWith(roleSuffix) || (baseName.startsWith(roleSuffix) && isAllDigits(numericSuffix));
   const propertyName = hasRoleSuffix ? `${baseName}` : `${baseName}${roleSuffix}`;
   const selectorParams = ensureSelectorParameters(params, selector);
-  const needsKey = isParameterizedPomPattern(selector.patternKind);
+  const indexedVariable = getIndexedSelectorVariable(selector);
 
-  if (needsKey) {
-    const keyType = selectorParams.key || "string";
+  if (indexedVariable) {
+    const keyType = selectorParams[indexedVariable] || "string";
     const keyedPropertyName = getterNameOverride ?? removeByKeySegment(propertyName);
     return [
       createClassGetter({
         name: keyedPropertyName,
         statements: [
-          `return this.keyedLocators((key: ${keyType}) => this.locatorByTestId(${testIdExpression(selector)}));`,
+          `return this.keyedLocators((${indexedVariable}: ${keyType}) => this.locatorByTestId(${testIdExpression(selector)}));`,
         ],
       }),
     ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@immense/vue-pom-generator",
-  "version": "0.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@immense/vue-pom-generator",
-      "version": "0.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "ts-morph": "^27.0.2"
@@ -16,7 +16,7 @@
         "@babel/types": "^7.28.5",
         "@floating-ui/core": "^1.7.5",
         "@github/copilot-sdk": "^0.1.8",
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "1.59.1",
         "@types/jsdom": "^27.0.0",
         "@types/node": "^24.1.0",
         "@vitest/coverage-v8": "^4.0.16",
@@ -24,6 +24,7 @@
         "eslint": "^9.27.0",
         "jsdom": "^27.4.0",
         "knip": "^5.82.1",
+        "playwright": "1.59.1",
         "simple-git-hooks": "^2.13.1",
         "typescript": "^5.9.2",
         "vite": "^7.3.1",
@@ -37,11 +38,8 @@
         "@vue/compiler-core": ">=3.5",
         "@vue/compiler-dom": ">=3.5",
         "@vue/compiler-sfc": ">=3.5",
-        "@vue/shared": ">=3.5",
         "eslint": ">=9",
-        "vite": "^5 || ^6 || ^7",
-        "vitest": "^4",
-        "vue": ">=3"
+        "vite": "^5 || ^6 || ^7"
       },
       "peerDependenciesMeta": {
         "eslint": {
@@ -1810,13 +1808,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
-      "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.1"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -6595,13 +6593,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
-      "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.1"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -6614,9 +6612,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
-      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@vue/compiler-dom": ">=3.5",
     "@vue/compiler-sfc": ">=3.5",
     "eslint": ">=9",
+    "playwright": "1.59.1",
     "vite": "^5 || ^6 || ^7"
   },
   "peerDependenciesMeta": {
@@ -72,11 +73,11 @@
     "ts-morph": "^27.0.2"
   },
   "devDependencies": {
-    "@babel/types": "^7.28.5",
     "@antfu/eslint-config": "5.3.0",
-    "@github/copilot-sdk": "^0.1.8",
+    "@babel/types": "^7.28.5",
     "@floating-ui/core": "^1.7.5",
-    "@playwright/test": "^1.57.0",
+    "@github/copilot-sdk": "^0.1.8",
+    "@playwright/test": "1.59.1",
     "@types/jsdom": "^27.0.0",
     "@types/node": "^24.1.0",
     "@vitest/coverage-v8": "^4.0.16",
@@ -84,6 +85,7 @@
     "eslint": "^9.27.0",
     "jsdom": "^27.4.0",
     "knip": "^5.82.1",
+    "playwright": "1.59.1",
     "simple-git-hooks": "^2.13.1",
     "typescript": "^5.9.2",
     "vite": "^7.3.1",

--- a/plugin/create-vue-pom-generator-plugins.ts
+++ b/plugin/create-vue-pom-generator-plugins.ts
@@ -355,7 +355,6 @@ export function createVuePomGeneratorPlugins(options: PomGeneratorPluginOptions 
   const excludedComponents = injection.excludeComponents ?? [];
   const testIdAttribute = (injection.attribute ?? "data-testid").trim() || "data-testid";
   const existingIdBehavior: ExistingIdBehavior = injection.existingIdBehavior ?? "preserve";
-  const clickInstrumentation = injection.clickInstrumentation ?? true;
 
   const outDir = (generationOptions?.outDir ?? "tests/playwright/__generated__").trim();
   const emitLanguages: Array<"ts" | "csharp"> = (generationOptions?.emit && generationOptions.emit.length)
@@ -480,7 +479,6 @@ export function createVuePomGeneratorPlugins(options: PomGeneratorPluginOptions 
     vueOptions,
     existingIdBehavior,
     nameCollisionBehavior,
-    clickInstrumentation,
     nativeWrappers,
     elementMetadata,
     semanticNameMap,
@@ -513,7 +511,6 @@ export function createVuePomGeneratorPlugins(options: PomGeneratorPluginOptions 
     nameCollisionBehavior,
     missingSemanticNameBehavior,
     existingIdBehavior,
-    clickInstrumentation,
     outDir,
     emitLanguages,
     typescriptOutputStructure,

--- a/plugin/create-vue-pom-generator-plugins.ts
+++ b/plugin/create-vue-pom-generator-plugins.ts
@@ -7,13 +7,15 @@ import type { PluginOption, ResolvedConfig } from "vite";
 import type { VuePomGeneratorLogger, VuePomGeneratorVerbosity } from "./logger";
 import { createLogger } from "./logger";
 import { loadNuxtProjectDiscovery } from "./nuxt-discovery";
+import { resolveGenerationSupportOptions } from "./resolved-generation-options";
+import { applyNuxtDiscoveryToInjectionOptions, resolveInjectionSupportOptions } from "./resolved-injection-options";
 import { createSupportPlugins } from "./support-plugins";
 import { createTestIdsVirtualModulesPlugin } from "./support/virtual-modules";
-import type { ErrorBehavior, ErrorBehaviorOptions, ExistingIdBehavior, MissingSemanticNameBehavior, PlaywrightOutputStructure, PomGeneratorPluginOptions, PomNameCollisionBehavior, RouterModuleShimDefinition, VuePluginOwnership, VuePomGeneratorPluginOptions } from "./types";
+import type { PomGeneratorPluginOptions, RouterModuleShimDefinition, VuePluginOwnership, VuePomGeneratorPluginOptions } from "./types";
 import { createVuePluginWithTestIds } from "./vue-plugin";
 
 import type { ElementMetadata } from "../metadata-collector";
-import type { IComponentDependencies, NativeWrappersMap } from "../utils";
+import type { IComponentDependencies } from "../utils";
 
 const nuxtConfigMarker = Symbol.for("@immense/vue-pom-generator.nuxt");
 const nuxtConfigFileNames = [
@@ -61,46 +63,6 @@ function assertOneOf<T extends string>(value: T | undefined, allowed: readonly T
     return;
   }
   throw new TypeError(`${name} must be one of: ${allowed.join(", ")}.`);
-}
-
-function assertErrorBehavior(
-  value: ErrorBehavior | undefined,
-  name: string,
-): asserts value is ErrorBehavior {
-  if (!value) {
-    return;
-  }
-
-  if (value === "ignore" || value === "error") {
-    return;
-  }
-
-  if (typeof value !== "object" || Array.isArray(value)) {
-    throw new TypeError(`${name} must be "ignore", "error", or an object.`);
-  }
-
-  const supportedKeys = new Set<keyof ErrorBehaviorOptions>(["missingSemanticNameBehavior"]);
-  for (const key of Object.keys(value)) {
-    if (!supportedKeys.has(key as keyof ErrorBehaviorOptions)) {
-      throw new TypeError(`${name} contains unsupported key "${key}".`);
-    }
-  }
-
-  assertOneOf(value.missingSemanticNameBehavior, ["ignore", "error"], `${name}.missingSemanticNameBehavior`);
-}
-
-function resolveMissingSemanticNameBehavior(
-  value: ErrorBehavior | undefined,
-): MissingSemanticNameBehavior {
-  if (!value) {
-    return "error";
-  }
-
-  if (value === "ignore" || value === "error") {
-    return value;
-  }
-
-  return value.missingSemanticNameBehavior ?? "error";
 }
 
 function readPackageJson(projectRoot: string): Record<string, unknown> | null {
@@ -273,7 +235,7 @@ function applyTemplateCompilerOptionsToResolvedVuePlugin(
       );
     }
 
-    throw new Error("[vue-pom-generator] Nuxt mode requires the resolved Vite Vue plugin, but none was found.");
+    throw new Error("[vue-pom-generator] Nuxt bridge could not find vite:vue plugin to patch.");
   }
 
   const currentOptions = viteVuePlugin.api.options ?? {};
@@ -345,22 +307,23 @@ export function createVuePomGeneratorPlugins(options: PomGeneratorPluginOptions 
   const verbosity: VuePomGeneratorVerbosity = options.logging?.verbosity ?? "warn";
 
   const vueOptions = options.vueOptions;
-
-  const legacyVueOptions = options as VuePomGeneratorPluginOptions;
-  const pageDirsRef = { current: (!isNuxt ? [legacyVueOptions.injection?.viewsDir ?? "src/views"] : ["app/pages"]) };
-  const componentDirsRef = { current: (!isNuxt ? (legacyVueOptions.injection?.componentDirs ?? ["src/components"]) : ["app/components"]) };
-  const layoutDirsRef = { current: (!isNuxt ? (legacyVueOptions.injection?.layoutDirs ?? ["src/layouts"]) : ["app/layouts"]) };
-  const wrapperSearchRootsRef = { current: (!isNuxt ? (legacyVueOptions.injection?.wrapperSearchRoots ?? []) : []) };
-  const nativeWrappers = (injection.nativeWrappers ?? {}) as NativeWrappersMap;
-  const excludedComponents = injection.excludeComponents ?? [];
-  const testIdAttribute = (injection.attribute ?? "data-testid").trim() || "data-testid";
-  const existingIdBehavior: ExistingIdBehavior = injection.existingIdBehavior ?? "preserve";
-
-  const outDir = (generationOptions?.outDir ?? "tests/playwright/__generated__").trim();
-  const emitLanguages: Array<"ts" | "csharp"> = (generationOptions?.emit && generationOptions.emit.length)
-    ? generationOptions.emit
-    : ["ts"];
-  const nameCollisionBehavior: PomNameCollisionBehavior = generationOptions?.nameCollisionBehavior ?? "suffix";
+  const resolvedInjectionOptionsRef = {
+    current: resolveInjectionSupportOptions({
+      isNuxt,
+      viewsDir: injection.viewsDir,
+      componentDirs: injection.componentDirs,
+      layoutDirs: injection.layoutDirs,
+      wrapperSearchRoots: injection.wrapperSearchRoots,
+      nativeWrappers: injection.nativeWrappers,
+      excludedComponents: injection.excludeComponents,
+      existingIdBehavior: injection.existingIdBehavior,
+      testIdAttribute: injection.attribute,
+    }),
+  };
+  const resolvedInjectionOptions = resolvedInjectionOptionsRef.current;
+  const nativeWrappers = resolvedInjectionOptions.nativeWrappers;
+  const excludedComponents = resolvedInjectionOptions.excludedComponents;
+  const testIdAttribute = resolvedInjectionOptions.testIdAttribute;
   const routerEntry = !isNuxt ? vueGenerationOptions?.router?.entry : undefined;
   const routerType = isNuxt ? "nuxt" : (vueGenerationOptions?.router?.type ?? "vue-router");
   const routerModuleShims = !isNuxt ? vueGenerationOptions?.router?.moduleShims : undefined;
@@ -369,29 +332,45 @@ export function createVuePomGeneratorPlugins(options: PomGeneratorPluginOptions 
   }
   const vuePluginOwnership: VuePluginOwnership = isNuxt ? "external" : (options.vuePluginOwnership ?? "internal");
   const usesExternalVuePlugin = vuePluginOwnership === "external";
-  const csharp = generationOptions?.csharp;
-  const errorBehavior = options.errorBehavior;
-  const missingSemanticNameBehavior = resolveMissingSemanticNameBehavior(errorBehavior);
-  const typescriptOutputStructure: PlaywrightOutputStructure = generationOptions?.playwright?.outputStructure ?? "aggregated";
   const generateFixtures = generationOptions?.playwright?.fixtures;
   const customPoms = generationOptions?.playwright?.customPoms;
 
   const resolvedCustomPomAttachments = customPoms?.attachments ?? [];
-  const resolvedCustomPomDir = customPoms?.dir ?? "tests/playwright/pom/custom";
   const resolvedCustomPomImportAliases = customPoms?.importAliases;
-  const resolvedCustomPomImportCollisionBehavior = customPoms?.importNameCollisionBehavior ?? "error";
+  const requireCustomPomDir = customPoms?.dir !== undefined
+    || resolvedCustomPomAttachments.length > 0
+    || Object.keys(resolvedCustomPomImportAliases ?? {}).length > 0;
+  const resolvedGenerationOptions = resolveGenerationSupportOptions({
+    outDir: generationOptions?.outDir,
+    emitLanguages: generationOptions?.emit,
+    typescriptOutputStructure: generationOptions?.playwright?.outputStructure,
+    csharp: generationOptions?.csharp,
+    generateFixtures,
+    customPomAttachments: resolvedCustomPomAttachments,
+    customPomDir: customPoms?.dir,
+    requireCustomPomDir,
+    customPomImportAliases: resolvedCustomPomImportAliases,
+    customPomImportNameCollisionBehavior: customPoms?.importNameCollisionBehavior,
+    nameCollisionBehavior: generationOptions?.nameCollisionBehavior,
+    existingIdBehavior: resolvedInjectionOptions.existingIdBehavior,
+    testIdAttribute,
+    routerAwarePoms: (typeof routerEntry === "string" && routerEntry.trim().length > 0) || routerType === "nuxt",
+    routerEntry,
+    routerType,
+    routerModuleShims,
+  });
 
   const basePageClassPathOverride = generationOptions?.basePageClassPath;
-  const getPageDirs = () => pageDirsRef.current;
+  const getPageDirs = () => resolvedInjectionOptionsRef.current.pageDirs;
   const getViewsDir = () => getPageDirs()[0] ?? "src/views";
-  const getComponentDirs = () => componentDirsRef.current;
-  const getLayoutDirs = () => layoutDirsRef.current;
+  const getComponentDirs = () => resolvedInjectionOptionsRef.current.componentDirs;
+  const getLayoutDirs = () => resolvedInjectionOptionsRef.current.layoutDirs;
   const getSourceDirs = () => Array.from(new Set([
     ...getPageDirs(),
     ...getComponentDirs(),
     ...getLayoutDirs(),
   ]));
-  const getWrapperSearchRoots = () => wrapperSearchRootsRef.current;
+  const getWrapperSearchRoots = () => resolvedInjectionOptionsRef.current.wrapperSearchRoots;
   const sharedStateKey = JSON.stringify({
     cwd: process.cwd(),
     mode: isNuxt ? "nuxt" : "vue",
@@ -399,9 +378,9 @@ export function createVuePomGeneratorPlugins(options: PomGeneratorPluginOptions 
     componentDirs: isNuxt ? null : getComponentDirs(),
     layoutDirs: isNuxt ? null : getLayoutDirs(),
     wrapperSearchRoots: isNuxt ? null : getWrapperSearchRoots(),
-    outDir,
+    outDir: resolvedGenerationOptions.outDir,
     testIdAttribute,
-    routerType,
+    routerType: resolvedGenerationOptions.routerType,
     vuePluginOwnership,
   });
   const sharedState = getSharedGeneratorState(sharedStateKey);
@@ -427,12 +406,10 @@ export function createVuePomGeneratorPlugins(options: PomGeneratorPluginOptions 
       if (isNuxt) {
         const nuxtDiscovery = await loadNuxtProjectDiscovery(process.cwd());
         projectRootRef.current = nuxtDiscovery.rootDir;
-        pageDirsRef.current = nuxtDiscovery.pageDirs.length
-          ? nuxtDiscovery.pageDirs
-          : [path.resolve(nuxtDiscovery.srcDir, "pages")];
-        componentDirsRef.current = nuxtDiscovery.componentDirs;
-        layoutDirsRef.current = nuxtDiscovery.layoutDirs;
-        wrapperSearchRootsRef.current = nuxtDiscovery.wrapperSearchRoots;
+        resolvedInjectionOptionsRef.current = applyNuxtDiscoveryToInjectionOptions(
+          resolvedInjectionOptionsRef.current,
+          nuxtDiscovery,
+        );
       }
 
       // Fail-fast validation.
@@ -441,15 +418,13 @@ export function createVuePomGeneratorPlugins(options: PomGeneratorPluginOptions 
       assertNonEmptyStringArray(getComponentDirs(), "[vue-pom-generator] injection.componentDirs");
       assertNonEmptyStringArray(getLayoutDirs(), "[vue-pom-generator] injection.layoutDirs");
       assertNonEmptyStringArray(getWrapperSearchRoots(), "[vue-pom-generator] injection.wrapperSearchRoots");
-      assertErrorBehavior(errorBehavior, "[vue-pom-generator] errorBehavior");
-
       if (generationEnabled) {
-        assertNonEmptyString(outDir, "[vue-pom-generator] generation.outDir");
-        assertOneOf(typescriptOutputStructure, ["aggregated", "split"], "[vue-pom-generator] generation.playwright.outputStructure");
-        assertRouterModuleShims(routerModuleShims, "[vue-pom-generator] generation.router.moduleShims");
+        assertNonEmptyString(resolvedGenerationOptions.outDir, "[vue-pom-generator] generation.outDir");
+        assertOneOf(resolvedGenerationOptions.typescriptOutputStructure, ["aggregated", "split"], "[vue-pom-generator] generation.playwright.outputStructure");
+        assertRouterModuleShims(resolvedGenerationOptions.routerModuleShims, "[vue-pom-generator] generation.router.moduleShims");
 
-        if (!isNuxt && vueGenerationOptions?.router && routerType === "vue-router") {
-          assertNonEmptyString(routerEntry, "[vue-pom-generator] generation.router.entry");
+        if (!isNuxt && vueGenerationOptions?.router && resolvedGenerationOptions.routerType === "vue-router") {
+          assertNonEmptyString(resolvedGenerationOptions.routerEntry, "[vue-pom-generator] generation.router.entry");
         }
       }
 
@@ -477,8 +452,8 @@ export function createVuePomGeneratorPlugins(options: PomGeneratorPluginOptions 
 
   const { metadataCollectorPlugin, internalVuePlugin, templateCompilerOptions } = createVuePluginWithTestIds({
     vueOptions,
-    existingIdBehavior,
-    nameCollisionBehavior,
+    existingIdBehavior: resolvedGenerationOptions.existingIdBehavior,
+    nameCollisionBehavior: resolvedGenerationOptions.nameCollisionBehavior,
     nativeWrappers,
     elementMetadata,
     semanticNameMap,
@@ -494,8 +469,6 @@ export function createVuePomGeneratorPlugins(options: PomGeneratorPluginOptions 
   });
   templateCompilerOptionsForResolvedPlugin = templateCompilerOptions;
 
-  const routerAwarePoms = (typeof routerEntry === "string" && routerEntry.trim().length > 0) || routerType === "nuxt";
-
   const supportPlugins = createSupportPlugins({
     componentTestIds,
     componentHierarchyMap,
@@ -508,26 +481,10 @@ export function createVuePomGeneratorPlugins(options: PomGeneratorPluginOptions 
     getViewsDir,
     getSourceDirs,
     getWrapperSearchRoots: getWrapperSearchRootsAbs,
-    nameCollisionBehavior,
-    missingSemanticNameBehavior,
-    existingIdBehavior,
-    outDir,
-    emitLanguages,
-    typescriptOutputStructure,
-    csharp,
-    routerAwarePoms,
-    routerEntry,
-    generateFixtures,
+    generation: resolvedGenerationOptions,
     projectRootRef,
     basePageClassPath: basePageClassPathOverride,
-    customPomAttachments: resolvedCustomPomAttachments,
-    customPomDir: resolvedCustomPomDir,
-    customPomImportAliases: resolvedCustomPomImportAliases,
-    customPomImportNameCollisionBehavior: resolvedCustomPomImportCollisionBehavior,
-    testIdAttribute,
     loggerRef,
-    routerType,
-    routerModuleShims,
   });
 
   if (isNuxt) {

--- a/plugin/create-vue-pom-generator-plugins.ts
+++ b/plugin/create-vue-pom-generator-plugins.ts
@@ -355,6 +355,7 @@ export function createVuePomGeneratorPlugins(options: PomGeneratorPluginOptions 
   const excludedComponents = injection.excludeComponents ?? [];
   const testIdAttribute = (injection.attribute ?? "data-testid").trim() || "data-testid";
   const existingIdBehavior: ExistingIdBehavior = injection.existingIdBehavior ?? "preserve";
+  const clickInstrumentation = injection.clickInstrumentation ?? true;
 
   const outDir = (generationOptions?.outDir ?? "tests/playwright/__generated__").trim();
   const emitLanguages: Array<"ts" | "csharp"> = (generationOptions?.emit && generationOptions.emit.length)
@@ -479,6 +480,7 @@ export function createVuePomGeneratorPlugins(options: PomGeneratorPluginOptions 
     vueOptions,
     existingIdBehavior,
     nameCollisionBehavior,
+    clickInstrumentation,
     nativeWrappers,
     elementMetadata,
     semanticNameMap,
@@ -511,6 +513,7 @@ export function createVuePomGeneratorPlugins(options: PomGeneratorPluginOptions 
     nameCollisionBehavior,
     missingSemanticNameBehavior,
     existingIdBehavior,
+    clickInstrumentation,
     outDir,
     emitLanguages,
     typescriptOutputStructure,

--- a/plugin/resolved-generation-options.ts
+++ b/plugin/resolved-generation-options.ts
@@ -1,0 +1,60 @@
+import type {
+  ExistingIdBehavior,
+  PlaywrightOutputStructure,
+  PomNameCollisionBehavior,
+  RouterModuleShimDefinition,
+} from "./types";
+
+export interface ResolvedCustomPomAttachmentConfig {
+  className: string;
+  propertyName: string;
+  attachWhenUsesComponents: string[];
+  attachTo?: "views" | "components" | "both" | "pagesAndComponents";
+  flatten?: boolean;
+}
+
+export interface ResolvedGenerationSupportOptions {
+  outDir: string;
+  emitLanguages: Array<"ts" | "csharp">;
+  typescriptOutputStructure: PlaywrightOutputStructure;
+  csharp?: {
+    namespace?: string;
+  };
+  generateFixtures?: boolean | string | { outDir?: string };
+  customPomAttachments: ResolvedCustomPomAttachmentConfig[];
+  customPomDir: string;
+  requireCustomPomDir: boolean;
+  customPomImportAliases?: Record<string, string>;
+  customPomImportNameCollisionBehavior: "error" | "alias";
+  nameCollisionBehavior: PomNameCollisionBehavior;
+  existingIdBehavior: ExistingIdBehavior;
+  testIdAttribute: string;
+  routerAwarePoms: boolean;
+  routerEntry?: string;
+  routerType?: "vue-router" | "nuxt";
+  routerModuleShims?: Record<string, RouterModuleShimDefinition>;
+}
+
+export function resolveGenerationSupportOptions(
+  options: Partial<ResolvedGenerationSupportOptions>,
+): ResolvedGenerationSupportOptions {
+  return {
+    outDir: (options.outDir ?? "tests/playwright/__generated__").trim(),
+    emitLanguages: options.emitLanguages?.length ? options.emitLanguages : ["ts"],
+    typescriptOutputStructure: options.typescriptOutputStructure ?? "aggregated",
+    csharp: options.csharp,
+    generateFixtures: options.generateFixtures,
+    customPomAttachments: options.customPomAttachments ?? [],
+    customPomDir: options.customPomDir ?? "tests/playwright/pom/custom",
+    requireCustomPomDir: options.requireCustomPomDir ?? false,
+    customPomImportAliases: options.customPomImportAliases,
+    customPomImportNameCollisionBehavior: options.customPomImportNameCollisionBehavior ?? "error",
+    nameCollisionBehavior: options.nameCollisionBehavior ?? "error",
+    existingIdBehavior: options.existingIdBehavior ?? "error",
+    testIdAttribute: (options.testIdAttribute ?? "data-testid").trim() || "data-testid",
+    routerAwarePoms: options.routerAwarePoms ?? false,
+    routerEntry: options.routerEntry,
+    routerType: options.routerType ?? "vue-router",
+    routerModuleShims: options.routerModuleShims,
+  };
+}

--- a/plugin/resolved-injection-options.ts
+++ b/plugin/resolved-injection-options.ts
@@ -1,0 +1,60 @@
+import path from "node:path";
+
+import type { NativeWrappersMap } from "../utils";
+import type { NuxtResolvedDiscovery } from "./nuxt-discovery";
+import type { ExistingIdBehavior } from "./types";
+
+export interface ResolvedInjectionSupportOptions {
+  pageDirs: string[];
+  componentDirs: string[];
+  layoutDirs: string[];
+  wrapperSearchRoots: string[];
+  nativeWrappers: NativeWrappersMap;
+  excludedComponents: string[];
+  existingIdBehavior: ExistingIdBehavior;
+  testIdAttribute: string;
+}
+
+export interface ResolveInjectionSupportOptionsInput {
+  isNuxt?: boolean;
+  viewsDir?: string;
+  componentDirs?: string[];
+  layoutDirs?: string[];
+  wrapperSearchRoots?: string[];
+  nativeWrappers?: NativeWrappersMap;
+  excludedComponents?: string[];
+  existingIdBehavior?: ExistingIdBehavior;
+  testIdAttribute?: string;
+}
+
+export function resolveInjectionSupportOptions(
+  options: ResolveInjectionSupportOptionsInput,
+): ResolvedInjectionSupportOptions {
+  const isNuxt = options.isNuxt ?? false;
+
+  return {
+    pageDirs: isNuxt ? ["app/pages"] : [options.viewsDir ?? "src/views"],
+    componentDirs: isNuxt ? ["app/components"] : (options.componentDirs ?? ["src/components"]),
+    layoutDirs: isNuxt ? ["app/layouts"] : (options.layoutDirs ?? ["src/layouts"]),
+    wrapperSearchRoots: isNuxt ? [] : (options.wrapperSearchRoots ?? []),
+    nativeWrappers: options.nativeWrappers ?? {},
+    excludedComponents: options.excludedComponents ?? [],
+    existingIdBehavior: options.existingIdBehavior ?? "error",
+    testIdAttribute: (options.testIdAttribute ?? "data-testid").trim() || "data-testid",
+  };
+}
+
+export function applyNuxtDiscoveryToInjectionOptions(
+  options: ResolvedInjectionSupportOptions,
+  discovery: NuxtResolvedDiscovery,
+): ResolvedInjectionSupportOptions {
+  return {
+    ...options,
+    pageDirs: discovery.pageDirs.length
+      ? discovery.pageDirs
+      : [path.resolve(discovery.srcDir, "pages")],
+    componentDirs: discovery.componentDirs,
+    layoutDirs: discovery.layoutDirs,
+    wrapperSearchRoots: discovery.wrapperSearchRoots,
+  };
+}

--- a/plugin/support-plugins.ts
+++ b/plugin/support-plugins.ts
@@ -4,7 +4,7 @@ import type { PluginOption } from "vite";
 
 import type { IComponentDependencies, NativeWrappersMap } from "../utils";
 import type { VuePomGeneratorLogger } from "./logger";
-import type { PlaywrightOutputStructure, PomNameCollisionBehavior, RouterModuleShimDefinition } from "./types";
+import type { ResolvedGenerationSupportOptions } from "./resolved-generation-options";
 import { createBuildProcessorPlugin } from "./support/build-plugin";
 import { createDevProcessorPlugin } from "./support/dev-plugin";
 import { createTestIdsVirtualModulesPlugin } from "./support/virtual-modules";
@@ -21,37 +21,9 @@ interface SupportFactoryOptions {
   getViewsDir: () => string;
   getSourceDirs: () => string[];
   getWrapperSearchRoots: () => string[];
-  nameCollisionBehavior?: PomNameCollisionBehavior;
-  missingSemanticNameBehavior?: "ignore" | "error";
-  /** How to handle existing data-testid attributes in the source. */
-  existingIdBehavior?: "preserve" | "overwrite" | "error";
-
-  /** Output directory for generated files (POMs + optional fixtures). */
-  outDir?: string;
-
-  /** Languages to emit POMs for. */
-  emitLanguages?: Array<"ts" | "csharp">;
-  typescriptOutputStructure?: PlaywrightOutputStructure;
-
-  csharp?: {
-    namespace?: string;
-  };
-
-  routerAwarePoms: boolean;
-  routerEntry?: string;
-  routerType?: "vue-router" | "nuxt";
-  routerModuleShims?: Record<string, RouterModuleShimDefinition>;
-
-  /** Generate Playwright fixtures alongside generated POMs. */
-  generateFixtures?: boolean | string | { outDir?: string };
-  customPomAttachments?: Array<{ className: string; propertyName: string; attachWhenUsesComponents: string[]; attachTo?: "views" | "components" | "both" | "pagesAndComponents"; flatten?: boolean }>;
+  generation: ResolvedGenerationSupportOptions;
   projectRootRef: { current: string };
   basePageClassPath?: string;
-  customPomDir?: string;
-  customPomImportAliases?: Record<string, string>;
-  customPomImportNameCollisionBehavior?: "error" | "alias";
-  testIdAttribute: string;
-
   loggerRef: { current: VuePomGeneratorLogger };
 }
 
@@ -68,27 +40,30 @@ export function createSupportPlugins(options: SupportFactoryOptions): PluginOpti
     getViewsDir,
     getSourceDirs,
     getWrapperSearchRoots,
-    nameCollisionBehavior = "suffix",
-    missingSemanticNameBehavior = "error",
-    existingIdBehavior,
+    generation,
+    projectRootRef,
+    basePageClassPath: basePageClassPathOverride,
+    loggerRef,
+  } = options;
+  const {
     outDir,
     emitLanguages,
     typescriptOutputStructure,
     csharp,
+    generateFixtures,
+    customPomAttachments,
+    customPomDir,
+    requireCustomPomDir,
+    customPomImportAliases,
+    customPomImportNameCollisionBehavior,
+    nameCollisionBehavior,
+    existingIdBehavior,
+    testIdAttribute,
     routerAwarePoms,
     routerEntry,
     routerType,
     routerModuleShims,
-    generateFixtures,
-    customPomAttachments,
-    projectRootRef,
-    basePageClassPath: basePageClassPathOverride,
-    customPomDir,
-    customPomImportAliases,
-    customPomImportNameCollisionBehavior,
-    testIdAttribute,
-    loggerRef,
-  } = options;
+  } = generation;
 
   const resolveRouterEntry = () => {
     if (!routerAwarePoms)
@@ -127,27 +102,12 @@ export function createSupportPlugins(options: SupportFactoryOptions): PluginOpti
     getSourceDirs,
     basePageClassPath,
     normalizedBasePagePath,
-    outDir,
-    emitLanguages,
-    typescriptOutputStructure,
-    csharp,
-    generateFixtures,
-    customPomAttachments,
+    generation,
     projectRootRef,
-    customPomDir,
-    customPomImportAliases,
-    customPomImportNameCollisionBehavior,
-    testIdAttribute,
-    nameCollisionBehavior,
-    missingSemanticNameBehavior,
-    existingIdBehavior,
     nativeWrappers,
     excludedComponents,
     getWrapperSearchRoots,
-    routerAwarePoms,
-    routerType,
     getResolvedRouterEntry: resolveRouterEntry,
-    routerModuleShims,
     loggerRef,
   });
 
@@ -163,23 +123,8 @@ export function createSupportPlugins(options: SupportFactoryOptions): PluginOpti
     projectRootRef,
     normalizedBasePagePath,
     basePageClassPath,
-    outDir,
-    emitLanguages,
-    typescriptOutputStructure,
-    csharp,
-    generateFixtures,
-    customPomAttachments,
-    customPomDir,
-    customPomImportAliases,
-    customPomImportNameCollisionBehavior,
-    nameCollisionBehavior,
-    missingSemanticNameBehavior,
-    existingIdBehavior,
-    testIdAttribute,
-    routerAwarePoms,
-    routerType,
+    generation,
     getResolvedRouterEntry: resolveRouterEntry,
-    routerModuleShims,
     loggerRef,
   });
 

--- a/plugin/support-plugins.ts
+++ b/plugin/support-plugins.ts
@@ -25,6 +25,7 @@ interface SupportFactoryOptions {
   missingSemanticNameBehavior?: "ignore" | "error";
   /** How to handle existing data-testid attributes in the source. */
   existingIdBehavior?: "preserve" | "overwrite" | "error";
+  clickInstrumentation?: boolean;
 
   /** Output directory for generated files (POMs + optional fixtures). */
   outDir?: string;
@@ -71,6 +72,7 @@ export function createSupportPlugins(options: SupportFactoryOptions): PluginOpti
     nameCollisionBehavior = "suffix",
     missingSemanticNameBehavior = "error",
     existingIdBehavior,
+    clickInstrumentation = true,
     outDir,
     emitLanguages,
     typescriptOutputStructure,
@@ -141,6 +143,7 @@ export function createSupportPlugins(options: SupportFactoryOptions): PluginOpti
     nameCollisionBehavior,
     missingSemanticNameBehavior,
     existingIdBehavior,
+    clickInstrumentation,
     nativeWrappers,
     excludedComponents,
     getWrapperSearchRoots,
@@ -175,6 +178,7 @@ export function createSupportPlugins(options: SupportFactoryOptions): PluginOpti
     nameCollisionBehavior,
     missingSemanticNameBehavior,
     existingIdBehavior,
+    clickInstrumentation,
     testIdAttribute,
     routerAwarePoms,
     routerType,

--- a/plugin/support-plugins.ts
+++ b/plugin/support-plugins.ts
@@ -25,7 +25,6 @@ interface SupportFactoryOptions {
   missingSemanticNameBehavior?: "ignore" | "error";
   /** How to handle existing data-testid attributes in the source. */
   existingIdBehavior?: "preserve" | "overwrite" | "error";
-  clickInstrumentation?: boolean;
 
   /** Output directory for generated files (POMs + optional fixtures). */
   outDir?: string;
@@ -72,7 +71,6 @@ export function createSupportPlugins(options: SupportFactoryOptions): PluginOpti
     nameCollisionBehavior = "suffix",
     missingSemanticNameBehavior = "error",
     existingIdBehavior,
-    clickInstrumentation = true,
     outDir,
     emitLanguages,
     typescriptOutputStructure,
@@ -143,7 +141,6 @@ export function createSupportPlugins(options: SupportFactoryOptions): PluginOpti
     nameCollisionBehavior,
     missingSemanticNameBehavior,
     existingIdBehavior,
-    clickInstrumentation,
     nativeWrappers,
     excludedComponents,
     getWrapperSearchRoots,
@@ -178,7 +175,6 @@ export function createSupportPlugins(options: SupportFactoryOptions): PluginOpti
     nameCollisionBehavior,
     missingSemanticNameBehavior,
     existingIdBehavior,
-    clickInstrumentation,
     testIdAttribute,
     routerAwarePoms,
     routerType,

--- a/plugin/support/build-plugin.ts
+++ b/plugin/support/build-plugin.ts
@@ -14,7 +14,7 @@ import type { IComponentDependencies, NativeWrappersMap, RouterIntrospectionResu
 import { setResolveToComponentNameFn, setRouteNameToComponentNameMap, toPascalCase } from "../../utils";
 import type { VuePomGeneratorLogger } from "../logger";
 import { resolveComponentNameFromPath } from "../path-utils";
-import type { PlaywrightOutputStructure, PomNameCollisionBehavior, RouterModuleShimDefinition } from "../types";
+import type { ResolvedGenerationSupportOptions } from "../resolved-generation-options";
 
 interface BuildProcessorOptions {
   componentHierarchyMap: Map<string, IComponentDependencies>;
@@ -27,37 +27,15 @@ interface BuildProcessorOptions {
 
   basePageClassPath: string;
   normalizedBasePagePath: string;
-
-  outDir?: string;
-  emitLanguages?: Array<"ts" | "csharp">;
-  typescriptOutputStructure?: PlaywrightOutputStructure;
-  csharp?: {
-    namespace?: string;
-  };
-  generateFixtures?: boolean | string | { outDir?: string };
-  customPomAttachments?: Array<{ className: string; propertyName: string; attachWhenUsesComponents: string[]; attachTo?: "views" | "components" | "both" | "pagesAndComponents"; flatten?: boolean }>;
+  generation: ResolvedGenerationSupportOptions;
   projectRootRef: { current: string };
-  customPomDir?: string;
-  customPomImportAliases?: Record<string, string>;
-  customPomImportNameCollisionBehavior?: "error" | "alias";
-  testIdAttribute: string;
-
-  /** How to handle POM member-name collisions. */
-  nameCollisionBehavior?: PomNameCollisionBehavior;
-  missingSemanticNameBehavior?: "ignore" | "error";
-  /** How to handle existing data-testid attributes. */
-  existingIdBehavior?: "preserve" | "overwrite" | "error";
   /** Native wrapper component config. */
   nativeWrappers: NativeWrappersMap;
   /** Components excluded from test-id injection. */
   excludedComponents: string[];
   /** Getter for resolved wrapper search root directories. */
   getWrapperSearchRoots: () => string[];
-
-  routerAwarePoms: boolean;
   getResolvedRouterEntry: () => string | undefined;
-  routerType?: "vue-router" | "nuxt";
-  routerModuleShims?: Record<string, RouterModuleShimDefinition>;
 
   loggerRef: { current: VuePomGeneratorLogger };
 }
@@ -110,29 +88,32 @@ export function createBuildProcessorPlugin(options: BuildProcessorOptions): Plug
     getSourceDirs,
     basePageClassPath,
     normalizedBasePagePath,
+    generation,
+    projectRootRef,
+    nativeWrappers,
+    excludedComponents,
+    getWrapperSearchRoots,
+    getResolvedRouterEntry,
+    loggerRef,
+  } = options;
+  const {
     outDir,
     emitLanguages,
     typescriptOutputStructure,
     csharp,
     generateFixtures,
     customPomAttachments,
-    projectRootRef,
     customPomDir,
+    requireCustomPomDir,
     customPomImportAliases,
     customPomImportNameCollisionBehavior,
     testIdAttribute,
     nameCollisionBehavior,
-    missingSemanticNameBehavior = "error",
     existingIdBehavior,
-    nativeWrappers,
-    excludedComponents,
-    getWrapperSearchRoots,
     routerAwarePoms,
-    getResolvedRouterEntry,
     routerType,
     routerModuleShims,
-    loggerRef,
-  } = options;
+  } = generation;
 
   // Vite (v6/v7) may run multiple build environments/passes (e.g. SSR + client) in a single invocation.
   // Some passes can execute without compiling any Vue SFC templates that reach our transform, leaving
@@ -260,10 +241,9 @@ export function createBuildProcessorPlugin(options: BuildProcessorOptions): Plug
                 excludedComponents,
                 getViewsDirAbs(),
                 {
-                  existingIdBehavior: existingIdBehavior ?? "preserve",
+                  existingIdBehavior: existingIdBehavior ?? "error",
                   testIdAttribute,
                   nameCollisionBehavior,
-                  missingSemanticNameBehavior,
                   warn: (message: string) => loggerRef.current.warn(message),
                   vueFilesPathMap,
                   wrapperSearchRoots: getWrapperSearchRoots(),
@@ -391,6 +371,7 @@ export function createBuildProcessorPlugin(options: BuildProcessorOptions): Plug
         customPomAttachments,
         projectRoot: projectRootRef.current,
         customPomDir,
+        requireCustomPomDir,
         customPomImportAliases,
         customPomImportNameCollisionBehavior,
         testIdAttribute,

--- a/plugin/support/build-plugin.ts
+++ b/plugin/support/build-plugin.ts
@@ -47,7 +47,6 @@ interface BuildProcessorOptions {
   missingSemanticNameBehavior?: "ignore" | "error";
   /** How to handle existing data-testid attributes. */
   existingIdBehavior?: "preserve" | "overwrite" | "error";
-  clickInstrumentation?: boolean;
   /** Native wrapper component config. */
   nativeWrappers: NativeWrappersMap;
   /** Components excluded from test-id injection. */
@@ -125,7 +124,6 @@ export function createBuildProcessorPlugin(options: BuildProcessorOptions): Plug
     nameCollisionBehavior,
     missingSemanticNameBehavior = "error",
     existingIdBehavior,
-    clickInstrumentation = true,
     nativeWrappers,
     excludedComponents,
     getWrapperSearchRoots,
@@ -266,7 +264,6 @@ export function createBuildProcessorPlugin(options: BuildProcessorOptions): Plug
                   testIdAttribute,
                   nameCollisionBehavior,
                   missingSemanticNameBehavior,
-                  clickInstrumentation,
                   warn: (message: string) => loggerRef.current.warn(message),
                   vueFilesPathMap,
                   wrapperSearchRoots: getWrapperSearchRoots(),

--- a/plugin/support/build-plugin.ts
+++ b/plugin/support/build-plugin.ts
@@ -47,6 +47,7 @@ interface BuildProcessorOptions {
   missingSemanticNameBehavior?: "ignore" | "error";
   /** How to handle existing data-testid attributes. */
   existingIdBehavior?: "preserve" | "overwrite" | "error";
+  clickInstrumentation?: boolean;
   /** Native wrapper component config. */
   nativeWrappers: NativeWrappersMap;
   /** Components excluded from test-id injection. */
@@ -124,6 +125,7 @@ export function createBuildProcessorPlugin(options: BuildProcessorOptions): Plug
     nameCollisionBehavior,
     missingSemanticNameBehavior = "error",
     existingIdBehavior,
+    clickInstrumentation = true,
     nativeWrappers,
     excludedComponents,
     getWrapperSearchRoots,
@@ -264,6 +266,7 @@ export function createBuildProcessorPlugin(options: BuildProcessorOptions): Plug
                   testIdAttribute,
                   nameCollisionBehavior,
                   missingSemanticNameBehavior,
+                  clickInstrumentation,
                   warn: (message: string) => loggerRef.current.warn(message),
                   vueFilesPathMap,
                   wrapperSearchRoots: getWrapperSearchRoots(),

--- a/plugin/support/dev-plugin.ts
+++ b/plugin/support/dev-plugin.ts
@@ -15,7 +15,7 @@ import type { IComponentDependencies, NativeWrappersMap, RouterIntrospectionResu
 import { setResolveToComponentNameFn, setRouteNameToComponentNameMap, toPascalCase } from "../../utils";
 import type { VuePomGeneratorLogger } from "../logger";
 import { isPathWithinDir, resolveComponentNameFromPath } from "../path-utils";
-import type { PlaywrightOutputStructure, PomNameCollisionBehavior, RouterModuleShimDefinition } from "../types";
+import type { ResolvedGenerationSupportOptions } from "../resolved-generation-options";
 
 interface DevProcessorOptions {
   nativeWrappers: NativeWrappersMap;
@@ -30,28 +30,8 @@ interface DevProcessorOptions {
   projectRootRef: { current: string };
   normalizedBasePagePath: string;
   basePageClassPath: string;
-
-  outDir?: string;
-  emitLanguages?: Array<"ts" | "csharp">;
-  typescriptOutputStructure?: PlaywrightOutputStructure;
-  csharp?: {
-    namespace?: string;
-  };
-  generateFixtures?: boolean | string | { outDir?: string };
-  customPomAttachments?: Array<{ className: string; propertyName: string; attachWhenUsesComponents: string[]; attachTo?: "views" | "components" | "both" | "pagesAndComponents"; flatten?: boolean }>;
-  customPomDir?: string;
-  customPomImportAliases?: Record<string, string>;
-  customPomImportNameCollisionBehavior?: "error" | "alias";
-  nameCollisionBehavior?: PomNameCollisionBehavior;
-  missingSemanticNameBehavior?: "ignore" | "error";
-  /** How to handle existing data-testid attributes in the source. */
-  existingIdBehavior?: "preserve" | "overwrite" | "error";
-  testIdAttribute: string;
-
-  routerAwarePoms: boolean;
+  generation: ResolvedGenerationSupportOptions;
   getResolvedRouterEntry: () => string | undefined;
-  routerType?: "vue-router" | "nuxt";
-  routerModuleShims?: Record<string, RouterModuleShimDefinition>;
 
   loggerRef: { current: VuePomGeneratorLogger };
 }
@@ -69,6 +49,11 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
     projectRootRef,
     normalizedBasePagePath,
     basePageClassPath,
+    generation,
+    getResolvedRouterEntry,
+    loggerRef,
+  } = options;
+  const {
     outDir,
     emitLanguages,
     typescriptOutputStructure,
@@ -76,18 +61,16 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
     generateFixtures,
     customPomAttachments,
     customPomDir,
+    requireCustomPomDir,
     customPomImportAliases,
     customPomImportNameCollisionBehavior,
-    nameCollisionBehavior = "suffix",
-    missingSemanticNameBehavior = "error",
+    nameCollisionBehavior,
     existingIdBehavior,
     testIdAttribute,
     routerAwarePoms,
-    getResolvedRouterEntry,
     routerType,
     routerModuleShims,
-    loggerRef,
-  } = options;
+  } = generation;
 
   // Bridge between configureServer (where we have timers/logger) and handleHotUpdate.
   let scheduleVueFileRegen: ((filePath: string, source: "hmr" | "fs") => void) | null = null;
@@ -320,9 +303,8 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
               excludedComponents,
               getViewsDirAbs(),
               {
-                existingIdBehavior: existingIdBehavior ?? "preserve",
+                existingIdBehavior: existingIdBehavior ?? "error",
                 nameCollisionBehavior,
-                missingSemanticNameBehavior,
                 testIdAttribute,
                 warn: message => loggerRef.current.warn(message),
                 vueFilesPathMap: provisionalVuePathMap,
@@ -383,6 +365,7 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
           customPomAttachments,
           projectRoot: projectRootRef.current,
           customPomDir,
+          requireCustomPomDir,
           customPomImportAliases,
           customPomImportNameCollisionBehavior,
           pageDirs: getPageDirs(),

--- a/plugin/support/dev-plugin.ts
+++ b/plugin/support/dev-plugin.ts
@@ -46,7 +46,6 @@ interface DevProcessorOptions {
   missingSemanticNameBehavior?: "ignore" | "error";
   /** How to handle existing data-testid attributes in the source. */
   existingIdBehavior?: "preserve" | "overwrite" | "error";
-  clickInstrumentation?: boolean;
   testIdAttribute: string;
 
   routerAwarePoms: boolean;
@@ -82,7 +81,6 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
     nameCollisionBehavior = "suffix",
     missingSemanticNameBehavior = "error",
     existingIdBehavior,
-    clickInstrumentation = true,
     testIdAttribute,
     routerAwarePoms,
     getResolvedRouterEntry,
@@ -325,7 +323,6 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
                 existingIdBehavior: existingIdBehavior ?? "preserve",
                 nameCollisionBehavior,
                 missingSemanticNameBehavior,
-                clickInstrumentation,
                 testIdAttribute,
                 warn: message => loggerRef.current.warn(message),
                 vueFilesPathMap: provisionalVuePathMap,

--- a/plugin/support/dev-plugin.ts
+++ b/plugin/support/dev-plugin.ts
@@ -46,6 +46,7 @@ interface DevProcessorOptions {
   missingSemanticNameBehavior?: "ignore" | "error";
   /** How to handle existing data-testid attributes in the source. */
   existingIdBehavior?: "preserve" | "overwrite" | "error";
+  clickInstrumentation?: boolean;
   testIdAttribute: string;
 
   routerAwarePoms: boolean;
@@ -81,6 +82,7 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
     nameCollisionBehavior = "suffix",
     missingSemanticNameBehavior = "error",
     existingIdBehavior,
+    clickInstrumentation = true,
     testIdAttribute,
     routerAwarePoms,
     getResolvedRouterEntry,
@@ -323,6 +325,7 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
                 existingIdBehavior: existingIdBehavior ?? "preserve",
                 nameCollisionBehavior,
                 missingSemanticNameBehavior,
+                clickInstrumentation,
                 testIdAttribute,
                 warn: message => loggerRef.current.warn(message),
                 vueFilesPathMap: provisionalVuePathMap,

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -3,11 +3,6 @@ import type { NativeWrappersMap } from "../utils";
 
 export type ExistingIdBehavior = "preserve" | "overwrite" | "error";
 export type VuePluginOwnership = "internal" | "external";
-export type MissingSemanticNameBehavior = "ignore" | "error";
-export interface ErrorBehaviorOptions {
-  missingSemanticNameBehavior?: MissingSemanticNameBehavior;
-}
-export type ErrorBehavior = MissingSemanticNameBehavior | ErrorBehaviorOptions;
 export type PlaywrightOutputStructure = "aggregated" | "split";
 
 /**
@@ -55,19 +50,6 @@ export interface VuePomGeneratorPluginOptions {
      */
     verbosity?: "silent" | "warn" | "info" | "debug";
   };
-
-  /**
-   * Controls strict/error behavior for generator checks.
-   *
-   * - `"ignore"`: keep permissive fallback behavior for all supported strictness checks
-   * - `"error"` (default): enable error-on-failure behavior for all supported strictness checks
-   * - `{ ... }`: override individual checks without enabling all of them
-   *
-   * Current scope: this first pass is intentionally narrow. The object form currently supports
-   * `missingSemanticNameBehavior`, which targets button-like wrappers with `:handler` during
-   * Playwright generation.
-   */
-  errorBehavior?: ErrorBehavior;
 
   /**
    * Configuration for injecting/deriving test ids from Vue templates.
@@ -208,11 +190,11 @@ export interface VuePomGeneratorPluginOptions {
       * - Resolve collisions by adding a stable naming signal (distinct handler, distinct id/name, or
       *   structural change) rather than relying on silent suffixing.
       *
-     * - "error": throw and fail the compilation on the first collision encountered
-     * - "warn": log a warning and append a numeric suffix to disambiguate
-     * - "suffix": append a numeric suffix silently (default)
-     */
-    nameCollisionBehavior?: PomNameCollisionBehavior;
+      * - "error": throw and fail the compilation on the first collision encountered (default)
+      * - "warn": log a warning and append a numeric suffix to disambiguate
+      * - "suffix": append a numeric suffix silently
+      */
+     nameCollisionBehavior?: PomNameCollisionBehavior;
 
     /**
      * Absolute path to the BasePage template module to inline into generated output.

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -130,16 +130,6 @@ export interface VuePomGeneratorPluginOptions {
     wrapperSearchRoots?: string[];
 
     /**
-      * Whether to wrap click handlers so the app emits `__testid_event__` runtime events.
-      *
-      * Defaults to `true`.
-      *
-      * Set this to `false` to opt out when you only want template injection / POM generation
-      * without runtime click-handler wrapping.
-      */
-    clickInstrumentation?: boolean;
-
-    /**
       * What to do when the author already provided a test id attribute.
       *
      * - `"preserve"` (default): keep the existing value

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -130,8 +130,18 @@ export interface VuePomGeneratorPluginOptions {
     wrapperSearchRoots?: string[];
 
     /**
-     * What to do when the author already provided a test id attribute.
-     *
+      * Whether to wrap click handlers so the app emits `__testid_event__` runtime events.
+      *
+      * Defaults to `true`.
+      *
+      * Set this to `false` to opt out when you only want template injection / POM generation
+      * without runtime click-handler wrapping.
+      */
+    clickInstrumentation?: boolean;
+
+    /**
+      * What to do when the author already provided a test id attribute.
+      *
      * - `"preserve"` (default): keep the existing value
      * - `"overwrite"`: replace it with the generated value
      * - `"error"`: throw to force cleanup/migration

--- a/plugin/vue-plugin.ts
+++ b/plugin/vue-plugin.ts
@@ -20,7 +20,6 @@ interface InternalFactoryOptions {
   vueOptions?: VuePluginOptions;
   existingIdBehavior: "preserve" | "overwrite" | "error";
   nameCollisionBehavior: PomNameCollisionBehavior;
-  clickInstrumentation?: boolean;
   nativeWrappers: NativeWrappersMap;
   elementMetadata: Map<string, Map<string, ElementMetadata>>;
   semanticNameMap: Map<string, string>;
@@ -106,7 +105,6 @@ export function createVuePluginWithTestIds(options: InternalFactoryOptions): {
     vueOptions,
     existingIdBehavior,
     nameCollisionBehavior,
-    clickInstrumentation = true,
     nativeWrappers,
     elementMetadata,
     semanticNameMap,
@@ -212,7 +210,6 @@ export function createVuePluginWithTestIds(options: InternalFactoryOptions): {
                   existingIdBehavior,
                   testIdAttribute,
                   nameCollisionBehavior,
-                  clickInstrumentation,
                   warn: (message) => loggerRef.current.warn(message),
                   vueFilesPathMap,
                   wrapperSearchRoots: getWrapperSearchRoots(),
@@ -247,7 +244,6 @@ export function createVuePluginWithTestIds(options: InternalFactoryOptions): {
                 existingIdBehavior,
                 testIdAttribute,
                 nameCollisionBehavior,
-                clickInstrumentation,
                 warn: (message) => loggerRef.current.warn(message),
                 vueFilesPathMap,
                 wrapperSearchRoots: getWrapperSearchRoots(),

--- a/plugin/vue-plugin.ts
+++ b/plugin/vue-plugin.ts
@@ -20,6 +20,7 @@ interface InternalFactoryOptions {
   vueOptions?: VuePluginOptions;
   existingIdBehavior: "preserve" | "overwrite" | "error";
   nameCollisionBehavior: PomNameCollisionBehavior;
+  clickInstrumentation?: boolean;
   nativeWrappers: NativeWrappersMap;
   elementMetadata: Map<string, Map<string, ElementMetadata>>;
   semanticNameMap: Map<string, string>;
@@ -105,6 +106,7 @@ export function createVuePluginWithTestIds(options: InternalFactoryOptions): {
     vueOptions,
     existingIdBehavior,
     nameCollisionBehavior,
+    clickInstrumentation = true,
     nativeWrappers,
     elementMetadata,
     semanticNameMap,
@@ -210,6 +212,7 @@ export function createVuePluginWithTestIds(options: InternalFactoryOptions): {
                   existingIdBehavior,
                   testIdAttribute,
                   nameCollisionBehavior,
+                  clickInstrumentation,
                   warn: (message) => loggerRef.current.warn(message),
                   vueFilesPathMap,
                   wrapperSearchRoots: getWrapperSearchRoots(),
@@ -244,6 +247,7 @@ export function createVuePluginWithTestIds(options: InternalFactoryOptions): {
                 existingIdBehavior,
                 testIdAttribute,
                 nameCollisionBehavior,
+                clickInstrumentation,
                 warn: (message) => loggerRef.current.warn(message),
                 vueFilesPathMap,
                 wrapperSearchRoots: getWrapperSearchRoots(),

--- a/plugin/vue-plugin.ts
+++ b/plugin/vue-plugin.ts
@@ -352,8 +352,7 @@ export function createVuePluginWithTestIds(options: InternalFactoryOptions): {
 
       const api = viteVuePlugin?.api;
       if (!api) {
-        loggerRef.current.warn("[vue-pom-generator] Nuxt bridge could not find vite:vue plugin to patch.");
-        return;
+        throw new Error("[vue-pom-generator] Nuxt bridge could not find vite:vue plugin to patch.");
       }
 
       const currentOptions = api.options ?? {};

--- a/pom-params.ts
+++ b/pom-params.ts
@@ -13,7 +13,6 @@ export interface PomMethodSignature {
   parameters: PomParameterSpec[];
 }
 
-export type PomLegacyParameterRecord = Record<string, string>;
 export type PomParameterInput = readonly PomParameterSpec[] | undefined;
 
 export function splitPomParameterTypeExpression(typeExpression: string): { type: string; initializer?: string } {
@@ -70,14 +69,6 @@ export function createPomParameters(...parameters: Array<PomParameterSpec | read
       isRestParameter: param.isRestParameter,
     });
   });
-}
-
-export function fromLegacyPomParameterRecord(params: PomLegacyParameterRecord | undefined): PomParameterSpec[] {
-  if (!params) {
-    return [];
-  }
-
-  return Object.entries(params).map(([name, typeExpression]) => createPomParameterSpec(name, typeExpression));
 }
 
 export function normalizePomParameters(params: PomParameterInput): PomParameterSpec[] {

--- a/pom-params.ts
+++ b/pom-params.ts
@@ -5,6 +5,12 @@ export interface PomParameterSpec {
   initializer?: string;
 }
 
+export interface PomMethodSignature {
+  parameters: PomParameterSpec[];
+}
+
+export type PomParameterInput = Record<string, string> | readonly PomParameterSpec[] | undefined;
+
 export function splitPomParameterTypeExpression(typeExpression: string): { type: string; initializer?: string } {
   const trimmed = typeExpression.trim();
   const initializerIndex = trimmed.lastIndexOf("=");
@@ -18,28 +24,69 @@ export function splitPomParameterTypeExpression(typeExpression: string): { type:
   };
 }
 
-export function normalizePomParameters(params: Record<string, string> | undefined): PomParameterSpec[] {
+export function createPomParameterSpec(name: string, typeExpression: string): PomParameterSpec {
+  const { type, initializer } = splitPomParameterTypeExpression(typeExpression);
+  return {
+    name,
+    typeExpression,
+    type,
+    initializer,
+  };
+}
+
+export function normalizePomParameters(params: PomParameterInput): PomParameterSpec[] {
   if (!params) {
     return [];
   }
 
-  return Object.entries(params).map(([name, typeExpression]) => {
-    const { type, initializer } = splitPomParameterTypeExpression(typeExpression);
-    return {
-      name,
-      typeExpression,
-      type,
-      initializer,
-    };
-  });
+  if (Array.isArray(params)) {
+    return params.map(param => ({ ...param }));
+  }
+
+  return Object.entries(params).map(([name, typeExpression]) => createPomParameterSpec(name, typeExpression));
 }
 
-export function getPomParameterNames(params: Record<string, string> | undefined): string[] {
+export function getPomParameterNames(params: PomParameterInput): string[] {
   return normalizePomParameters(params).map(param => param.name);
 }
 
-export function formatTypeScriptPomParameters(params: Record<string, string> | undefined): string {
+export function getPomParameter(params: PomParameterInput, name: string): PomParameterSpec | undefined {
+  return normalizePomParameters(params).find(param => param.name === name);
+}
+
+export function hasPomParameter(params: PomParameterInput, name: string): boolean {
+  return !!getPomParameter(params, name);
+}
+
+export function formatTypeScriptPomParameters(params: PomParameterInput): string {
   return normalizePomParameters(params)
     .map(param => `${param.name}: ${param.typeExpression}`)
     .join(", ");
+}
+
+export function createPomMethodSignature(parameters: PomParameterInput): PomMethodSignature {
+  return {
+    parameters: normalizePomParameters(parameters),
+  };
+}
+
+export function pomParameterSpecEquals(left: PomParameterSpec, right: PomParameterSpec): boolean {
+  return left.name === right.name
+    && left.typeExpression === right.typeExpression
+    && left.type === right.type
+    && left.initializer === right.initializer;
+}
+
+export function pomParameterListEquals(left: PomParameterInput, right: PomParameterInput): boolean {
+  const leftParams = normalizePomParameters(left);
+  const rightParams = normalizePomParameters(right);
+  if (leftParams.length !== rightParams.length) {
+    return false;
+  }
+
+  return leftParams.every((param, index) => pomParameterSpecEquals(param, rightParams[index]));
+}
+
+export function pomMethodSignatureEquals(left: PomMethodSignature, right: PomMethodSignature): boolean {
+  return pomParameterListEquals(left.parameters, right.parameters);
 }

--- a/pom-params.ts
+++ b/pom-params.ts
@@ -53,6 +53,26 @@ export function createPomParameterSpec(
   };
 }
 
+function isPomParameterEntry(
+  parameter: PomParameterSpec | readonly [string, string],
+): parameter is readonly [string, string] {
+  return Array.isArray(parameter);
+}
+
+export function createPomParameters(...parameters: Array<PomParameterSpec | readonly [string, string]>): PomParameterSpec[] {
+  return parameters.map((param) => {
+    if (isPomParameterEntry(param)) {
+      return createPomParameterSpec(param[0], param[1]);
+    }
+
+    return createPomParameterSpec(param.name, param.typeExpression ?? param.type, {
+      initializer: param.initializer,
+      hasQuestionToken: param.hasQuestionToken,
+      isRestParameter: param.isRestParameter,
+    });
+  });
+}
+
 export function normalizePomParameters(params: PomParameterSource): PomParameterSpec[] {
   if (!params) {
     return [];

--- a/pom-params.ts
+++ b/pom-params.ts
@@ -79,6 +79,32 @@ export function hasPomParameter(params: PomParameterInput, name: string): boolea
   return !!getPomParameter(params, name);
 }
 
+export function setPomParameter(
+  params: PomParameterInput,
+  name: string,
+  typeExpression?: string,
+  options: {
+    initializer?: string;
+    hasQuestionToken?: boolean;
+    isRestParameter?: boolean;
+  } = {},
+): PomParameterSpec[] {
+  const nextParam = createPomParameterSpec(name, typeExpression, options);
+  const normalizedParams = normalizePomParameters(params);
+  const existingIndex = normalizedParams.findIndex(param => param.name === name);
+  if (existingIndex < 0) {
+    return [...normalizedParams, nextParam];
+  }
+
+  const nextParams = normalizedParams.slice();
+  nextParams[existingIndex] = nextParam;
+  return nextParams;
+}
+
+export function removePomParameter(params: PomParameterInput, name: string): PomParameterSpec[] {
+  return normalizePomParameters(params).filter(param => param.name !== name);
+}
+
 export function formatTypeScriptPomParameters(params: PomParameterInput): string {
   return normalizePomParameters(params)
     .map((param) => {

--- a/pom-params.ts
+++ b/pom-params.ts
@@ -13,7 +13,9 @@ export interface PomMethodSignature {
   parameters: PomParameterSpec[];
 }
 
-export type PomParameterInput = Record<string, string> | readonly PomParameterSpec[] | undefined;
+export type PomLegacyParameterRecord = Record<string, string>;
+export type PomParameterInput = readonly PomParameterSpec[] | undefined;
+export type PomParameterSource = PomLegacyParameterRecord | PomParameterInput;
 
 export function splitPomParameterTypeExpression(typeExpression: string): { type: string; initializer?: string } {
   const trimmed = typeExpression.trim();
@@ -51,7 +53,7 @@ export function createPomParameterSpec(
   };
 }
 
-export function normalizePomParameters(params: PomParameterInput): PomParameterSpec[] {
+export function normalizePomParameters(params: PomParameterSource): PomParameterSpec[] {
   if (!params) {
     return [];
   }
@@ -103,18 +105,6 @@ export function setPomParameter(
 
 export function removePomParameter(params: PomParameterInput, name: string): PomParameterSpec[] {
   return normalizePomParameters(params).filter(param => param.name !== name);
-}
-
-export function formatTypeScriptPomParameters(params: PomParameterInput): string {
-  return normalizePomParameters(params)
-    .map((param) => {
-      const prefix = param.isRestParameter ? "..." : "";
-      const questionToken = param.hasQuestionToken ? "?" : "";
-      const typeExpression = param.typeExpression ? `: ${param.typeExpression}` : "";
-      const initializer = param.initializer !== undefined ? ` = ${param.initializer}` : "";
-      return `${prefix}${param.name}${questionToken}${typeExpression}${initializer}`;
-    })
-    .join(", ");
 }
 
 export function toTypeScriptPomParameterStructures(params: PomParameterInput): OptionalKind<ParameterDeclarationStructure>[] {

--- a/pom-params.ts
+++ b/pom-params.ts
@@ -15,7 +15,6 @@ export interface PomMethodSignature {
 
 export type PomLegacyParameterRecord = Record<string, string>;
 export type PomParameterInput = readonly PomParameterSpec[] | undefined;
-export type PomParameterSource = PomLegacyParameterRecord | PomParameterInput;
 
 export function splitPomParameterTypeExpression(typeExpression: string): { type: string; initializer?: string } {
   const trimmed = typeExpression.trim();
@@ -73,20 +72,24 @@ export function createPomParameters(...parameters: Array<PomParameterSpec | read
   });
 }
 
-export function normalizePomParameters(params: PomParameterSource): PomParameterSpec[] {
+export function fromLegacyPomParameterRecord(params: PomLegacyParameterRecord | undefined): PomParameterSpec[] {
   if (!params) {
     return [];
   }
 
-  if (Array.isArray(params)) {
-    return params.map(param => createPomParameterSpec(param.name, param.typeExpression ?? param.type, {
-      initializer: param.initializer,
-      hasQuestionToken: param.hasQuestionToken,
-      isRestParameter: param.isRestParameter,
-    }));
+  return Object.entries(params).map(([name, typeExpression]) => createPomParameterSpec(name, typeExpression));
+}
+
+export function normalizePomParameters(params: PomParameterInput): PomParameterSpec[] {
+  if (!params) {
+    return [];
   }
 
-  return Object.entries(params).map(([name, typeExpression]) => createPomParameterSpec(name, typeExpression));
+  return params.map(param => createPomParameterSpec(param.name, param.typeExpression ?? param.type, {
+    initializer: param.initializer,
+    hasQuestionToken: param.hasQuestionToken,
+    isRestParameter: param.isRestParameter,
+  }));
 }
 
 export function getPomParameterNames(params: PomParameterInput): string[] {

--- a/pom-params.ts
+++ b/pom-params.ts
@@ -1,8 +1,12 @@
+import type { OptionalKind, ParameterDeclarationStructure } from "./typescript-codegen";
+
 export interface PomParameterSpec {
   name: string;
-  typeExpression: string;
-  type: string;
+  typeExpression?: string;
+  type?: string;
   initializer?: string;
+  hasQuestionToken?: boolean;
+  isRestParameter?: boolean;
 }
 
 export interface PomMethodSignature {
@@ -24,13 +28,26 @@ export function splitPomParameterTypeExpression(typeExpression: string): { type:
   };
 }
 
-export function createPomParameterSpec(name: string, typeExpression: string): PomParameterSpec {
-  const { type, initializer } = splitPomParameterTypeExpression(typeExpression);
+export function createPomParameterSpec(
+  name: string,
+  typeExpression?: string,
+  options: {
+    initializer?: string;
+    hasQuestionToken?: boolean;
+    isRestParameter?: boolean;
+  } = {},
+): PomParameterSpec {
+  const normalizedTypeExpression = typeExpression?.trim();
+  const { type, initializer } = normalizedTypeExpression
+    ? splitPomParameterTypeExpression(normalizedTypeExpression)
+    : { type: undefined, initializer: undefined };
   return {
     name,
-    typeExpression,
+    typeExpression: normalizedTypeExpression,
     type,
-    initializer,
+    initializer: options.initializer ?? initializer,
+    hasQuestionToken: options.hasQuestionToken,
+    isRestParameter: options.isRestParameter,
   };
 }
 
@@ -40,7 +57,11 @@ export function normalizePomParameters(params: PomParameterInput): PomParameterS
   }
 
   if (Array.isArray(params)) {
-    return params.map(param => ({ ...param }));
+    return params.map(param => createPomParameterSpec(param.name, param.typeExpression ?? param.type, {
+      initializer: param.initializer,
+      hasQuestionToken: param.hasQuestionToken,
+      isRestParameter: param.isRestParameter,
+    }));
   }
 
   return Object.entries(params).map(([name, typeExpression]) => createPomParameterSpec(name, typeExpression));
@@ -60,8 +81,28 @@ export function hasPomParameter(params: PomParameterInput, name: string): boolea
 
 export function formatTypeScriptPomParameters(params: PomParameterInput): string {
   return normalizePomParameters(params)
-    .map(param => `${param.name}: ${param.typeExpression}`)
+    .map((param) => {
+      const prefix = param.isRestParameter ? "..." : "";
+      const questionToken = param.hasQuestionToken ? "?" : "";
+      const typeExpression = param.typeExpression ? `: ${param.typeExpression}` : "";
+      const initializer = param.initializer !== undefined ? ` = ${param.initializer}` : "";
+      return `${prefix}${param.name}${questionToken}${typeExpression}${initializer}`;
+    })
     .join(", ");
+}
+
+export function toTypeScriptPomParameterStructures(params: PomParameterInput): OptionalKind<ParameterDeclarationStructure>[] {
+  return normalizePomParameters(params).map(param => ({
+    name: param.name,
+    type: param.type || undefined,
+    initializer: param.initializer,
+    hasQuestionToken: param.hasQuestionToken,
+    isRestParameter: param.isRestParameter,
+  }));
+}
+
+export function getPomParameterArgumentNames(params: PomParameterInput): string[] {
+  return normalizePomParameters(params).map(param => param.isRestParameter ? `...${param.name}` : param.name);
 }
 
 export function createPomMethodSignature(parameters: PomParameterInput): PomMethodSignature {
@@ -74,7 +115,9 @@ export function pomParameterSpecEquals(left: PomParameterSpec, right: PomParamet
   return left.name === right.name
     && left.typeExpression === right.typeExpression
     && left.type === right.type
-    && left.initializer === right.initializer;
+    && left.initializer === right.initializer
+    && left.hasQuestionToken === right.hasQuestionToken
+    && left.isRestParameter === right.isRestParameter;
 }
 
 export function pomParameterListEquals(left: PomParameterInput, right: PomParameterInput): boolean {

--- a/pom-params.ts
+++ b/pom-params.ts
@@ -1,0 +1,45 @@
+export interface PomParameterSpec {
+  name: string;
+  typeExpression: string;
+  type: string;
+  initializer?: string;
+}
+
+export function splitPomParameterTypeExpression(typeExpression: string): { type: string; initializer?: string } {
+  const trimmed = typeExpression.trim();
+  const initializerIndex = trimmed.lastIndexOf("=");
+  if (initializerIndex < 0) {
+    return { type: trimmed };
+  }
+
+  return {
+    type: trimmed.slice(0, initializerIndex).trim(),
+    initializer: trimmed.slice(initializerIndex + 1).trim(),
+  };
+}
+
+export function normalizePomParameters(params: Record<string, string> | undefined): PomParameterSpec[] {
+  if (!params) {
+    return [];
+  }
+
+  return Object.entries(params).map(([name, typeExpression]) => {
+    const { type, initializer } = splitPomParameterTypeExpression(typeExpression);
+    return {
+      name,
+      typeExpression,
+      type,
+      initializer,
+    };
+  });
+}
+
+export function getPomParameterNames(params: Record<string, string> | undefined): string[] {
+  return normalizePomParameters(params).map(param => param.name);
+}
+
+export function formatTypeScriptPomParameters(params: Record<string, string> | undefined): string {
+  return normalizePomParameters(params)
+    .map(param => `${param.name}: ${param.typeExpression}`)
+    .join(", ");
+}

--- a/pom-patterns.ts
+++ b/pom-patterns.ts
@@ -11,6 +11,11 @@ export interface PomStringPattern {
   templateVariables: string[];
 }
 
+export interface PomPatternBinding {
+  expression: string;
+  setupStatements: string[];
+}
+
 export function inferPomPatternKindFromFormattedString(value: string): PomPatternKind {
   return value.includes("${") ? "parameterized" : "static";
 }
@@ -107,6 +112,10 @@ export function getIndexedPomPatternVariable(pattern: PomStringPattern): string 
   return pattern.templateVariables[0];
 }
 
+export function hasPomPatternVariables(pattern: PomStringPattern): boolean {
+  return pattern.templateVariables.length > 0;
+}
+
 export function toTypeScriptPomPatternExpression(pattern: PomStringPattern): string {
   return isParameterizedPomPattern(pattern.patternKind)
     ? `\`${pattern.formatted}\``
@@ -123,6 +132,30 @@ export function toCSharpPomPatternExpression(pattern: PomStringPattern): string 
   // JSON.stringify gives us a normal quoted string literal with escaping that is close
   // enough for the C# interpolated-string wrapper we emit.
   return `$${JSON.stringify(inner)}`;
+}
+
+export function bindTypeScriptPomPattern(pattern: PomStringPattern, variableName: string): PomPatternBinding {
+  const expression = toTypeScriptPomPatternExpression(pattern);
+  if (!isParameterizedPomPattern(pattern.patternKind)) {
+    return { expression, setupStatements: [] };
+  }
+
+  return {
+    expression: variableName,
+    setupStatements: [`const ${variableName} = ${expression};`],
+  };
+}
+
+export function bindCSharpPomPattern(pattern: PomStringPattern, variableName: string): PomPatternBinding {
+  const expression = toCSharpPomPatternExpression(pattern);
+  if (!isParameterizedPomPattern(pattern.patternKind)) {
+    return { expression, setupStatements: [] };
+  }
+
+  return {
+    expression: variableName,
+    setupStatements: [`var ${variableName} = ${expression};`],
+  };
 }
 
 export function pomStringPatternEquals(left: PomStringPattern, right: PomStringPattern): boolean {

--- a/pom-patterns.ts
+++ b/pom-patterns.ts
@@ -42,6 +42,71 @@ export function inferPomStringPattern(formatted: string): PomStringPattern {
   return createPomStringPattern(formatted, inferPomPatternKindFromFormattedString(formatted));
 }
 
+export function getPomPatternVariables(
+  patterns: readonly PomStringPattern[],
+  options: { omit?: readonly string[] } = {},
+): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const omitted = new Set(options.omit ?? []);
+
+  for (const pattern of patterns) {
+    for (const variableName of pattern.templateVariables) {
+      if (omitted.has(variableName) || seen.has(variableName)) {
+        continue;
+      }
+      seen.add(variableName);
+      out.push(variableName);
+    }
+  }
+
+  return out;
+}
+
+export function ensurePomPatternParameters(
+  params: Record<string, string> | undefined,
+  patterns: readonly PomStringPattern[],
+  options: {
+    omit?: readonly string[];
+    defaultType?: string;
+  } = {},
+): Record<string, string> {
+  const currentParams = params ?? {};
+  const defaultType = options.defaultType ?? "string";
+  const orderedEntries: [string, string][] = [];
+  const seen = new Set<string>();
+
+  for (const variableName of getPomPatternVariables(patterns, options)) {
+    seen.add(variableName);
+    orderedEntries.push([variableName, currentParams[variableName] ?? defaultType]);
+  }
+
+  for (const [name, typeExpr] of Object.entries(currentParams)) {
+    if (seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    orderedEntries.push([name, typeExpr]);
+  }
+
+  return Object.fromEntries(orderedEntries);
+}
+
+export function getIndexedPomPatternVariable(pattern: PomStringPattern): string | null {
+  if (!isParameterizedPomPattern(pattern.patternKind)) {
+    return null;
+  }
+
+  if (pattern.templateVariables.length !== 1) {
+    throw new Error(
+      `[vue-pom-generator] Parameterized locator getters require exactly one template variable; `
+      + `got ${pattern.templateVariables.length} in ${JSON.stringify(pattern.formatted)}.`,
+    );
+  }
+
+  return pattern.templateVariables[0];
+}
+
 export function pomStringPatternEquals(left: PomStringPattern, right: PomStringPattern): boolean {
   return left.formatted === right.formatted && left.patternKind === right.patternKind;
 }

--- a/pom-patterns.ts
+++ b/pom-patterns.ts
@@ -7,14 +7,35 @@ export function isParameterizedPomPattern(kind: PomPatternKind): boolean {
 export interface PomStringPattern {
   formatted: string;
   patternKind: PomPatternKind;
+  /** Unique `${...}` variable names referenced by `formatted`, in first-occurrence order. */
+  templateVariables: string[];
 }
 
 export function inferPomPatternKindFromFormattedString(value: string): PomPatternKind {
   return value.includes("${") ? "parameterized" : "static";
 }
 
+function getTemplateVariables(formatted: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const matches = formatted.matchAll(/\$\{(\w+)\}/g);
+  for (const match of matches) {
+    const variableName = match[1];
+    if (seen.has(variableName)) {
+      continue;
+    }
+    seen.add(variableName);
+    out.push(variableName);
+  }
+  return out;
+}
+
 export function createPomStringPattern(formatted: string, patternKind: PomPatternKind): PomStringPattern {
-  return { formatted, patternKind };
+  return {
+    formatted,
+    patternKind,
+    templateVariables: getTemplateVariables(formatted),
+  };
 }
 
 export function inferPomStringPattern(formatted: string): PomStringPattern {

--- a/pom-patterns.ts
+++ b/pom-patterns.ts
@@ -107,6 +107,24 @@ export function getIndexedPomPatternVariable(pattern: PomStringPattern): string 
   return pattern.templateVariables[0];
 }
 
+export function toTypeScriptPomPatternExpression(pattern: PomStringPattern): string {
+  return isParameterizedPomPattern(pattern.patternKind)
+    ? `\`${pattern.formatted}\``
+    : JSON.stringify(pattern.formatted);
+}
+
+export function toCSharpPomPatternExpression(pattern: PomStringPattern): string {
+  if (!isParameterizedPomPattern(pattern.patternKind)) {
+    return JSON.stringify(pattern.formatted);
+  }
+
+  // Convert our `${var}` placeholder format into C# interpolated-string `{var}`.
+  const inner = pattern.formatted.replace(/\$\{/g, "{");
+  // JSON.stringify gives us a normal quoted string literal with escaping that is close
+  // enough for the C# interpolated-string wrapper we emit.
+  return `$${JSON.stringify(inner)}`;
+}
+
 export function pomStringPatternEquals(left: PomStringPattern, right: PomStringPattern): boolean {
   return left.formatted === right.formatted && left.patternKind === right.patternKind;
 }

--- a/pom-patterns.ts
+++ b/pom-patterns.ts
@@ -1,3 +1,5 @@
+import { createPomParameterSpec, normalizePomParameters, type PomParameterInput, type PomParameterSpec } from "./pom-params";
+
 export type PomPatternKind = "static" | "parameterized";
 
 export function isParameterizedPomPattern(kind: PomPatternKind): boolean {
@@ -69,32 +71,32 @@ export function getPomPatternVariables(
 }
 
 export function ensurePomPatternParameters(
-  params: Record<string, string> | undefined,
+  params: PomParameterInput,
   patterns: readonly PomStringPattern[],
   options: {
     omit?: readonly string[];
     defaultType?: string;
   } = {},
-): Record<string, string> {
-  const currentParams = params ?? {};
+): PomParameterSpec[] {
+  const currentParams = normalizePomParameters(params);
   const defaultType = options.defaultType ?? "string";
-  const orderedEntries: [string, string][] = [];
+  const orderedParams: PomParameterSpec[] = [];
   const seen = new Set<string>();
 
   for (const variableName of getPomPatternVariables(patterns, options)) {
     seen.add(variableName);
-    orderedEntries.push([variableName, currentParams[variableName] ?? defaultType]);
+    orderedParams.push(currentParams.find(param => param.name === variableName) ?? createPomParameterSpec(variableName, defaultType));
   }
 
-  for (const [name, typeExpr] of Object.entries(currentParams)) {
-    if (seen.has(name)) {
+  for (const param of currentParams) {
+    if (seen.has(param.name)) {
       continue;
     }
-    seen.add(name);
-    orderedEntries.push([name, typeExpr]);
+    seen.add(param.name);
+    orderedParams.push(param);
   }
 
-  return Object.fromEntries(orderedEntries);
+  return orderedParams;
 }
 
 export function getIndexedPomPatternVariable(pattern: PomStringPattern): string | null {

--- a/pom-patterns.ts
+++ b/pom-patterns.ts
@@ -4,6 +4,43 @@ export function isParameterizedPomPattern(kind: PomPatternKind): boolean {
   return kind === "parameterized";
 }
 
+export interface PomStringPattern {
+  formatted: string;
+  patternKind: PomPatternKind;
+}
+
 export function inferPomPatternKindFromFormattedString(value: string): PomPatternKind {
   return value.includes("${") ? "parameterized" : "static";
+}
+
+export function createPomStringPattern(formatted: string, patternKind: PomPatternKind): PomStringPattern {
+  return { formatted, patternKind };
+}
+
+export function inferPomStringPattern(formatted: string): PomStringPattern {
+  return createPomStringPattern(formatted, inferPomPatternKindFromFormattedString(formatted));
+}
+
+export function pomStringPatternEquals(left: PomStringPattern, right: PomStringPattern): boolean {
+  return left.formatted === right.formatted && left.patternKind === right.patternKind;
+}
+
+export function uniquePomStringPatterns(primary: PomStringPattern, alternates?: PomStringPattern[]): PomStringPattern[] {
+  const out: PomStringPattern[] = [];
+  const seen = new Set<string>();
+  const add = (pattern: PomStringPattern) => {
+    const key = JSON.stringify(pattern);
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    out.push(pattern);
+  };
+
+  add(primary);
+  for (const alternate of alternates ?? []) {
+    add(alternate);
+  }
+
+  return out;
 }

--- a/pom-patterns.ts
+++ b/pom-patterns.ts
@@ -1,4 +1,4 @@
-import { createPomParameterSpec, normalizePomParameters, type PomParameterInput, type PomParameterSpec } from "./pom-params";
+import { normalizePomParameters, type PomParameterInput, type PomParameterSpec } from "./pom-params";
 
 export type PomPatternKind = "static" | "parameterized";
 
@@ -70,22 +70,36 @@ export function getPomPatternVariables(
   return out;
 }
 
-export function ensurePomPatternParameters(
+export function orderPomPatternParameters(
   params: PomParameterInput,
   patterns: readonly PomStringPattern[],
   options: {
     omit?: readonly string[];
-    defaultType?: string;
   } = {},
 ): PomParameterSpec[] {
   const currentParams = normalizePomParameters(params);
-  const defaultType = options.defaultType ?? "string";
   const orderedParams: PomParameterSpec[] = [];
   const seen = new Set<string>();
+  const missingParams: string[] = [];
 
   for (const variableName of getPomPatternVariables(patterns, options)) {
     seen.add(variableName);
-    orderedParams.push(currentParams.find(param => param.name === variableName) ?? createPomParameterSpec(variableName, defaultType));
+    const existingParam = currentParams.find(param => param.name === variableName);
+    if (!existingParam) {
+      missingParams.push(variableName);
+      continue;
+    }
+    orderedParams.push(existingParam);
+  }
+
+  if (missingParams.length > 0) {
+    const availableParams = currentParams.map(param => JSON.stringify(param.name)).join(", ") || "<none>";
+    const patternSummary = patterns.map(pattern => JSON.stringify(pattern.formatted)).join(", ");
+    throw new Error(
+      `[vue-pom-generator] Missing selector parameter(s) ${missingParams.map(name => JSON.stringify(name)).join(", ")} `
+      + `for parameterized pattern(s) ${patternSummary}. `
+      + `Available parameters: ${availableParams}.`,
+    );
   }
 
   for (const param of currentParams) {

--- a/pom-patterns.ts
+++ b/pom-patterns.ts
@@ -1,0 +1,9 @@
+export type PomPatternKind = "static" | "parameterized";
+
+export function isParameterizedPomPattern(kind: PomPatternKind): boolean {
+  return kind === "parameterized";
+}
+
+export function inferPomPatternKindFromFormattedString(value: string): PomPatternKind {
+  return value.includes("${") ? "parameterized" : "static";
+}

--- a/routing/to-directive.ts
+++ b/routing/to-directive.ts
@@ -13,6 +13,31 @@ interface RouteLocationLike {
   params?: Record<string, string | number>;
 }
 
+interface RouteLocationTarget {
+  name?: string;
+  path?: string;
+}
+
+export type RouteDirectiveTargetAnalysis =
+  | {
+    kind: "resolved";
+    rawSource: string;
+    target: string | RouteLocationTarget;
+    routeNameKey: string | null;
+    paramKeys: string[];
+  }
+  | {
+    kind: "unsupported";
+    rawSource: string | null;
+    reason: "missing-expression" | "dynamic-expression" | "missing-name-or-path";
+  }
+  | {
+    kind: "parse-error";
+    rawSource: string;
+    reason: "parse-error";
+    error: string;
+  };
+
 type ResolveToComponentNameFn = (to: RouteLocationLike | string) => string | null;
 
 function toPascalCaseRouteKey(value: string): string {
@@ -65,51 +90,86 @@ function buildPlaceholderParams(keys: string[]): Record<string, string> {
   return params;
 }
 
-function getRouteLocationLikeFromToDirective(toDirective: DirectiveNode): RouteLocationLike | string | null {
-  if (!toDirective.exp)
-    return null;
+const isNodeType = (node: object | null, type: string): node is { type: string } => {
+  return node !== null && (node as { type?: string }).type === type;
+};
 
-  // Parse the JS expression with Babel and extract supported shapes.
-  const exp = toDirective.exp;
-  const rawSource = stringifyExpression(exp).trim();
+const isStringLiteralNode = (node: object | null): node is { type: "StringLiteral"; value: string } => {
+  return isNodeType(node, "StringLiteral") && typeof (node as { value?: string }).value === "string";
+};
+
+const isIdentifierNode = (node: object | null): node is { type: "Identifier"; name: string } => {
+  return isNodeType(node, "Identifier") && typeof (node as { name?: string }).name === "string";
+};
+
+const isObjectPropertyNode = (node: object | null): node is { type: "ObjectProperty"; key: object; value: object } => {
+  if (!isNodeType(node, "ObjectProperty"))
+    return false;
+  const n = node as { key?: object; value?: object };
+  return typeof n.key === "object" && n.key !== null && typeof n.value === "object" && n.value !== null;
+};
+
+const isObjectExpressionNode = (node: object | null): node is { type: "ObjectExpression"; properties: object[] } => {
+  if (!isNodeType(node, "ObjectExpression"))
+    return false;
+  const n = node as { properties?: object[] };
+  return Array.isArray(n.properties);
+};
+
+function materializeResolvedRouteTarget(
+  target: string | RouteLocationTarget,
+  paramKeys: string[],
+): RouteLocationLike | string {
+  if (typeof target === "string")
+    return target;
+  if (!paramKeys.length)
+    return target;
+  return {
+    ...target,
+    params: buildPlaceholderParams(paramKeys),
+  };
+}
+
+export function analyzeToDirectiveTarget(toDirective: DirectiveNode): RouteDirectiveTargetAnalysis {
+  if (!toDirective.exp) {
+    return {
+      kind: "unsupported",
+      rawSource: null,
+      reason: "missing-expression",
+    };
+  }
+
+  const rawSource = stringifyExpression(toDirective.exp).trim();
 
   let expr: object;
   try {
     expr = parseExpression(rawSource, { plugins: ["typescript"] });
   }
-  catch {
-    return null;
+  catch (error) {
+    return {
+      kind: "parse-error",
+      rawSource,
+      reason: "parse-error",
+      error: error instanceof Error ? error.message : String(error),
+    };
   }
 
-  const isNodeType = (node: object | null, type: string): node is { type: string } => {
-    return node !== null && (node as { type?: string }).type === type;
-  };
-  const isStringLiteralNode = (node: object | null): node is { type: "StringLiteral"; value: string } => {
-    return isNodeType(node, "StringLiteral") && typeof (node as { value?: string }).value === "string";
-  };
-  const isIdentifierNode = (node: object | null): node is { type: "Identifier"; name: string } => {
-    return isNodeType(node, "Identifier") && typeof (node as { name?: string }).name === "string";
-  };
-  const isObjectPropertyNode = (node: object | null): node is { type: "ObjectProperty"; key: object; value: object } => {
-    if (!isNodeType(node, "ObjectProperty"))
-      return false;
-    const n = node as { key?: object; value?: object };
-    return typeof n.key === "object" && n.key !== null && typeof n.value === "object" && n.value !== null;
-  };
-  const isObjectExpressionNode = (node: object | null): node is { type: "ObjectExpression"; properties: object[] } => {
-    if (!isNodeType(node, "ObjectExpression"))
-      return false;
-    const n = node as { properties?: object[] };
-    return Array.isArray(n.properties);
-  };
-
   if (isStringLiteralNode(expr)) {
-    // :to="'/some/path'"
-    return expr.value;
+    return {
+      kind: "resolved",
+      rawSource,
+      target: expr.value,
+      routeNameKey: null,
+      paramKeys: [],
+    };
   }
 
   if (!isObjectExpressionNode(expr)) {
-    return null;
+    return {
+      kind: "unsupported",
+      rawSource,
+      reason: "dynamic-expression",
+    };
   }
 
   const getStringField = (fieldName: "name" | "path") => {
@@ -134,7 +194,7 @@ function getRouteLocationLikeFromToDirective(toDirective: DirectiveNode): RouteL
     return (isIdentifierNode(key) && key.name === "params") || (isStringLiteralNode(key) && key.value === "params");
   });
 
-  let params: Record<string, string> | undefined;
+  let paramKeys: string[] = [];
   if (paramsProp && isObjectPropertyNode(paramsProp) && isObjectExpressionNode(paramsProp.value as object)) {
     const keys: string[] = [];
     for (const prop of (paramsProp.value as { properties: object[] }).properties) {
@@ -146,35 +206,42 @@ function getRouteLocationLikeFromToDirective(toDirective: DirectiveNode): RouteL
       else if (isStringLiteralNode(key))
         keys.push(key.value);
     }
-    if (keys.length) {
-      params = buildPlaceholderParams(Array.from(new Set(keys)));
-    }
+    paramKeys = Array.from(new Set(keys));
   }
 
   if (name) {
-    // Keep the router-facing name as-is (spaces etc). Normalization is only for codegen naming.
-    return { name, params };
+    const trimmed = name.trim();
+    if (!trimmed.length) {
+      return {
+        kind: "unsupported",
+        rawSource,
+        reason: "missing-name-or-path",
+      };
+    }
+    return {
+      kind: "resolved",
+      rawSource,
+      target: { name },
+      routeNameKey: toPascalCaseRouteKey(trimmed),
+      paramKeys,
+    };
   }
+
   if (path) {
-    return { path, params };
+    return {
+      kind: "resolved",
+      rawSource,
+      target: { path },
+      routeNameKey: null,
+      paramKeys,
+    };
   }
-  return null;
-}
 
-function toDirectiveObjectFieldNameValue(toDirective: DirectiveNode): string | null {
-  const to = getRouteLocationLikeFromToDirective(toDirective);
-  if (!to || typeof to === "string")
-    return null;
-
-  const name = to.name;
-  if (typeof name !== "string")
-    return null;
-
-  const trimmed = name.trim();
-  if (!trimmed.length)
-    return null;
-
-  return toPascalCaseRouteKey(trimmed);
+  return {
+    kind: "unsupported",
+    rawSource,
+    reason: "missing-name-or-path",
+  };
 }
 
 /**
@@ -185,14 +252,8 @@ function toDirectiveObjectFieldNameValue(toDirective: DirectiveNode): string | n
  * - :to="someVar" (cannot be resolved statically; returns null)
  */
 export function getRouteNameKeyFromToDirective(toDirective: DirectiveNode): string | null {
-  // Prefer object-literal `name: '...'` parsing.
-  const objectName = toDirectiveObjectFieldNameValue(toDirective);
-  if (objectName)
-    return objectName;
-
-  // If Vue provided an AST, we can sometimes detect { name: '...' } without regex.
-  // Currently we keep this conservative: if it isn't a literal object with name, return null.
-  return null;
+  const analysis = analyzeToDirectiveTarget(toDirective);
+  return analysis.kind === "resolved" ? analysis.routeNameKey : null;
 }
 
 /**
@@ -201,18 +262,18 @@ export function getRouteNameKeyFromToDirective(toDirective: DirectiveNode): stri
  * Returns the Vue component identifier (e.g. `TenantDetailsPage`) when available.
  */
 export function tryResolveToDirectiveTargetComponentName(toDirective: DirectiveNode): string | null {
+  const analysis = analyzeToDirectiveTarget(toDirective);
+
   // Prefer router.resolve (more accurate; can handle path or name + placeholder params).
-  const to = getRouteLocationLikeFromToDirective(toDirective);
-  if (to && resolveToComponentName) {
-    const resolved = resolveToComponentName(to);
+  if (analysis.kind === "resolved" && resolveToComponentName) {
+    const resolved = resolveToComponentName(materializeResolvedRouteTarget(analysis.target, analysis.paramKeys));
     if (resolved)
       return resolved;
   }
 
   // Fallback: route name -> component map (best-effort)
-  const key = getRouteNameKeyFromToDirective(toDirective);
-  if (!key || !routeNameToComponentName)
+  if (analysis.kind !== "resolved" || !analysis.routeNameKey || !routeNameToComponentName)
     return null;
 
-  return routeNameToComponentName.get(key) ?? null;
+  return routeNameToComponentName.get(analysis.routeNameKey) ?? null;
 }

--- a/sequence-diagram.md
+++ b/sequence-diagram.md
@@ -98,7 +98,7 @@ sequenceDiagram
         else Generate complex testId
             Transform->>Generators: generateTestId(node, context, toDirective, typeSubmit, key, componentName)
             Note over Generators: generateTestId Process
-            Generators->>Generators: getIdOrName(node) - extract id/name
+            Generators->>Generators: getStaticIdOrNameHint(node) - extract static id/name
             Generators->>Generators: getInnerText(node) - extract text content
             Generators->>Generators: Compose testId based on directives
             alt toDirective exists
@@ -165,7 +165,7 @@ Multiple specialized generators handle different element types:
 - `isOptionTagWithvalue()` - For option elements
 
 ### 4. **Helper Functions**
-- `getIdOrName()` - Extracts id/name attributes
+- `getStaticIdOrNameHint()` - Extracts static id/name attributes
 - `getInnerText()` - Extracts text content from children
 - `formatTagName()` - Formats tag suffix (e.g., "_btn")
 - `getComposedClickHandlerContent()` - Analyzes @click handlers

--- a/sequence-diagram.md
+++ b/sequence-diagram.md
@@ -83,14 +83,14 @@ sequenceDiagram
                 Transform->>Generators: getSelfClosingForDirectiveKeyAttrValue(node)
                 Generators-->>Transform: return key value or null
             else Not in for directive
-                Transform->>Generators: getContainedInVForDirectiveKeyValue(context)
-                Generators-->>Transform: return key value or null
+                Transform->>Generators: getContainedInVForDirectiveKeyInfo(context)
+                Generators-->>Transform: return selector/runtime key info or null
             end
         end
 
         alt No key found
-            Transform->>Generators: getKeyDirectiveValue(node)
-            Generators-->>Transform: return key placeholder or null
+            Transform->>Generators: getKeyDirectiveInfo(node)
+            Generators-->>Transform: return selector/runtime key info or null
         end
 
         alt keyAttributeValue contains placeholder

--- a/tests/base-page.test.ts
+++ b/tests/base-page.test.ts
@@ -1,0 +1,15 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { BasePage } from "../class-generation/base-page";
+
+describe("BasePage", () => {
+  it("exposes page.screencast through a getter", () => {
+    const screencast = { path: "/tmp/demo.webm" };
+    const page = { screencast } as any;
+
+    const basePage = new BasePage(page);
+
+    expect(basePage.screencast).toBe(screencast);
+  });
+});

--- a/tests/build-serve-parity.test.ts
+++ b/tests/build-serve-parity.test.ts
@@ -14,6 +14,7 @@ import type { CompilerOptions } from "@vue/compiler-dom";
 import * as compilerDom from "@vue/compiler-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { generateFiles } from "../class-generation";
+import { resolveGenerationSupportOptions, type ResolvedGenerationSupportOptions } from "../plugin/resolved-generation-options";
 import { createDevProcessorPlugin } from "../plugin/support/dev-plugin";
 
 // Mock generateFiles so the dev plugin doesn't try to write real files
@@ -87,6 +88,11 @@ function makeDevPlugin(
   overrides?: Record<string, unknown>,
 ) {
   const basePageClassPath = path.join(projectRoot, "base-page.ts");
+  const generationOverrides = (overrides?.generation as Partial<ResolvedGenerationSupportOptions> | undefined) ?? {};
+  const overrideEntries = { ...(overrides ?? {}) };
+  delete overrideEntries.generation;
+  const existingIdBehaviorOverride = overrideEntries.existingIdBehavior as ResolvedGenerationSupportOptions["existingIdBehavior"] | undefined;
+  delete overrideEntries.existingIdBehavior;
   return createDevProcessorPlugin({
     nativeWrappers: {},
     excludedComponents: [],
@@ -99,10 +105,14 @@ function makeDevPlugin(
     projectRootRef: { current: projectRoot },
     normalizedBasePagePath: path.posix.normalize(basePageClassPath),
     basePageClassPath,
-    customPomAttachments: [],
-    nameCollisionBehavior: "error",
-    testIdAttribute: "data-testid",
-    routerAwarePoms: false,
+    generation: resolveGenerationSupportOptions({
+      customPomAttachments: [],
+      nameCollisionBehavior: "error",
+      existingIdBehavior: existingIdBehaviorOverride,
+      testIdAttribute: "data-testid",
+      routerAwarePoms: false,
+      ...generationOverrides,
+    }),
     getResolvedRouterEntry: () => undefined,
     loggerRef: {
       current: {
@@ -111,7 +121,7 @@ function makeDevPlugin(
         warn() {},
       },
     },
-    ...overrides,
+    ...overrideEntries,
   } as any);
 }
 

--- a/tests/class-generation-coverage.test.ts
+++ b/tests/class-generation-coverage.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 
 import type { IComponentDependencies, IDataTestId } from "../utils";
 import { generateFiles } from "../class-generation";
-import { createPomMethodSignature, createPomParameters } from "../pom-params";
+import { createPomMethodSignature, createPomParameters, fromLegacyPomParameterRecord } from "../pom-params";
 import { createPomStringPattern } from "../pom-patterns";
 import { renderTypeScriptLines } from "../typescript-codegen";
 
@@ -646,7 +646,7 @@ describe("class-generation coverage", () => {
           methodName: "ItemsCheckByKey",
           selector: createPomStringPattern("items-check-${key}", "parameterized"),
           // Broken params as currently produced by utils.ts: key is absent
-          parameters: createPomParameters(["text", "string"], ["annotationText", "string = \"\""]),
+          parameters: fromLegacyPomParameterRecord({ text: "string", annotationText: "string = \"\"" }),
         },
       };
 
@@ -697,7 +697,7 @@ describe("class-generation coverage", () => {
           methodName: "ItemsCheckByKey",
           selector: createPomStringPattern("items-check-${itemId}", "parameterized"),
           // Simulate stale/manual IR that forgot to carry the selector variable name.
-          parameters: createPomParameters(["text", "string"], ["annotationText", "string = \"\""]),
+          parameters: fromLegacyPomParameterRecord({ text: "string", annotationText: "string = \"\"" }),
         },
       };
 

--- a/tests/class-generation-coverage.test.ts
+++ b/tests/class-generation-coverage.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 
 import type { IComponentDependencies, IDataTestId } from "../utils";
 import { generateFiles } from "../class-generation";
-import { createPomMethodSignature, createPomParameterSpec, normalizePomParameters } from "../pom-params";
+import { createPomMethodSignature, createPomParameters } from "../pom-params";
 import { createPomStringPattern } from "../pom-patterns";
 import { renderTypeScriptLines } from "../typescript-codegen";
 
@@ -270,7 +270,7 @@ describe("class-generation coverage", () => {
         isView: false,
         dataTestIdSet: new Set([{ selectorValue: createPomStringPattern("TenantDetailsEditForm-Name-input", "static") }]),
         generatedMethods: new Map([
-          ["typeTenantName", createPomMethodSignature([createPomParameterSpec("name", "string")])],
+          ["typeTenantName", createPomMethodSignature(createPomParameters(["name", "string"]))],
         ]),
       });
 
@@ -336,7 +336,7 @@ describe("class-generation coverage", () => {
         isView: false,
         dataTestIdSet: new Set([{ selectorValue: createPomStringPattern("TenantDetailsEditForm-Name-input", "static") }]),
         generatedMethods: new Map([
-          ["typeTenantName", createPomMethodSignature([createPomParameterSpec("name", "string")])],
+          ["typeTenantName", createPomMethodSignature(createPomParameters(["name", "string"]))],
         ]),
       });
 
@@ -646,7 +646,7 @@ describe("class-generation coverage", () => {
           methodName: "ItemsCheckByKey",
           selector: createPomStringPattern("items-check-${key}", "parameterized"),
           // Broken params as currently produced by utils.ts: key is absent
-          parameters: normalizePomParameters({ text: "string", annotationText: "string = \"\"" }),
+          parameters: createPomParameters(["text", "string"], ["annotationText", "string = \"\""]),
         },
       };
 
@@ -697,7 +697,7 @@ describe("class-generation coverage", () => {
           methodName: "ItemsCheckByKey",
           selector: createPomStringPattern("items-check-${itemId}", "parameterized"),
           // Simulate stale/manual IR that forgot to carry the selector variable name.
-          parameters: normalizePomParameters({ text: "string", annotationText: "string = \"\"" }),
+          parameters: createPomParameters(["text", "string"], ["annotationText", "string = \"\""]),
         },
       };
 
@@ -740,7 +740,7 @@ describe("class-generation coverage", () => {
           nativeRole: "input",
           methodName: "StateSelectedTenant",
           selector: createPomStringPattern("TenantSelectBox-StateSelectedTenant-input", "static"),
-          parameters: normalizePomParameters({ text: "string", annotationText: "string = \"\"" }),
+          parameters: createPomParameters(["text", "string"], ["annotationText", "string = \"\""]),
         },
       };
 
@@ -783,7 +783,7 @@ describe("class-generation coverage", () => {
           nativeRole: "button",
           methodName: "ValueByKey",
           selector: createPomStringPattern("NavHost-${key}-immynavitem", "parameterized"),
-          parameters: normalizePomParameters({ key: "string" }),
+          parameters: createPomParameters(["key", "string"]),
         },
         targetPageObjectModelClass: "UsersPage",
       };

--- a/tests/class-generation-coverage.test.ts
+++ b/tests/class-generation-coverage.test.ts
@@ -685,6 +685,50 @@ describe("class-generation coverage", () => {
     }
   });
 
+  it("C#: parameterized selectors recover non-key template variables from structured metadata", async () => {
+    const tempRoot = makeTempRoot("vue-pom-csharp-selector-vars-");
+
+    try {
+      const dt: IDataTestId = {
+        selectorValue: createPomStringPattern("items-check-${itemId}", "parameterized"),
+        pom: {
+          nativeRole: "input",
+          methodName: "ItemsCheckByKey",
+          selector: createPomStringPattern("items-check-${itemId}", "parameterized"),
+          // Simulate stale/manual IR that forgot to carry the selector variable name.
+          params: { text: "string", annotationText: "string = \"\"" },
+        },
+      };
+
+      const componentHierarchyMap = new Map<string, IComponentDependencies>([
+        [
+          "ItemsPage",
+          makeDeps({
+            filePath: path.join(tempRoot, "src", "views", "ItemsPage.vue"),
+            isView: true,
+            dataTestIdSet: new Set([dt]),
+          }),
+        ],
+      ]);
+
+      const outDir = path.join(tempRoot, "pom");
+      await generateFiles(componentHierarchyMap, new Map(), null as any, {
+        outDir,
+        emitLanguages: ["csharp"],
+        csharp: { namespace: "Test.Generated" },
+      });
+
+      const csFile = path.join(outDir, "page-object-models.g.cs");
+      const cs = readFile(csFile);
+
+      expect(cs).toContain("string itemId");
+      expect(cs).toContain("items-check-{itemId}");
+      expect(cs).toMatch(/ItemsCheckByKeyInput\(string itemId/);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("C#: input actions resolve editable descendants before filling text", async () => {
     const tempRoot = makeTempRoot("vue-pom-csharp-editable-locator-");
 

--- a/tests/class-generation-coverage.test.ts
+++ b/tests/class-generation-coverage.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 
 import type { IComponentDependencies, IDataTestId } from "../utils";
 import { generateFiles } from "../class-generation";
-import { createPomMethodSignature, normalizePomParameters } from "../pom-params";
+import { createPomMethodSignature, createPomParameterSpec, normalizePomParameters } from "../pom-params";
 import { createPomStringPattern } from "../pom-patterns";
 import { renderTypeScriptLines } from "../typescript-codegen";
 
@@ -270,7 +270,7 @@ describe("class-generation coverage", () => {
         isView: false,
         dataTestIdSet: new Set([{ selectorValue: createPomStringPattern("TenantDetailsEditForm-Name-input", "static") }]),
         generatedMethods: new Map([
-          ["typeTenantName", createPomMethodSignature({ name: "string" })],
+          ["typeTenantName", createPomMethodSignature([createPomParameterSpec("name", "string")])],
         ]),
       });
 
@@ -336,7 +336,7 @@ describe("class-generation coverage", () => {
         isView: false,
         dataTestIdSet: new Set([{ selectorValue: createPomStringPattern("TenantDetailsEditForm-Name-input", "static") }]),
         generatedMethods: new Map([
-          ["typeTenantName", createPomMethodSignature({ name: "string" })],
+          ["typeTenantName", createPomMethodSignature([createPomParameterSpec("name", "string")])],
         ]),
       });
 

--- a/tests/class-generation-coverage.test.ts
+++ b/tests/class-generation-coverage.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 
 import type { IComponentDependencies, IDataTestId } from "../utils";
 import { generateFiles } from "../class-generation";
+import { createPomStringPattern } from "../pom-patterns";
 import { renderTypeScriptLines } from "../typescript-codegen";
 
 function writeFile(filePath: string, content: string) {
@@ -253,7 +254,7 @@ describe("class-generation coverage", () => {
       );
 
       const dt: IDataTestId = {
-        value: "TenantListPage-NewTenant-routerlink",
+        selectorValue: createPomStringPattern("TenantListPage-NewTenant-routerlink", "static"),
         targetPageObjectModelClass: "NewTenantPage",
       };
 
@@ -266,7 +267,7 @@ describe("class-generation coverage", () => {
       const depsForm = makeDeps({
         filePath: path.join(tempRoot, "src", "components", "TenantDetailsEditForm.vue"),
         isView: false,
-        dataTestIdSet: new Set([{ value: "TenantDetailsEditForm-Name-input" }]),
+        dataTestIdSet: new Set([{ selectorValue: createPomStringPattern("TenantDetailsEditForm-Name-input", "static") }]),
         generatedMethods: new Map([
           ["typeTenantName", { params: "name: string", argNames: ["name"] }],
         ]),
@@ -318,7 +319,7 @@ describe("class-generation coverage", () => {
       );
 
       const navigationEntry: IDataTestId = {
-        value: "TenantListPage-NewTenant-routerlink",
+        selectorValue: createPomStringPattern("TenantListPage-NewTenant-routerlink", "static"),
         targetPageObjectModelClass: "NewTenantPage",
       };
 
@@ -332,7 +333,7 @@ describe("class-generation coverage", () => {
       const depsForm = makeDeps({
         filePath: path.join(tempRoot, "src", "components", "TenantDetailsEditForm.vue"),
         isView: false,
-        dataTestIdSet: new Set([{ value: "TenantDetailsEditForm-Name-input" }]),
+        dataTestIdSet: new Set([{ selectorValue: createPomStringPattern("TenantDetailsEditForm-Name-input", "static") }]),
         generatedMethods: new Map([
           ["typeTenantName", { params: "name: string", argNames: ["name"] }],
         ]),
@@ -438,7 +439,7 @@ describe("class-generation coverage", () => {
       const depsUsersView = makeDeps({
         filePath: path.join(tempRoot, "UsersView.vue"),
         isView: true,
-        dataTestIdSet: new Set([{ value: "UsersView-EnableSessionEmails-toggle" }]),
+        dataTestIdSet: new Set([{ selectorValue: createPomStringPattern("UsersView-EnableSessionEmails-toggle", "static") }]),
       });
 
       // Provide custom widget helpers so the generated file has imports for ToggleWidget.
@@ -529,7 +530,7 @@ describe("class-generation coverage", () => {
           makeDeps({
             filePath: viewPath,
             isView: true,
-            dataTestIdSet: new Set<IDataTestId>([{ value: "List-FetchData-button" }]),
+            dataTestIdSet: new Set<IDataTestId>([{ selectorValue: createPomStringPattern("List-FetchData-button", "static") }]),
           }),
         ],
       ]);
@@ -633,17 +634,16 @@ describe("class-generation coverage", () => {
     // `{key}` — causing a CS0103 compile error.  Both params must appear together.
     //
     // Simulate stale IR where params lacks `key` even though the selector is parameterized.
-    // The C# generator must add it when the formattedDataTestId contains `${key}`.
+    // The C# generator must add it when the structured selector is parameterized.
     const tempRoot = makeTempRoot("vue-pom-csharp-dyn-input-");
 
     try {
       const dt: IDataTestId = {
-        value: "items-check-${key}",
+        selectorValue: createPomStringPattern("items-check-${key}", "parameterized"),
         pom: {
           nativeRole: "input",
           methodName: "ItemsCheckByKey",
-          selectorPatternKind: "parameterized",
-          formattedDataTestId: "items-check-${key}",
+          selector: createPomStringPattern("items-check-${key}", "parameterized"),
           // Broken params as currently produced by utils.ts: key is absent
           params: { text: "string", annotationText: "string = \"\"" },
         },
@@ -690,12 +690,11 @@ describe("class-generation coverage", () => {
 
     try {
       const dt: IDataTestId = {
-        value: "TenantSelectBox-StateSelectedTenant-input",
+        selectorValue: createPomStringPattern("TenantSelectBox-StateSelectedTenant-input", "static"),
         pom: {
           nativeRole: "input",
           methodName: "StateSelectedTenant",
-          selectorPatternKind: "static",
-          formattedDataTestId: "TenantSelectBox-StateSelectedTenant-input",
+          selector: createPomStringPattern("TenantSelectBox-StateSelectedTenant-input", "static"),
           params: { text: "string", annotationText: "string = \"\"" },
         },
       };
@@ -734,25 +733,23 @@ describe("class-generation coverage", () => {
 
     try {
       const keyedNav: IDataTestId = {
-        value: "NavHost-${value}-immynavitem",
+        selectorValue: createPomStringPattern("NavHost-${value}-immynavitem", "parameterized"),
         pom: {
           nativeRole: "button",
           methodName: "ValueByKey",
-          selectorPatternKind: "parameterized",
-          formattedDataTestId: "NavHost-${key}-immynavitem",
+          selector: createPomStringPattern("NavHost-${key}-immynavitem", "parameterized"),
           params: { key: "string" },
         },
         targetPageObjectModelClass: "UsersPage",
       };
 
       const alternateNav: IDataTestId = {
-        value: "NavHost-SystemUpdate-routerlink",
+        selectorValue: createPomStringPattern("NavHost-SystemUpdate-routerlink", "static"),
         pom: {
           nativeRole: "button",
           methodName: "SystemUpdate",
-          selectorPatternKind: "static",
-          formattedDataTestId: "NavHost-SystemUpdate-routerlink",
-          alternateFormattedDataTestIds: ["NavHost-Update-routerlink"],
+          selector: createPomStringPattern("NavHost-SystemUpdate-routerlink", "static"),
+          alternateSelectors: [createPomStringPattern("NavHost-Update-routerlink", "static")],
           params: {},
         },
         targetPageObjectModelClass: "SystemUpdatePage",

--- a/tests/class-generation-coverage.test.ts
+++ b/tests/class-generation-coverage.test.ts
@@ -632,9 +632,8 @@ describe("class-generation coverage", () => {
     // emitting `(string text, string annotationText = "")` but the locator body referenced
     // `{key}` — causing a CS0103 compile error.  Both params must appear together.
     //
-    // Simulate the broken state: params lacks `key` (as utils.ts incorrectly deletes it
-    // for input elements with dynamic test IDs).  The C# generator must add it when the
-    // formattedDataTestId contains `${key}`.
+    // Simulate stale IR where params lacks `key` even though the selector is parameterized.
+    // The C# generator must add it when the formattedDataTestId contains `${key}`.
     const tempRoot = makeTempRoot("vue-pom-csharp-dyn-input-");
 
     try {
@@ -643,6 +642,7 @@ describe("class-generation coverage", () => {
         pom: {
           nativeRole: "input",
           methodName: "ItemsCheckByKey",
+          selectorPatternKind: "parameterized",
           formattedDataTestId: "items-check-${key}",
           // Broken params as currently produced by utils.ts: key is absent
           params: { text: "string", annotationText: "string = \"\"" },
@@ -694,6 +694,7 @@ describe("class-generation coverage", () => {
         pom: {
           nativeRole: "input",
           methodName: "StateSelectedTenant",
+          selectorPatternKind: "static",
           formattedDataTestId: "TenantSelectBox-StateSelectedTenant-input",
           params: { text: "string", annotationText: "string = \"\"" },
         },
@@ -737,6 +738,7 @@ describe("class-generation coverage", () => {
         pom: {
           nativeRole: "button",
           methodName: "ValueByKey",
+          selectorPatternKind: "parameterized",
           formattedDataTestId: "NavHost-${key}-immynavitem",
           params: { key: "string" },
         },
@@ -748,6 +750,7 @@ describe("class-generation coverage", () => {
         pom: {
           nativeRole: "button",
           methodName: "SystemUpdate",
+          selectorPatternKind: "static",
           formattedDataTestId: "NavHost-SystemUpdate-routerlink",
           alternateFormattedDataTestIds: ["NavHost-Update-routerlink"],
           params: {},

--- a/tests/class-generation-coverage.test.ts
+++ b/tests/class-generation-coverage.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 
 import type { IComponentDependencies, IDataTestId } from "../utils";
 import { generateFiles } from "../class-generation";
-import { createPomMethodSignature, createPomParameters, fromLegacyPomParameterRecord } from "../pom-params";
+import { createPomMethodSignature, createPomParameters } from "../pom-params";
 import { createPomStringPattern } from "../pom-patterns";
 import { renderTypeScriptLines } from "../typescript-codegen";
 
@@ -629,13 +629,7 @@ describe("class-generation coverage", () => {
     }
   });
 
-  it("C#: dynamic-test-id input element generates key+text params so the locator compiles", async () => {
-    // Regression: when an <input> has :data-testid="`...-${key}`", the C# generator was
-    // emitting `(string text, string annotationText = "")` but the locator body referenced
-    // `{key}` — causing a CS0103 compile error.  Both params must appear together.
-    //
-    // Simulate stale IR where params lacks `key` even though the selector is parameterized.
-    // The C# generator must add it when the structured selector is parameterized.
+  it("C#: fails fast when parameterized selectors omit key params", async () => {
     const tempRoot = makeTempRoot("vue-pom-csharp-dyn-input-");
 
     try {
@@ -645,8 +639,7 @@ describe("class-generation coverage", () => {
           nativeRole: "input",
           methodName: "ItemsCheckByKey",
           selector: createPomStringPattern("items-check-${key}", "parameterized"),
-          // Broken params as currently produced by utils.ts: key is absent
-          parameters: fromLegacyPomParameterRecord({ text: "string", annotationText: "string = \"\"" }),
+          parameters: createPomParameters(["text", "string"], ["annotationText", "string = \"\""]),
         },
       };
 
@@ -662,31 +655,17 @@ describe("class-generation coverage", () => {
       ]);
 
       const outDir = path.join(tempRoot, "pom");
-      await generateFiles(componentHierarchyMap, new Map(), null as any, {
+      await expect(generateFiles(componentHierarchyMap, new Map(), null as any, {
         outDir,
         emitLanguages: ["csharp"],
         csharp: { namespace: "Test.Generated" },
-      });
-
-      const csFile = path.join(outDir, "page-object-models.g.cs");
-      const cs = readFile(csFile);
-      const csGitAttributesPath = path.join(outDir, ".gitattributes");
-      expect(fs.existsSync(csGitAttributesPath)).toBe(true);
-      expect(readFile(csGitAttributesPath)).toContain("page-object-models.g.cs linguist-generated");
-
-      // The locator must include key as a parameter, not just text.
-      expect(cs).toContain("string key");
-      // Locator body must use {key} interpolation.
-      expect(cs).toContain("items-check-{key}");
-      // The method must compile: key must not be an undeclared reference.
-      // (If key appears only in the template but not in the signature, C# throws CS0103.)
-      expect(cs).toMatch(/ItemsCheckByKeyInput\(string key/);
+      })).rejects.toThrow(/Missing selector parameter\(s\) "key"/);
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }
   });
 
-  it("C#: parameterized selectors recover non-key template variables from structured metadata", async () => {
+  it("C#: fails fast when parameterized selectors omit non-key template variables", async () => {
     const tempRoot = makeTempRoot("vue-pom-csharp-selector-vars-");
 
     try {
@@ -697,7 +676,7 @@ describe("class-generation coverage", () => {
           methodName: "ItemsCheckByKey",
           selector: createPomStringPattern("items-check-${itemId}", "parameterized"),
           // Simulate stale/manual IR that forgot to carry the selector variable name.
-          parameters: fromLegacyPomParameterRecord({ text: "string", annotationText: "string = \"\"" }),
+          parameters: createPomParameters(["text", "string"], ["annotationText", "string = \"\""]),
         },
       };
 
@@ -713,18 +692,11 @@ describe("class-generation coverage", () => {
       ]);
 
       const outDir = path.join(tempRoot, "pom");
-      await generateFiles(componentHierarchyMap, new Map(), null as any, {
+      await expect(generateFiles(componentHierarchyMap, new Map(), null as any, {
         outDir,
         emitLanguages: ["csharp"],
         csharp: { namespace: "Test.Generated" },
-      });
-
-      const csFile = path.join(outDir, "page-object-models.g.cs");
-      const cs = readFile(csFile);
-
-      expect(cs).toContain("string itemId");
-      expect(cs).toContain("items-check-{itemId}");
-      expect(cs).toMatch(/ItemsCheckByKeyInput\(string itemId/);
+      })).rejects.toThrow(/Missing selector parameter\(s\) "itemId"/);
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }

--- a/tests/class-generation-coverage.test.ts
+++ b/tests/class-generation-coverage.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 
 import type { IComponentDependencies, IDataTestId } from "../utils";
 import { generateFiles } from "../class-generation";
+import { createPomMethodSignature, normalizePomParameters } from "../pom-params";
 import { createPomStringPattern } from "../pom-patterns";
 import { renderTypeScriptLines } from "../typescript-codegen";
 
@@ -269,7 +270,7 @@ describe("class-generation coverage", () => {
         isView: false,
         dataTestIdSet: new Set([{ selectorValue: createPomStringPattern("TenantDetailsEditForm-Name-input", "static") }]),
         generatedMethods: new Map([
-          ["typeTenantName", { params: "name: string", argNames: ["name"] }],
+          ["typeTenantName", createPomMethodSignature({ name: "string" })],
         ]),
       });
 
@@ -335,7 +336,7 @@ describe("class-generation coverage", () => {
         isView: false,
         dataTestIdSet: new Set([{ selectorValue: createPomStringPattern("TenantDetailsEditForm-Name-input", "static") }]),
         generatedMethods: new Map([
-          ["typeTenantName", { params: "name: string", argNames: ["name"] }],
+          ["typeTenantName", createPomMethodSignature({ name: "string" })],
         ]),
       });
 
@@ -645,7 +646,7 @@ describe("class-generation coverage", () => {
           methodName: "ItemsCheckByKey",
           selector: createPomStringPattern("items-check-${key}", "parameterized"),
           // Broken params as currently produced by utils.ts: key is absent
-          params: { text: "string", annotationText: "string = \"\"" },
+          parameters: normalizePomParameters({ text: "string", annotationText: "string = \"\"" }),
         },
       };
 
@@ -696,7 +697,7 @@ describe("class-generation coverage", () => {
           methodName: "ItemsCheckByKey",
           selector: createPomStringPattern("items-check-${itemId}", "parameterized"),
           // Simulate stale/manual IR that forgot to carry the selector variable name.
-          params: { text: "string", annotationText: "string = \"\"" },
+          parameters: normalizePomParameters({ text: "string", annotationText: "string = \"\"" }),
         },
       };
 
@@ -739,7 +740,7 @@ describe("class-generation coverage", () => {
           nativeRole: "input",
           methodName: "StateSelectedTenant",
           selector: createPomStringPattern("TenantSelectBox-StateSelectedTenant-input", "static"),
-          params: { text: "string", annotationText: "string = \"\"" },
+          parameters: normalizePomParameters({ text: "string", annotationText: "string = \"\"" }),
         },
       };
 
@@ -782,7 +783,7 @@ describe("class-generation coverage", () => {
           nativeRole: "button",
           methodName: "ValueByKey",
           selector: createPomStringPattern("NavHost-${key}-immynavitem", "parameterized"),
-          params: { key: "string" },
+          parameters: normalizePomParameters({ key: "string" }),
         },
         targetPageObjectModelClass: "UsersPage",
       };
@@ -794,7 +795,7 @@ describe("class-generation coverage", () => {
           methodName: "SystemUpdate",
           selector: createPomStringPattern("NavHost-SystemUpdate-routerlink", "static"),
           alternateSelectors: [createPomStringPattern("NavHost-Update-routerlink", "static")],
-          params: {},
+          parameters: [],
         },
         targetPageObjectModelClass: "SystemUpdatePage",
       };

--- a/tests/class-generation.test.ts
+++ b/tests/class-generation.test.ts
@@ -1,24 +1,24 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
 
-import { __internal } from "../utils";
+import { __internal, templateAttributeValue } from "../utils";
 
 describe("class-generation getMethodTools helpers", () => {
   it("replaces any ${...} interpolation with ${key}", () => {
-    expect(__internal.replaceAllTemplateExpressionsWithKey("submenu-item-${item.id}")).toBe("submenu-item-${key}");
-    expect(__internal.replaceAllTemplateExpressionsWithKey("Foo-${bar.baz}-routerlink")).toBe("Foo-${key}-routerlink");
+    expect(__internal.replaceAllTemplateExpressionsWithKey(templateAttributeValue("submenu-item-${item.id}"))).toBe("submenu-item-${key}");
+    expect(__internal.replaceAllTemplateExpressionsWithKey(templateAttributeValue("Foo-${bar.baz}-routerlink"))).toBe("Foo-${key}-routerlink");
   });
 
   it("replaces multiple and nested template expressions safely", () => {
     // Multiple expressions become multiple `${key}` placeholders
-    expect(__internal.replaceAllTemplateExpressionsWithKey("a-${x}-b-${y}-c")).toBe("a-${key}-b-${key}-c");
+    expect(__internal.replaceAllTemplateExpressionsWithKey(templateAttributeValue("a-${x}-b-${y}-c"))).toBe("a-${key}-b-${key}-c");
 
     // Nested braces inside an expression should be consumed as part of the expression
-    expect(__internal.replaceAllTemplateExpressionsWithKey("x-${fn({ a: 1, b: { c: 2 } })}-y")).toBe("x-${key}-y");
+    expect(__internal.replaceAllTemplateExpressionsWithKey(templateAttributeValue("x-${fn({ a: 1, b: { c: 2 } })}-y"))).toBe("x-${key}-y");
 
     // Expressions that contain `${...}` text inside string literals should not be split into fragments
     // (this simulates the real-world failure mode described in the generator comment)
-    expect(__internal.replaceAllTemplateExpressionsWithKey("x-${str.replace('${notATemplate}', 'ok')}-y")).toBe("x-${key}-y");
+    expect(__internal.replaceAllTemplateExpressionsWithKey(templateAttributeValue("x-${str.replace('${notATemplate}', 'ok')}-y"))).toBe("x-${key}-y");
   });
 
   it("creates a safe method name even with dynamic placeholders", () => {

--- a/tests/class-generation.test.ts
+++ b/tests/class-generation.test.ts
@@ -5,20 +5,20 @@ import { __internal, templateAttributeValue } from "../utils";
 
 describe("class-generation getMethodTools helpers", () => {
   it("replaces any ${...} interpolation with ${key}", () => {
-    expect(__internal.replaceAllTemplateExpressionsWithKey(templateAttributeValue("submenu-item-${item.id}"))).toBe("submenu-item-${key}");
-    expect(__internal.replaceAllTemplateExpressionsWithKey(templateAttributeValue("Foo-${bar.baz}-routerlink"))).toBe("Foo-${key}-routerlink");
+    expect(__internal.toPomKeyPattern(templateAttributeValue("submenu-item-${item.id}"))).toBe("submenu-item-${key}");
+    expect(__internal.toPomKeyPattern(templateAttributeValue("Foo-${bar.baz}-routerlink"))).toBe("Foo-${key}-routerlink");
   });
 
   it("replaces multiple and nested template expressions safely", () => {
     // Multiple expressions become multiple `${key}` placeholders
-    expect(__internal.replaceAllTemplateExpressionsWithKey(templateAttributeValue("a-${x}-b-${y}-c"))).toBe("a-${key}-b-${key}-c");
+    expect(__internal.toPomKeyPattern(templateAttributeValue("a-${x}-b-${y}-c"))).toBe("a-${key}-b-${key}-c");
 
     // Nested braces inside an expression should be consumed as part of the expression
-    expect(__internal.replaceAllTemplateExpressionsWithKey(templateAttributeValue("x-${fn({ a: 1, b: { c: 2 } })}-y"))).toBe("x-${key}-y");
+    expect(__internal.toPomKeyPattern(templateAttributeValue("x-${fn({ a: 1, b: { c: 2 } })}-y"))).toBe("x-${key}-y");
 
     // Expressions that contain `${...}` text inside string literals should not be split into fragments
     // (this simulates the real-world failure mode described in the generator comment)
-    expect(__internal.replaceAllTemplateExpressionsWithKey(templateAttributeValue("x-${str.replace('${notATemplate}', 'ok')}-y"))).toBe("x-${key}-y");
+    expect(__internal.toPomKeyPattern(templateAttributeValue("x-${str.replace('${notATemplate}', 'ok')}-y"))).toBe("x-${key}-y");
   });
 
   it("creates a safe method name even with dynamic placeholders", () => {

--- a/tests/dev-plugin-options.test.ts
+++ b/tests/dev-plugin-options.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveGenerationSupportOptions } from "../plugin/resolved-generation-options";
 import { createDevProcessorPlugin } from "../plugin/support/dev-plugin";
 import type { PlaywrightOutputStructure } from "../plugin/types";
 import type { IComponentDependencies, NativeWrappersMap } from "../utils";
@@ -11,7 +12,6 @@ import type { IComponentDependencies, NativeWrappersMap } from "../utils";
 interface CreateTestIdTransformOptions {
   existingIdBehavior?: string;
   nameCollisionBehavior?: string;
-  missingSemanticNameBehavior?: string;
   testIdAttribute?: string;
   warn?: (message: string) => void;
   vueFilesPathMap?: Map<string, string>;
@@ -112,12 +112,13 @@ describe("dev processor option plumbing", () => {
         projectRootRef: { current: projectRoot },
         normalizedBasePagePath: path.posix.normalize(basePageClassPath),
         basePageClassPath,
-        customPomAttachments: [],
-        nameCollisionBehavior: "error",
-        missingSemanticNameBehavior: "error",
-        typescriptOutputStructure: "split",
-        testIdAttribute: "data-testid",
-        routerAwarePoms: false,
+        generation: resolveGenerationSupportOptions({
+          customPomAttachments: [],
+          nameCollisionBehavior: "error",
+          typescriptOutputStructure: "split",
+          testIdAttribute: "data-testid",
+          routerAwarePoms: false,
+        }),
         getResolvedRouterEntry: () => undefined,
         loggerRef: {
           current: {
@@ -147,9 +148,8 @@ describe("dev processor option plumbing", () => {
 
       expect(transformCall[4]).toBe(path.resolve(projectRoot, "src", "views"));
       expect(transformOptions).toMatchObject({
-        existingIdBehavior: "preserve",
+        existingIdBehavior: "error",
         nameCollisionBehavior: "error",
-        missingSemanticNameBehavior: "error",
         testIdAttribute: "data-testid",
         wrapperSearchRoots,
       });
@@ -176,7 +176,7 @@ describe("dev processor option plumbing", () => {
     }
   });
 
-  it("defaults missingSemanticNameBehavior to error when strictness is not overridden", async () => {
+  it("does not pass a legacy semantic fallback override into the transform", async () => {
     const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vue-pom-generator-dev-default-strict-"));
 
     try {
@@ -199,10 +199,12 @@ describe("dev processor option plumbing", () => {
         projectRootRef: { current: projectRoot },
         normalizedBasePagePath: path.posix.normalize(path.join(projectRoot, "base-page.ts")),
         basePageClassPath: path.join(projectRoot, "base-page.ts"),
-        customPomAttachments: [],
-        nameCollisionBehavior: "error",
-        testIdAttribute: "data-testid",
-        routerAwarePoms: false,
+        generation: resolveGenerationSupportOptions({
+          customPomAttachments: [],
+          nameCollisionBehavior: "error",
+          testIdAttribute: "data-testid",
+          routerAwarePoms: false,
+        }),
         getResolvedRouterEntry: () => undefined,
         loggerRef: {
           current: {
@@ -227,7 +229,7 @@ describe("dev processor option plumbing", () => {
         throw new Error("Expected createTestIdTransform to be called");
       }
 
-      expect(transformCall[5]?.missingSemanticNameBehavior).toBe("error");
+      expect(Object.prototype.hasOwnProperty.call(transformCall[5] ?? {}, "missingSemanticNameBehavior")).toBe(false);
     }
     finally {
       fs.rmSync(projectRoot, { recursive: true, force: true });
@@ -263,10 +265,12 @@ describe("dev processor option plumbing", () => {
         projectRootRef: { current: projectRoot },
         normalizedBasePagePath: path.posix.normalize(path.join(projectRoot, "base-page.ts")),
         basePageClassPath: path.join(projectRoot, "base-page.ts"),
-        customPomAttachments: [],
-        nameCollisionBehavior: "error",
-        testIdAttribute: "data-testid",
-        routerAwarePoms: false,
+        generation: resolveGenerationSupportOptions({
+          customPomAttachments: [],
+          nameCollisionBehavior: "error",
+          testIdAttribute: "data-testid",
+          routerAwarePoms: false,
+        }),
         getResolvedRouterEntry: () => undefined,
         loggerRef: {
           current: {

--- a/tests/fixtures/generated-tsc/playwright.d.ts
+++ b/tests/fixtures/generated-tsc/playwright.d.ts
@@ -1,0 +1,3 @@
+/* eslint-disable */
+export type Page = any;
+export type Locator = any;

--- a/tests/generated-tsc.test.ts
+++ b/tests/generated-tsc.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import type { IComponentDependencies, IDataTestId } from "../utils";
 import { generateFiles } from "../class-generation";
-import { createPomMethodSignature, createPomParameterSpec, normalizePomParameters } from "../pom-params";
+import { createPomMethodSignature, createPomParameters } from "../pom-params";
 import { createPomStringPattern } from "../pom-patterns";
 import { renderTypeScriptLines } from "../typescript-codegen";
 
@@ -88,7 +88,7 @@ describe("generated output", () => {
         nativeRole: "button",
         methodName: "SaveButton",
         selector: createPomStringPattern(formattedDataTestId, "parameterized"),
-        parameters: normalizePomParameters({ key: "string" }),
+        parameters: createPomParameters(["key", "string"]),
       },
     };
 
@@ -107,7 +107,7 @@ describe("generated output", () => {
             label: createPomStringPattern("Cloud", "static"),
             exact: true,
           },
-          parameters: normalizePomParameters({ annotationText: "string = \"\"" }),
+          parameters: createPomParameters(["annotationText", "string = \"\""]),
         },
       ],
       generatedMethods: new Map(),
@@ -157,7 +157,7 @@ describe("generated output", () => {
         methodName: "ItemsCheckByKey",
         selector: createPomStringPattern("items-check-${key}", "parameterized"),
         // Simulate stale IR that predates the structured selector object and forgot to carry `key`.
-        parameters: normalizePomParameters({ text: "string", annotationText: 'string = ""' }),
+        parameters: createPomParameters(["text", "string"], ["annotationText", 'string = ""']),
       },
     };
 
@@ -205,7 +205,7 @@ describe("generated output", () => {
         methodName: "ItemsCheckByKey",
         selector: createPomStringPattern("items-check-${itemId}", "parameterized"),
         // Simulate stale/manual IR that forgot to carry the selector variable name.
-        parameters: normalizePomParameters({ text: "string", annotationText: 'string = ""' }),
+        parameters: createPomParameters(["text", "string"], ["annotationText", 'string = ""']),
       },
     };
 
@@ -281,11 +281,11 @@ describe("generated output", () => {
           nativeRole: "input",
           methodName: "TenantName",
           selector: createPomStringPattern("TenantDetailsEditForm-Name-input", "static"),
-          parameters: normalizePomParameters({ text: "string", annotationText: 'string = ""' }),
+          parameters: createPomParameters(["text", "string"], ["annotationText", 'string = ""']),
         },
       }]),
       generatedMethods: new Map([
-        ["typeTenantName", createPomMethodSignature([createPomParameterSpec("name", "string")])],
+        ["typeTenantName", createPomMethodSignature(createPomParameters(["name", "string"]))],
       ]),
       isView: false,
     };
@@ -709,7 +709,7 @@ describe("generated output", () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set([childAEntry]),
-      generatedMethods: new Map([["clickOnlyInAButton", createPomMethodSignature([createPomParameterSpec("wait", "boolean = true")])]]),
+      generatedMethods: new Map([["clickOnlyInAButton", createPomMethodSignature(createPomParameters(["wait", "boolean = true"]))]]),
       isView: false,
     };
 
@@ -718,7 +718,7 @@ describe("generated output", () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set([childBEntry]),
-      generatedMethods: new Map([["clickSomethingElseButton", createPomMethodSignature([createPomParameterSpec("wait", "boolean = true")])]]),
+      generatedMethods: new Map([["clickSomethingElseButton", createPomMethodSignature(createPomParameters(["wait", "boolean = true"]))]]),
       isView: false,
     };
 

--- a/tests/generated-tsc.test.ts
+++ b/tests/generated-tsc.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import type { IComponentDependencies, IDataTestId } from "../utils";
 import { generateFiles } from "../class-generation";
-import { createPomMethodSignature, createPomParameters } from "../pom-params";
+import { createPomMethodSignature, createPomParameters, fromLegacyPomParameterRecord } from "../pom-params";
 import { createPomStringPattern } from "../pom-patterns";
 import { renderTypeScriptLines } from "../typescript-codegen";
 
@@ -157,7 +157,7 @@ describe("generated output", () => {
         methodName: "ItemsCheckByKey",
         selector: createPomStringPattern("items-check-${key}", "parameterized"),
         // Simulate stale IR that predates the structured selector object and forgot to carry `key`.
-        parameters: createPomParameters(["text", "string"], ["annotationText", 'string = ""']),
+        parameters: fromLegacyPomParameterRecord({ text: "string", annotationText: 'string = ""' }),
       },
     };
 
@@ -205,7 +205,7 @@ describe("generated output", () => {
         methodName: "ItemsCheckByKey",
         selector: createPomStringPattern("items-check-${itemId}", "parameterized"),
         // Simulate stale/manual IR that forgot to carry the selector variable name.
-        parameters: createPomParameters(["text", "string"], ["annotationText", 'string = ""']),
+        parameters: fromLegacyPomParameterRecord({ text: "string", annotationText: 'string = ""' }),
       },
     };
 

--- a/tests/generated-tsc.test.ts
+++ b/tests/generated-tsc.test.ts
@@ -187,6 +187,55 @@ describe("generated output", () => {
     }
   });
 
+  it("typechecks parameterized input methods when selector vars are not named key", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vue-pom-generator-selector-vars-"));
+
+    writePlaywrightTypeStub(tempRoot);
+
+    const basePagePath = path.join(tempRoot, "base-page.ts");
+    copyRepoFixture(tempRoot, "base-page.full.ts", "base-page.ts");
+    copyRepoFixture(tempRoot, "pointer.ts", "pointer.ts");
+
+    const componentName = "ItemsPage";
+    const dataTestIdEntry: IDataTestId = {
+      selectorValue: createPomStringPattern("items-check-${itemId}", "parameterized"),
+      pom: {
+        nativeRole: "input",
+        methodName: "ItemsCheckByKey",
+        selector: createPomStringPattern("items-check-${itemId}", "parameterized"),
+        // Simulate stale/manual IR that forgot to carry the selector variable name.
+        params: { text: "string", annotationText: 'string = ""' },
+      },
+    };
+
+    const deps: IComponentDependencies = {
+      filePath: path.join(tempRoot, `${componentName}.vue`),
+      childrenComponentSet: new Set(),
+      usedComponentSet: new Set(),
+      dataTestIdSet: new Set([dataTestIdEntry]),
+      generatedMethods: new Map(),
+      isView: false,
+    };
+
+    const outDir = path.join(tempRoot, "out");
+    await generateFiles(new Map([[componentName, deps]]), new Map(), basePagePath, {
+      outDir,
+      projectRoot: tempRoot,
+    });
+
+    const generatedFilePath = path.join(outDir, "page-object-models.g.ts");
+    const generatedContent = fs.readFileSync(generatedFilePath, "utf8");
+    expect(generatedContent).toMatch(/async typeItemsCheckByKey\(itemId: string, text: string, annotationText: string = ""\)/);
+    expect(generatedContent).toContain("keyedLocators((itemId: string) => this.locatorByTestId(`items-check-${itemId}`))");
+
+    const result = runTscNoEmit([generatedFilePath, basePagePath], { cwd: tempRoot });
+    if (result.status !== 0) {
+      const stdout = (result.stdout || "").toString();
+      const stderr = (result.stderr || "").toString();
+      throw new Error(`tsc failed (exit ${result.status})\n\nSTDOUT:\n${stdout}\n\nSTDERR:\n${stderr}`);
+    }
+  });
+
   it("typechecks split TypeScript output with barrel exports and stub targets", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vue-pom-generator-split-"));
 

--- a/tests/generated-tsc.test.ts
+++ b/tests/generated-tsc.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import type { IComponentDependencies, IDataTestId } from "../utils";
 import { generateFiles } from "../class-generation";
+import { createPomMethodSignature, normalizePomParameters } from "../pom-params";
 import { createPomStringPattern } from "../pom-patterns";
 import { renderTypeScriptLines } from "../typescript-codegen";
 
@@ -87,7 +88,7 @@ describe("generated output", () => {
         nativeRole: "button",
         methodName: "SaveButton",
         selector: createPomStringPattern(formattedDataTestId, "parameterized"),
-        params: { key: "string" },
+        parameters: normalizePomParameters({ key: "string" }),
       },
     };
 
@@ -106,7 +107,7 @@ describe("generated output", () => {
             label: createPomStringPattern("Cloud", "static"),
             exact: true,
           },
-          params: { annotationText: "string = \"\"" },
+          parameters: normalizePomParameters({ annotationText: "string = \"\"" }),
         },
       ],
       generatedMethods: new Map(),
@@ -156,7 +157,7 @@ describe("generated output", () => {
         methodName: "ItemsCheckByKey",
         selector: createPomStringPattern("items-check-${key}", "parameterized"),
         // Simulate stale IR that predates the structured selector object and forgot to carry `key`.
-        params: { text: "string", annotationText: 'string = ""' },
+        parameters: normalizePomParameters({ text: "string", annotationText: 'string = ""' }),
       },
     };
 
@@ -204,7 +205,7 @@ describe("generated output", () => {
         methodName: "ItemsCheckByKey",
         selector: createPomStringPattern("items-check-${itemId}", "parameterized"),
         // Simulate stale/manual IR that forgot to carry the selector variable name.
-        params: { text: "string", annotationText: 'string = ""' },
+        parameters: normalizePomParameters({ text: "string", annotationText: 'string = ""' }),
       },
     };
 
@@ -257,7 +258,7 @@ describe("generated output", () => {
         nativeRole: "button",
         methodName: "NewTenant",
         selector: createPomStringPattern("TenantListPage-NewTenant-routerlink", "static"),
-        params: {},
+        parameters: [],
       },
     };
 
@@ -280,11 +281,11 @@ describe("generated output", () => {
           nativeRole: "input",
           methodName: "TenantName",
           selector: createPomStringPattern("TenantDetailsEditForm-Name-input", "static"),
-          params: { text: "string", annotationText: 'string = ""' },
+          parameters: normalizePomParameters({ text: "string", annotationText: 'string = ""' }),
         },
       }]),
       generatedMethods: new Map([
-        ["typeTenantName", { params: "name: string", argNames: ["name"] }],
+        ["typeTenantName", createPomMethodSignature({ name: "string" })],
       ]),
       isView: false,
     };
@@ -675,7 +676,7 @@ describe("generated output", () => {
         nativeRole: "button",
         methodName: "OnlyInAButton",
         selector: createPomStringPattern("ChildA-OnlyInA-button", "static"),
-        params: {},
+        parameters: [],
       },
     };
 
@@ -685,7 +686,7 @@ describe("generated output", () => {
         nativeRole: "button",
         methodName: "SomethingElseButton",
         selector: createPomStringPattern("ChildB-SomethingElse-button", "static"),
-        params: {},
+        parameters: [],
       },
     };
 
@@ -703,7 +704,7 @@ describe("generated output", () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set([childAEntry]),
-      generatedMethods: new Map([["clickOnlyInAButton", { params: "wait: boolean = true", argNames: ["wait"] }]]),
+      generatedMethods: new Map([["clickOnlyInAButton", createPomMethodSignature({ wait: "boolean = true" })]]),
       isView: false,
     };
 
@@ -712,7 +713,7 @@ describe("generated output", () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set([childBEntry]),
-      generatedMethods: new Map([["clickSomethingElseButton", { params: "wait: boolean = true", argNames: ["wait"] }]]),
+      generatedMethods: new Map([["clickSomethingElseButton", createPomMethodSignature({ wait: "boolean = true" })]]),
       isView: false,
     };
 

--- a/tests/generated-tsc.test.ts
+++ b/tests/generated-tsc.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import type { IComponentDependencies, IDataTestId } from "../utils";
 import { generateFiles } from "../class-generation";
+import { createPomStringPattern } from "../pom-patterns";
 import { renderTypeScriptLines } from "../typescript-codegen";
 
 function extractClassBlock(content: string, className: string): string {
@@ -81,12 +82,11 @@ describe("generated output", () => {
 
     const formattedDataTestId = "TestComponent-${key}-Save-button";
     const dataTestIdEntry: IDataTestId = {
-      value: formattedDataTestId,
+      selectorValue: createPomStringPattern(formattedDataTestId, "parameterized"),
       pom: {
         nativeRole: "button",
         methodName: "SaveButton",
-        selectorPatternKind: "parameterized",
-        formattedDataTestId,
+        selector: createPomStringPattern(formattedDataTestId, "parameterized"),
         params: { key: "string" },
       },
     };
@@ -102,10 +102,8 @@ describe("generated output", () => {
           name: "selectDatabaseTypeCloud",
           selector: {
             kind: "withinTestIdByLabel",
-            rootFormattedDataTestId: "TestComponent-databaseType-radio",
-            rootPatternKind: "static",
-            formattedLabel: "Cloud",
-            labelPatternKind: "static",
+            rootTestId: createPomStringPattern("TestComponent-databaseType-radio", "static"),
+            label: createPomStringPattern("Cloud", "static"),
             exact: true,
           },
           params: { annotationText: "string = \"\"" },
@@ -152,13 +150,12 @@ describe("generated output", () => {
 
     const componentName = "ItemsPage";
     const dataTestIdEntry: IDataTestId = {
-      value: "items-check-${key}",
+      selectorValue: createPomStringPattern("items-check-${key}", "parameterized"),
       pom: {
         nativeRole: "input",
         methodName: "ItemsCheckByKey",
-        selectorPatternKind: "parameterized",
-        formattedDataTestId: "items-check-${key}",
-        // Simulate stale IR that predates selectorPatternKind and forgot to carry `key`.
+        selector: createPomStringPattern("items-check-${key}", "parameterized"),
+        // Simulate stale IR that predates the structured selector object and forgot to carry `key`.
         params: { text: "string", annotationText: 'string = ""' },
       },
     };
@@ -205,13 +202,12 @@ describe("generated output", () => {
     );
 
     const navigationEntry: IDataTestId = {
-      value: "TenantListPage-NewTenant-routerlink",
+      selectorValue: createPomStringPattern("TenantListPage-NewTenant-routerlink", "static"),
       targetPageObjectModelClass: "NewTenantPage",
       pom: {
         nativeRole: "button",
         methodName: "NewTenant",
-        selectorPatternKind: "static",
-        formattedDataTestId: "TenantListPage-NewTenant-routerlink",
+        selector: createPomStringPattern("TenantListPage-NewTenant-routerlink", "static"),
         params: {},
       },
     };
@@ -230,12 +226,11 @@ describe("generated output", () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set([{
-        value: "TenantDetailsEditForm-Name-input",
+        selectorValue: createPomStringPattern("TenantDetailsEditForm-Name-input", "static"),
         pom: {
           nativeRole: "input",
           methodName: "TenantName",
-          selectorPatternKind: "static",
-          formattedDataTestId: "TenantDetailsEditForm-Name-input",
+          selector: createPomStringPattern("TenantDetailsEditForm-Name-input", "static"),
           params: { text: "string", annotationText: 'string = ""' },
         },
       }]),
@@ -451,7 +446,7 @@ describe("generated output", () => {
       usedComponentSet: new Set(["ImmyDxDataGrid"]),
       dataTestIdSet: new Set([
         {
-          value: "UsersTable-Refresh-button",
+          selectorValue: createPomStringPattern("UsersTable-Refresh-button", "static"),
         },
       ]),
       generatedMethods: new Map(),
@@ -520,7 +515,7 @@ describe("generated output", () => {
       usedComponentSet: new Set(["Page", "ImmyDxDataGrid"]),
       dataTestIdSet: new Set([
         {
-          value: "UsersView-EnableSessionEmails-toggle",
+          selectorValue: createPomStringPattern("UsersView-EnableSessionEmails-toggle", "static"),
         },
       ]),
       generatedMethods: new Map(),
@@ -626,23 +621,21 @@ describe("generated output", () => {
     const childB = "ChildB";
 
     const childAEntry: IDataTestId = {
-      value: "ChildA-OnlyInA-button",
+      selectorValue: createPomStringPattern("ChildA-OnlyInA-button", "static"),
       pom: {
         nativeRole: "button",
         methodName: "OnlyInAButton",
-        selectorPatternKind: "static",
-        formattedDataTestId: "ChildA-OnlyInA-button",
+        selector: createPomStringPattern("ChildA-OnlyInA-button", "static"),
         params: {},
       },
     };
 
     const childBEntry: IDataTestId = {
-      value: "ChildB-SomethingElse-button",
+      selectorValue: createPomStringPattern("ChildB-SomethingElse-button", "static"),
       pom: {
         nativeRole: "button",
         methodName: "SomethingElseButton",
-        selectorPatternKind: "static",
-        formattedDataTestId: "ChildB-SomethingElse-button",
+        selector: createPomStringPattern("ChildB-SomethingElse-button", "static"),
         params: {},
       },
     };

--- a/tests/generated-tsc.test.ts
+++ b/tests/generated-tsc.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import type { IComponentDependencies, IDataTestId } from "../utils";
 import { generateFiles } from "../class-generation";
-import { createPomMethodSignature, createPomParameters, fromLegacyPomParameterRecord } from "../pom-params";
+import { createPomMethodSignature, createPomParameters } from "../pom-params";
 import { createPomStringPattern } from "../pom-patterns";
 import { renderTypeScriptLines } from "../typescript-codegen";
 
@@ -38,6 +38,7 @@ function copyRepoFixture(rootDir: string, fixtureName: string, destinationRelati
 }
 
 function writePlaywrightTypeStub(rootDir: string) {
+  copyRepoFixture(rootDir, "playwright.d.ts", path.join("node_modules", "playwright", "index.d.ts"));
   copyRepoFixture(rootDir, "playwright-test.d.ts", path.join("node_modules", "@playwright", "test", "index.d.ts"));
 }
 
@@ -140,7 +141,7 @@ describe("generated output", () => {
     }
   });
 
-  it("typechecks parameterized input methods even when stale IR omits key params", async () => {
+  it("fails fast when parameterized input methods omit key params", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vue-pom-generator-keyed-input-"));
 
     writePlaywrightTypeStub(tempRoot);
@@ -156,8 +157,8 @@ describe("generated output", () => {
         nativeRole: "input",
         methodName: "ItemsCheckByKey",
         selector: createPomStringPattern("items-check-${key}", "parameterized"),
-        // Simulate stale IR that predates the structured selector object and forgot to carry `key`.
-        parameters: fromLegacyPomParameterRecord({ text: "string", annotationText: 'string = ""' }),
+        // Simulate stale/manual IR that forgot to carry the selector parameter.
+        parameters: createPomParameters(["text", "string"], ["annotationText", 'string = ""']),
       },
     };
 
@@ -171,24 +172,13 @@ describe("generated output", () => {
     };
 
     const outDir = path.join(tempRoot, "out");
-    await generateFiles(new Map([[componentName, deps]]), new Map(), basePagePath, {
+    await expect(generateFiles(new Map([[componentName, deps]]), new Map(), basePagePath, {
       outDir,
       projectRoot: tempRoot,
-    });
-
-    const generatedFilePath = path.join(outDir, "page-object-models.g.ts");
-    const generatedContent = fs.readFileSync(generatedFilePath, "utf8");
-    expect(generatedContent).toMatch(/async typeItemsCheckByKey\(key: string, text: string, annotationText: string = ""\)/);
-
-    const result = runTscNoEmit([generatedFilePath, basePagePath], { cwd: tempRoot });
-    if (result.status !== 0) {
-      const stdout = (result.stdout || "").toString();
-      const stderr = (result.stderr || "").toString();
-      throw new Error(`tsc failed (exit ${result.status})\n\nSTDOUT:\n${stdout}\n\nSTDERR:\n${stderr}`);
-    }
+    })).rejects.toThrow(/Missing selector parameter\(s\) "key"/);
   });
 
-  it("typechecks parameterized input methods when selector vars are not named key", async () => {
+  it("fails fast when parameterized input methods omit non-key selector vars", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vue-pom-generator-selector-vars-"));
 
     writePlaywrightTypeStub(tempRoot);
@@ -205,7 +195,7 @@ describe("generated output", () => {
         methodName: "ItemsCheckByKey",
         selector: createPomStringPattern("items-check-${itemId}", "parameterized"),
         // Simulate stale/manual IR that forgot to carry the selector variable name.
-        parameters: fromLegacyPomParameterRecord({ text: "string", annotationText: 'string = ""' }),
+        parameters: createPomParameters(["text", "string"], ["annotationText", 'string = ""']),
       },
     };
 
@@ -219,22 +209,10 @@ describe("generated output", () => {
     };
 
     const outDir = path.join(tempRoot, "out");
-    await generateFiles(new Map([[componentName, deps]]), new Map(), basePagePath, {
+    await expect(generateFiles(new Map([[componentName, deps]]), new Map(), basePagePath, {
       outDir,
       projectRoot: tempRoot,
-    });
-
-    const generatedFilePath = path.join(outDir, "page-object-models.g.ts");
-    const generatedContent = fs.readFileSync(generatedFilePath, "utf8");
-    expect(generatedContent).toMatch(/async typeItemsCheckByKey\(itemId: string, text: string, annotationText: string = ""\)/);
-    expect(generatedContent).toContain("keyedLocators((itemId: string) => this.locatorByTestId(`items-check-${itemId}`))");
-
-    const result = runTscNoEmit([generatedFilePath, basePagePath], { cwd: tempRoot });
-    if (result.status !== 0) {
-      const stdout = (result.stdout || "").toString();
-      const stderr = (result.stderr || "").toString();
-      throw new Error(`tsc failed (exit ${result.status})\n\nSTDOUT:\n${stdout}\n\nSTDERR:\n${stderr}`);
-    }
+    })).rejects.toThrow(/Missing selector parameter\(s\) "itemId"/);
   });
 
   it("typechecks split TypeScript output with barrel exports and stub targets", async () => {
@@ -544,7 +522,7 @@ describe("generated output", () => {
     }
   });
 
-  it("skips missing custom helper attachments and widget instances when no helper files exist", async () => {
+  it("fails when configured custom helper infrastructure is missing", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vue-pom-generator-"));
 
     writePlaywrightTypeStub(tempRoot);
@@ -581,10 +559,11 @@ describe("generated output", () => {
     const vueFilesPathMap = new Map<string, string>();
     const outDir = path.join(tempRoot, "out");
 
-    await generateFiles(componentHierarchyMap, vueFilesPathMap, basePagePath, {
+    await expect(generateFiles(componentHierarchyMap, vueFilesPathMap, basePagePath, {
       outDir,
       projectRoot: tempRoot,
       customPomDir: "tests/playwright/pom/custom",
+      requireCustomPomDir: true,
       customPomAttachments: [
         {
           className: "Grid",
@@ -600,25 +579,7 @@ describe("generated output", () => {
           flatten: true,
         },
       ],
-    });
-
-    const generatedFile = path.join(outDir, "page-object-models.g.ts");
-    const generatedContent = fs.readFileSync(generatedFile, "utf8");
-
-    expect(generatedContent).not.toContain("ToggleWidget");
-    expect(generatedContent).not.toContain("CheckboxWidget");
-    expect(generatedContent).not.toContain("new Grid(");
-    expect(generatedContent).not.toContain("new ConfirmationModal(");
-    expect(generatedContent).not.toContain("return this.grid.");
-    expect(generatedContent).not.toContain("return this.confirmationModal.");
-
-    const result = runTscNoEmit([generatedFile, basePagePath], { cwd: tempRoot });
-
-    if (result.status !== 0) {
-      const stdout = (result.stdout || "").toString();
-      const stderr = (result.stderr || "").toString();
-      throw new Error(`tsc failed (exit ${result.status})\n\nSTDOUT:\n${stdout}\n\nSTDERR:\n${stderr}`);
-    }
+    })).rejects.toThrow(/Custom POM directory .* does not exist/i);
   });
 
   it("only emits view passthrough methods when the view has a single child component POM", async () => {

--- a/tests/generated-tsc.test.ts
+++ b/tests/generated-tsc.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import type { IComponentDependencies, IDataTestId } from "../utils";
 import { generateFiles } from "../class-generation";
-import { createPomMethodSignature, normalizePomParameters } from "../pom-params";
+import { createPomMethodSignature, createPomParameterSpec, normalizePomParameters } from "../pom-params";
 import { createPomStringPattern } from "../pom-patterns";
 import { renderTypeScriptLines } from "../typescript-codegen";
 
@@ -285,7 +285,7 @@ describe("generated output", () => {
         },
       }]),
       generatedMethods: new Map([
-        ["typeTenantName", createPomMethodSignature({ name: "string" })],
+        ["typeTenantName", createPomMethodSignature([createPomParameterSpec("name", "string")])],
       ]),
       isView: false,
     };
@@ -709,7 +709,7 @@ describe("generated output", () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set([childAEntry]),
-      generatedMethods: new Map([["clickOnlyInAButton", createPomMethodSignature({ wait: "boolean = true" })]]),
+      generatedMethods: new Map([["clickOnlyInAButton", createPomMethodSignature([createPomParameterSpec("wait", "boolean = true")])]]),
       isView: false,
     };
 
@@ -718,7 +718,7 @@ describe("generated output", () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set([childBEntry]),
-      generatedMethods: new Map([["clickSomethingElseButton", createPomMethodSignature({ wait: "boolean = true" })]]),
+      generatedMethods: new Map([["clickSomethingElseButton", createPomMethodSignature([createPomParameterSpec("wait", "boolean = true")])]]),
       isView: false,
     };
 

--- a/tests/generated-tsc.test.ts
+++ b/tests/generated-tsc.test.ts
@@ -477,17 +477,20 @@ describe("generated output", () => {
     );
     writeFile(
       path.join(tempRoot, "tests", "playwright", "pom", "custom", "Grid.ts"),
-      [
-        "export class Grid {",
-        "  constructor(_page: any, _owner: any) {}",
-        "  Search(text: string, options?: { timeoutMs?: number }) {",
-        "    return { text, options };",
-        "  }",
-        "  searchHighlight(text: string) {",
-        "    return text;",
-        "  }",
-        "}",
-      ].join("\n"),
+        [
+          "export class Grid {",
+          "  constructor(_page: any, _owner: any) {}",
+          "  Search(text: string, options?: { timeoutMs?: number }) {",
+          "    return { text, options };",
+          "  }",
+          "  SearchAll(...terms: string[]) {",
+          "    return terms;",
+          "  }",
+          "  searchHighlight(text: string) {",
+          "    return text;",
+          "  }",
+          "}",
+        ].join("\n"),
     );
 
     const deps: IComponentDependencies = {
@@ -527,6 +530,8 @@ describe("generated output", () => {
     expect(classBlock).toContain("grid: Grid;");
     expect(classBlock).toContain("Search(text: string, options?: { timeoutMs?: number }) {");
     expect(classBlock).toContain("return this.grid.Search(text, options);");
+    expect(classBlock).toContain("SearchAll(...terms: string[]) {");
+    expect(classBlock).toContain("return this.grid.SearchAll(...terms);");
     expect(classBlock).toContain("searchHighlight(text: string) {");
     expect(classBlock).toContain("return this.grid.searchHighlight(text);");
 

--- a/tests/generated-tsc.test.ts
+++ b/tests/generated-tsc.test.ts
@@ -85,6 +85,7 @@ describe("generated output", () => {
       pom: {
         nativeRole: "button",
         methodName: "SaveButton",
+        selectorPatternKind: "parameterized",
         formattedDataTestId,
         params: { key: "string" },
       },
@@ -102,7 +103,9 @@ describe("generated output", () => {
           selector: {
             kind: "withinTestIdByLabel",
             rootFormattedDataTestId: "TestComponent-databaseType-radio",
+            rootPatternKind: "static",
             formattedLabel: "Cloud",
+            labelPatternKind: "static",
             exact: true,
           },
           params: { annotationText: "string = \"\"" },
@@ -138,6 +141,55 @@ describe("generated output", () => {
     }
   });
 
+  it("typechecks parameterized input methods even when stale IR omits key params", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vue-pom-generator-keyed-input-"));
+
+    writePlaywrightTypeStub(tempRoot);
+
+    const basePagePath = path.join(tempRoot, "base-page.ts");
+    copyRepoFixture(tempRoot, "base-page.full.ts", "base-page.ts");
+    copyRepoFixture(tempRoot, "pointer.ts", "pointer.ts");
+
+    const componentName = "ItemsPage";
+    const dataTestIdEntry: IDataTestId = {
+      value: "items-check-${key}",
+      pom: {
+        nativeRole: "input",
+        methodName: "ItemsCheckByKey",
+        selectorPatternKind: "parameterized",
+        formattedDataTestId: "items-check-${key}",
+        // Simulate stale IR that predates selectorPatternKind and forgot to carry `key`.
+        params: { text: "string", annotationText: 'string = ""' },
+      },
+    };
+
+    const deps: IComponentDependencies = {
+      filePath: path.join(tempRoot, `${componentName}.vue`),
+      childrenComponentSet: new Set(),
+      usedComponentSet: new Set(),
+      dataTestIdSet: new Set([dataTestIdEntry]),
+      generatedMethods: new Map(),
+      isView: false,
+    };
+
+    const outDir = path.join(tempRoot, "out");
+    await generateFiles(new Map([[componentName, deps]]), new Map(), basePagePath, {
+      outDir,
+      projectRoot: tempRoot,
+    });
+
+    const generatedFilePath = path.join(outDir, "page-object-models.g.ts");
+    const generatedContent = fs.readFileSync(generatedFilePath, "utf8");
+    expect(generatedContent).toMatch(/async typeItemsCheckByKey\(key: string, text: string, annotationText: string = ""\)/);
+
+    const result = runTscNoEmit([generatedFilePath, basePagePath], { cwd: tempRoot });
+    if (result.status !== 0) {
+      const stdout = (result.stdout || "").toString();
+      const stderr = (result.stderr || "").toString();
+      throw new Error(`tsc failed (exit ${result.status})\n\nSTDOUT:\n${stdout}\n\nSTDERR:\n${stderr}`);
+    }
+  });
+
   it("typechecks split TypeScript output with barrel exports and stub targets", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vue-pom-generator-split-"));
 
@@ -158,6 +210,7 @@ describe("generated output", () => {
       pom: {
         nativeRole: "button",
         methodName: "NewTenant",
+        selectorPatternKind: "static",
         formattedDataTestId: "TenantListPage-NewTenant-routerlink",
         params: {},
       },
@@ -181,6 +234,7 @@ describe("generated output", () => {
         pom: {
           nativeRole: "input",
           methodName: "TenantName",
+          selectorPatternKind: "static",
           formattedDataTestId: "TenantDetailsEditForm-Name-input",
           params: { text: "string", annotationText: 'string = ""' },
         },
@@ -576,6 +630,7 @@ describe("generated output", () => {
       pom: {
         nativeRole: "button",
         methodName: "OnlyInAButton",
+        selectorPatternKind: "static",
         formattedDataTestId: "ChildA-OnlyInA-button",
         params: {},
       },
@@ -586,6 +641,7 @@ describe("generated output", () => {
       pom: {
         nativeRole: "button",
         methodName: "SomethingElseButton",
+        selectorPatternKind: "static",
         formattedDataTestId: "ChildB-SomethingElse-button",
         params: {},
       },

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -193,30 +193,6 @@ describe("createVuePomGeneratorPlugins options", () => {
     expect(names).toContain("vue-pom-generator-dev");
   });
 
-  it("accepts root-level errorBehavior as a string", async () => {
-    const plugins = createVuePomGeneratorPlugins({
-      errorBehavior: "error",
-      generation: {
-        outDir: "./tests/playwright/generated",
-      },
-    });
-
-    await expect(runConfigResolved(plugins)).resolves.toBeUndefined();
-  });
-
-  it("accepts root-level errorBehavior as an object", async () => {
-    const plugins = createVuePomGeneratorPlugins({
-      errorBehavior: {
-        missingSemanticNameBehavior: "error",
-      },
-      generation: {
-        outDir: "./tests/playwright/generated",
-      },
-    });
-
-    await expect(runConfigResolved(plugins)).resolves.toBeUndefined();
-  });
-
   it("accepts split Playwright output structure", async () => {
     const plugins = createVuePomGeneratorPlugins({
       generation: {
@@ -266,30 +242,6 @@ describe("createVuePomGeneratorPlugins options", () => {
     await expect(runConfigResolved(plugins)).rejects.toThrow("generation.router.entry");
   });
 
-  it("fails fast for invalid root-level errorBehavior string", async () => {
-    const plugins = createVuePomGeneratorPlugins({
-      errorBehavior: "strict" as "ignore",
-      generation: {
-        outDir: "tests/playwright/generated",
-      },
-    });
-
-    await expect(runConfigResolved(plugins)).rejects.toThrow("errorBehavior");
-  });
-
-  it("fails fast for invalid root-level errorBehavior object", async () => {
-    const plugins = createVuePomGeneratorPlugins({
-      errorBehavior: {
-        missingSemanticNameBehavior: "strict" as "ignore",
-      },
-      generation: {
-        outDir: "tests/playwright/generated",
-      },
-    });
-
-    await expect(runConfigResolved(plugins)).rejects.toThrow("errorBehavior.missingSemanticNameBehavior");
-  });
-
   it("fails fast for invalid generation.playwright.outputStructure", async () => {
     const plugins = createVuePomGeneratorPlugins({
       generation: {
@@ -335,9 +287,6 @@ describe("createVuePomGeneratorPlugins options", () => {
 
   it("supports alias and typed config helper exports", () => {
     const config = defineVuePomGeneratorConfig({
-      errorBehavior: {
-        missingSemanticNameBehavior: "error",
-      },
       generation: false,
       vueOptions: {
         script: { defineModel: true },
@@ -347,9 +296,6 @@ describe("createVuePomGeneratorPlugins options", () => {
     const plugins = vuePomGenerator(config);
     expect(Array.isArray(plugins)).toBe(true);
     expect(plugins.length).toBeGreaterThan(0);
-    expect(config.errorBehavior).toEqual({
-      missingSemanticNameBehavior: "error",
-    });
 
     const nuxtConfig = defineNuxtPomGeneratorConfig({
       generation: false,
@@ -423,6 +369,44 @@ describe("createVuePomGeneratorPlugins options", () => {
       expect(compilerOptions?.nodeTransforms?.length).toBeGreaterThan(0);
       expect(compilerOptions?.expressionPlugins).toContain("typescript");
       expect(compilerOptions?.prefixIdentifiers).toBe(true);
+    });
+  });
+
+  it("fails fast when auto-detected Nuxt projects cannot find vite:vue to patch", async () => {
+    await withTempProject({
+      "package.json": JSON.stringify({
+        devDependencies: {
+          nuxt: "^4.0.0",
+        },
+      }),
+      "app.vue": "<template><div /></template>",
+    }, async () => {
+      const plugins = createVuePomGeneratorPlugins({
+        generation: {
+          outDir: "tests/playwright/generated",
+        },
+      });
+
+      const configPlugin = plugins
+        .map((p) => {
+          if (typeof p !== "object" || !p || !("name" in p))
+            return null;
+          return p as ConfigPlugin;
+        })
+        .find(p => p?.name === "vue-pom-generator-config");
+
+      if (!configPlugin?.configResolved)
+        throw new Error("config plugin not found");
+
+      await expect(configPlugin.configResolved({
+        root: "/project",
+        logger: {
+          info() {},
+          warn() {},
+          error() {},
+        },
+        plugins: [],
+      })).rejects.toThrow("Nuxt bridge could not find vite:vue plugin to patch");
     });
   });
 });

--- a/tests/resolved-injection-options.test.ts
+++ b/tests/resolved-injection-options.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import {
+  applyNuxtDiscoveryToInjectionOptions,
+  resolveInjectionSupportOptions,
+} from "../plugin/resolved-injection-options";
+
+describe("resolved injection options", () => {
+  it("resolves the standard Vue defaults into one support shape", () => {
+    expect(resolveInjectionSupportOptions({})).toEqual({
+      pageDirs: ["src/views"],
+      componentDirs: ["src/components"],
+      layoutDirs: ["src/layouts"],
+      wrapperSearchRoots: [],
+      nativeWrappers: {},
+      excludedComponents: [],
+      existingIdBehavior: "error",
+      testIdAttribute: "data-testid",
+    });
+  });
+
+  it("starts from Nuxt defaults and applies discovered directories", () => {
+    const resolved = resolveInjectionSupportOptions({
+      isNuxt: true,
+      excludedComponents: ["IgnoredButton"],
+      testIdAttribute: "  ",
+    });
+
+    expect(resolved).toEqual({
+      pageDirs: ["app/pages"],
+      componentDirs: ["app/components"],
+      layoutDirs: ["app/layouts"],
+      wrapperSearchRoots: [],
+      nativeWrappers: {},
+      excludedComponents: ["IgnoredButton"],
+      existingIdBehavior: "error",
+      testIdAttribute: "data-testid",
+    });
+
+    expect(applyNuxtDiscoveryToInjectionOptions(resolved, {
+      rootDir: "/project",
+      srcDir: "/project/app",
+      pageDirs: [],
+      componentDirs: ["/project/app/components", "/project/layer/components"],
+      layoutDirs: ["/project/app/layouts"],
+      wrapperSearchRoots: ["/project/shared-wrappers"],
+    })).toEqual({
+      pageDirs: ["/project/app/pages"],
+      componentDirs: ["/project/app/components", "/project/layer/components"],
+      layoutDirs: ["/project/app/layouts"],
+      wrapperSearchRoots: ["/project/shared-wrappers"],
+      nativeWrappers: {},
+      excludedComponents: ["IgnoredButton"],
+      existingIdBehavior: "error",
+      testIdAttribute: "data-testid",
+    });
+  });
+});

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -449,6 +449,31 @@ describe('createTestIdTransform', () => {
     expect(code).not.toContain('_ctx._ctx.item.id')
   })
 
+  it('preserves keyed template segments that start with literal text', () => {
+    const componentHierarchyMap = new Map()
+
+    const code = compileAndCaptureCode(
+      [
+        '<ul>',
+        '  <li',
+        '    v-for="item in items"',
+        '    :key="`line-${item.id}`"',
+        '    @click="select(item)"',
+        '  >',
+        '    {{ item.id }}',
+        '  </li>',
+        '</ul>',
+      ].join('\n'),
+      {
+        filename: '/src/components/MyComp.vue',
+        nodeTransforms: [createTestIdTransform('MyComp', componentHierarchyMap, {}, [], '/src/views')],
+      },
+    )
+
+    expect(code).toContain('"data-testid": `MyComp-line-${item.id}-Select-li`')
+    expect(code).not.toContain('${line-${item.id}}')
+  })
+
   it('injects click instrumentation by default', () => {
     const code = compileWithRuntimeTemplateOptions(
       `

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import type { AttributeNode, DirectiveNode, ElementNode, ForNode, RootNode, TemplateChildNode } from '@vue/compiler-core'
+import type { AttributeNode, BindingMetadata, DirectiveNode, ElementNode, ForNode, RootNode, TemplateChildNode } from '@vue/compiler-core'
 import type { Node as BabelNode } from '@babel/types'
 
 import fs from 'node:fs'
@@ -9,12 +9,13 @@ import { fileURLToPath } from 'node:url'
 
 import type { CompilerOptions } from '@vue/compiler-dom'
 import type { IComponentDependencies, NativeWrappersMap } from '../utils'
-import { ConstantTypes, NodeTypes } from '@vue/compiler-core'
-import { baseCompile, parserOptions } from '@vue/compiler-dom'
+import { BindingTypes, ConstantTypes, NodeTypes } from '@vue/compiler-core'
+import { baseCompile, compile as compileDom, parserOptions } from '@vue/compiler-dom'
 import { parse as parseSfc } from '@vue/compiler-sfc'
 
 
 import { describe, expect, it } from 'vitest'
+import { createVuePluginWithTestIds } from '../plugin/vue-plugin'
 import { __internal, createTestIdTransform } from '../transform'
 
 
@@ -73,6 +74,49 @@ function compileAndCaptureCode(source: string, options: CompilerOptions & { file
   )
 
   return result.code
+}
+
+function compileWithRuntimeTemplateOptions(
+  source: string,
+  options: {
+    clickInstrumentation?: boolean
+    nativeWrappers?: NativeWrappersMap
+    bindingMetadata?: BindingMetadata
+  } = {},
+): string {
+  const componentHierarchyMap = new Map<string, IComponentDependencies>()
+  const { templateCompilerOptions } = createVuePluginWithTestIds({
+    existingIdBehavior: 'preserve',
+    nameCollisionBehavior: 'error',
+    clickInstrumentation: options.clickInstrumentation,
+    nativeWrappers: options.nativeWrappers ?? {},
+    elementMetadata: new Map(),
+    semanticNameMap: new Map(),
+    componentHierarchyMap,
+    vueFilesPathMap: new Map(),
+    excludedComponents: [],
+    getViewsDirAbs: () => '/src/views',
+    testIdAttribute: 'data-testid',
+    loggerRef: {
+      current: {
+        info() {},
+        debug() {},
+        warn() {},
+      },
+    },
+    getSourceDirs: () => ['/src/views', '/src/components'],
+    getWrapperSearchRoots: () => [],
+    getProjectRoot: () => '/',
+  })
+
+  return compileDom(source, {
+    ...templateCompilerOptions,
+    filename: '/src/views/MyComp.vue',
+    inline: true,
+    cacheHandlers: true,
+    bindingMetadata: options.bindingMetadata,
+    mode: 'module',
+  }).code
 }
 
 function findFirstDataTestIdDirectiveExpAst(root: RootNode): BabelNode | null | false | undefined {
@@ -398,12 +442,80 @@ describe('createTestIdTransform', () => {
       nestedVForTemplate,
       {
         filename: '/src/components/MyComp.vue',
+        nodeTransforms: [createTestIdTransform('MyComp', componentHierarchyMap, {}, [], '/src/views', { clickInstrumentation: true })],
+      },
+    )
+
+    expect(code).toContain('"data-testid": `MyComp-${_ctx.item.id}-line-${matches.lineNumber}-LineSelected-li`')
+    expect(code).not.toContain('${`${item.id}-line-${matches.lineNumber}`}')
+    expect(code).not.toContain('_ctx._ctx.item.id')
+  })
+
+  it('injects click instrumentation by default', () => {
+    const code = compileWithRuntimeTemplateOptions(
+      `
+        <ImmyTable>
+          <template #actions="{ item }">
+            <ImmyButton @click="remove(item)">Remove</ImmyButton>
+          </template>
+        </ImmyTable>
+      `,
+      {
+        nativeWrappers: { ImmyButton: { role: 'button' } },
+        bindingMetadata: {
+          remove: BindingTypes.SETUP_CONST,
+        },
+      },
+    )
+
+    expect(code).toContain('__testid_event__')
+    expect(code).toContain('"data-click-instrumented": "1"')
+    expect(code).toContain('"data-testid": `MyComp-${item.key ?? item.data?.id ?? item.id ?? item.value ?? item}-Remove-button`')
+  })
+
+  it('can disable click instrumentation explicitly', () => {
+    const code = compileWithRuntimeTemplateOptions(
+      `
+        <ImmyTable>
+          <template #actions="{ item }">
+            <ImmyButton @click="remove(item)">Remove</ImmyButton>
+          </template>
+        </ImmyTable>
+      `,
+      {
+        clickInstrumentation: false,
+        nativeWrappers: { ImmyButton: { role: 'button' } },
+        bindingMetadata: {
+          remove: BindingTypes.SETUP_CONST,
+        },
+      },
+    )
+
+    expect(code).toMatch(/onClick:\s*\$event =>\s*\(remove\(item\)\)/)
+    expect(code).toContain('"data-testid": `MyComp-${item.key ?? item.data?.id ?? item.id ?? item.value ?? item}-Remove-button`')
+    expect(code).not.toContain('__testid_event__')
+    expect(code).not.toContain('data-click-instrumented')
+  })
+
+  it('prefixes component-scope identifiers inside keyed router-link test ids', () => {
+    const componentHierarchyMap = new Map()
+
+    const code = compileAndCaptureCode(
+      `
+        <RouterLink :key="\`${'${'}item.name}-${'${'}item.url}\`" :to="item.url">
+          {{ item.name }}
+        </RouterLink>
+      `,
+      {
+        filename: '/src/components/MyComp.vue',
         nodeTransforms: [createTestIdTransform('MyComp', componentHierarchyMap, {}, [], '/src/views')],
       },
     )
 
-    expect(code).toContain('MyComp-${`${_ctx.item.id}-line-${matches.lineNumber}`}-LineSelected-li')
-    expect(code).not.toContain('_ctx._ctx.item.id')
+    expect(code).toContain('_ctx.item.name')
+    expect(code).toContain('_ctx.item.url')
+    expect(code).toContain('"data-testid": `MyComp-${_ctx.item.name}-${_ctx.item.url}--routerlink`')
+    expect(code).not.toContain('${`${item.name}-${item.url}`}')
   })
 
   it('ignores singleton :key values when generating click test ids', () => {

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -15,6 +15,7 @@ import { parse as parseSfc } from '@vue/compiler-sfc'
 
 
 import { describe, expect, it } from 'vitest'
+import { createPomMethodSignature, normalizePomParameters } from '../pom-params'
 import { createPomStringPattern } from '../pom-patterns'
 import { createVuePluginWithTestIds } from '../plugin/vue-plugin'
 import { __internal, createTestIdTransform } from '../transform'
@@ -735,7 +736,7 @@ describe('createTestIdTransform', () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set(),
-      generatedMethods: new Map([['clickShowMediaLibrary', { params: 'wait: boolean = true', argNames: ['wait'] }]]),
+      generatedMethods: new Map([['clickShowMediaLibrary', createPomMethodSignature({ wait: 'boolean = true' })]]),
       reservedPomMemberNames: new Set(['ShowMediaLibraryButton', 'clickShowMediaLibrary']),
       isView: false,
     })
@@ -772,7 +773,7 @@ describe('createTestIdTransform', () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set(),
-      generatedMethods: new Map([['clickShowMediaLibrary', { params: 'wait: boolean = true', argNames: ['wait'] }]]),
+      generatedMethods: new Map([['clickShowMediaLibrary', createPomMethodSignature({ wait: 'boolean = true' })]]),
       reservedPomMemberNames: new Set(['ShowMediaLibraryButton', 'clickShowMediaLibrary']),
       isView: false,
     })
@@ -813,7 +814,7 @@ describe('createTestIdTransform', () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set(),
-      generatedMethods: new Map([['clickRunDeploymentAction', { params: 'wait: boolean = true', argNames: ['wait'] }]]),
+      generatedMethods: new Map([['clickRunDeploymentAction', createPomMethodSignature({ wait: 'boolean = true' })]]),
       reservedPomMemberNames: new Set(['RunDeploymentActionButton', 'clickRunDeploymentAction']),
       isView: false,
     })
@@ -920,13 +921,11 @@ describe('createTestIdTransform', () => {
     const deps = componentHierarchyMap.get('MyComp') as IComponentDependencies | undefined
     expect(deps).toBeTruthy()
 
-    const sigOne = deps?.generatedMethods?.get('clickOneButton') as { params: string, argNames: string[] } | null | undefined
-    expect(sigOne?.params).toBe('wait: boolean = true')
-    expect(sigOne?.argNames).toEqual(['wait'])
+    const sigOne = deps?.generatedMethods?.get('clickOneButton')
+    expect(sigOne).toEqual(createPomMethodSignature({ wait: 'boolean = true' }))
 
-    const sigTwo = deps?.generatedMethods?.get('clickTwoButton') as { params: string, argNames: string[] } | null | undefined
-    expect(sigTwo?.params).toBe('wait: boolean = true')
-    expect(sigTwo?.argNames).toEqual(['wait'])
+    const sigTwo = deps?.generatedMethods?.get('clickTwoButton')
+    expect(sigTwo).toEqual(createPomMethodSignature({ wait: 'boolean = true' }))
 
     // With the IR-based generator, v-for static literal keys are represented as extra click method specs.
     const extras = deps?.pomExtraMethods ?? []
@@ -937,7 +936,7 @@ describe('createTestIdTransform', () => {
       kind: 'testId',
       testId: createPomStringPattern('MyComp-${key}-Select-button', 'parameterized'),
     })
-    expect(one?.params).toEqual({ wait: 'boolean = true' })
+    expect(one?.parameters).toEqual(normalizePomParameters({ wait: 'boolean = true' }))
 
     const two = extras.find(m => m.kind === 'click' && m.name === 'clickTwoButton')
     expect(two).toBeTruthy()
@@ -946,7 +945,7 @@ describe('createTestIdTransform', () => {
       kind: 'testId',
       testId: createPomStringPattern('MyComp-${key}-Select-button', 'parameterized'),
     })
-    expect(two?.params).toEqual({ wait: 'boolean = true' })
+    expect(two?.parameters).toEqual(normalizePomParameters({ wait: 'boolean = true' }))
   })
 
   it('treats v-for source with Math.random() as dynamic via constType', () => {
@@ -1000,10 +999,10 @@ describe('createTestIdTransform', () => {
     expect(simpleParts.some(p => p.constType === ConstantTypes.NOT_CONSTANT)).toBe(true)
 
     // Also ensure our generator does NOT attempt static-list key narrowing here.
-    const deps = componentHierarchyMap.get('MyComp') as { generatedMethods?: Map<string, { params: string, argNames: string[] } | null> } | undefined
+    const deps = componentHierarchyMap.get('MyComp') as IComponentDependencies | undefined
     expect(deps).toBeTruthy()
-    const sig = deps?.generatedMethods?.get('clickDoThingByKey') as { params: string, argNames: string[] } | null | undefined
-    expect(sig?.params).toBe('key: string')
+    const sig = deps?.generatedMethods?.get('clickDoThingByKey')
+    expect(sig).toEqual(createPomMethodSignature({ key: 'string' }))
   })
 
   it('does not populate exp.ast in this test harness even when prefixIdentifiers is enabled', () => {
@@ -1109,7 +1108,7 @@ describe('createTestIdTransform', () => {
         label: createPomStringPattern('Cloud', 'static'),
         exact: true,
       },
-      params: { annotationText: 'string = ""' },
+      parameters: normalizePomParameters({ annotationText: 'string = ""' }),
     })
   })
 
@@ -1191,7 +1190,7 @@ describe('createTestIdTransform', () => {
         label: createPomStringPattern('Cloud', 'static'),
         exact: true,
       },
-      params: { annotationText: 'string = ""' },
+      parameters: normalizePomParameters({ annotationText: 'string = ""' }),
     })
   })
 })

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -15,7 +15,7 @@ import { parse as parseSfc } from '@vue/compiler-sfc'
 
 
 import { describe, expect, it } from 'vitest'
-import { createPomMethodSignature, normalizePomParameters } from '../pom-params'
+import { createPomMethodSignature, createPomParameterSpec, normalizePomParameters } from '../pom-params'
 import { createPomStringPattern } from '../pom-patterns'
 import { createVuePluginWithTestIds } from '../plugin/vue-plugin'
 import { __internal, createTestIdTransform } from '../transform'
@@ -736,7 +736,7 @@ describe('createTestIdTransform', () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set(),
-      generatedMethods: new Map([['clickShowMediaLibrary', createPomMethodSignature({ wait: 'boolean = true' })]]),
+      generatedMethods: new Map([['clickShowMediaLibrary', createPomMethodSignature([createPomParameterSpec('wait', 'boolean = true')])]]),
       reservedPomMemberNames: new Set(['ShowMediaLibraryButton', 'clickShowMediaLibrary']),
       isView: false,
     })
@@ -773,7 +773,7 @@ describe('createTestIdTransform', () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set(),
-      generatedMethods: new Map([['clickShowMediaLibrary', createPomMethodSignature({ wait: 'boolean = true' })]]),
+      generatedMethods: new Map([['clickShowMediaLibrary', createPomMethodSignature([createPomParameterSpec('wait', 'boolean = true')])]]),
       reservedPomMemberNames: new Set(['ShowMediaLibraryButton', 'clickShowMediaLibrary']),
       isView: false,
     })
@@ -814,7 +814,7 @@ describe('createTestIdTransform', () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set(),
-      generatedMethods: new Map([['clickRunDeploymentAction', createPomMethodSignature({ wait: 'boolean = true' })]]),
+      generatedMethods: new Map([['clickRunDeploymentAction', createPomMethodSignature([createPomParameterSpec('wait', 'boolean = true')])]]),
       reservedPomMemberNames: new Set(['RunDeploymentActionButton', 'clickRunDeploymentAction']),
       isView: false,
     })
@@ -922,10 +922,10 @@ describe('createTestIdTransform', () => {
     expect(deps).toBeTruthy()
 
     const sigOne = deps?.generatedMethods?.get('clickOneButton')
-    expect(sigOne).toEqual(createPomMethodSignature({ wait: 'boolean = true' }))
+    expect(sigOne).toEqual(createPomMethodSignature([createPomParameterSpec('wait', 'boolean = true')]))
 
     const sigTwo = deps?.generatedMethods?.get('clickTwoButton')
-    expect(sigTwo).toEqual(createPomMethodSignature({ wait: 'boolean = true' }))
+    expect(sigTwo).toEqual(createPomMethodSignature([createPomParameterSpec('wait', 'boolean = true')]))
 
     // With the IR-based generator, v-for static literal keys are represented as extra click method specs.
     const extras = deps?.pomExtraMethods ?? []
@@ -1002,7 +1002,7 @@ describe('createTestIdTransform', () => {
     const deps = componentHierarchyMap.get('MyComp') as IComponentDependencies | undefined
     expect(deps).toBeTruthy()
     const sig = deps?.generatedMethods?.get('clickDoThingByKey')
-    expect(sig).toEqual(createPomMethodSignature({ key: 'string' }))
+    expect(sig).toEqual(createPomMethodSignature([createPomParameterSpec('key', 'string')]))
   })
 
   it('does not populate exp.ast in this test harness even when prefixIdentifiers is enabled', () => {
@@ -1077,11 +1077,11 @@ describe('createTestIdTransform', () => {
     expect(deps).toBeTruthy()
 
     const signature = deps?.generatedMethods?.get('selectSelectedGroup')
-    expect(signature).toEqual(createPomMethodSignature({
-      value: 'string',
-      timeOut: 'number = 500',
-      annotationText: 'string = ""',
-    }))
+    expect(signature).toEqual(createPomMethodSignature([
+      createPomParameterSpec('value', 'string'),
+      createPomParameterSpec('timeOut', 'number = 500'),
+      createPomParameterSpec('annotationText', 'string = ""'),
+    ]))
 
     const pom = Array.from(deps?.dataTestIdSet ?? []).find(entry => entry.pom?.methodName === 'SelectedGroup')?.pom
     expect(pom?.parameters).toEqual(normalizePomParameters({

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -15,6 +15,7 @@ import { parse as parseSfc } from '@vue/compiler-sfc'
 
 
 import { describe, expect, it } from 'vitest'
+import { createPomStringPattern } from '../pom-patterns'
 import { createVuePluginWithTestIds } from '../plugin/vue-plugin'
 import { __internal, createTestIdTransform } from '../transform'
 
@@ -320,7 +321,7 @@ describe('createTestIdTransform', () => {
 
     const deps = componentHierarchyMap.get('MyComp')
     expect(deps).toBeTruthy()
-    expect(Array.from(deps!.dataTestIdSet).some(e => e.value === 'MyComp-Save-button')).toBe(true)
+    expect(Array.from(deps!.dataTestIdSet).some(e => e.selectorValue.formatted === 'MyComp-Save-button')).toBe(true)
   })
 
   it('preserves existing data-testid when existingIdBehavior is preserve', () => {
@@ -720,10 +721,10 @@ describe('createTestIdTransform', () => {
 
     const primary = fieldValuePoms.find(p => p.emitPrimary !== false)
     const mergedSecondary = fieldValuePoms.find(p => p.emitPrimary === false)
-    expect(primary?.formattedDataTestId).toBe('DynamicFormField-FieldValue-input')
+    expect(primary?.selector).toEqual(createPomStringPattern('DynamicFormField-FieldValue-input', 'static'))
     expect(primary?.mergeKey).toContain('wrapper:ifgroup:')
     expect(primary?.mergeKey).toContain(':model:FieldValue')
-    expect(primary?.alternateFormattedDataTestIds).toBeUndefined()
+    expect(primary?.alternateSelectors).toBeUndefined()
     expect(mergedSecondary?.emitPrimary).toBe(false)
   })
 
@@ -934,8 +935,7 @@ describe('createTestIdTransform', () => {
     expect(one?.keyLiteral).toBe('One')
     expect(one?.selector).toEqual({
       kind: 'testId',
-      patternKind: 'parameterized',
-      formattedDataTestId: 'MyComp-${key}-Select-button',
+      testId: createPomStringPattern('MyComp-${key}-Select-button', 'parameterized'),
     })
     expect(one?.params).toEqual({ wait: 'boolean = true' })
 
@@ -944,8 +944,7 @@ describe('createTestIdTransform', () => {
     expect(two?.keyLiteral).toBe('Two')
     expect(two?.selector).toEqual({
       kind: 'testId',
-      patternKind: 'parameterized',
-      formattedDataTestId: 'MyComp-${key}-Select-button',
+      testId: createPomStringPattern('MyComp-${key}-Select-button', 'parameterized'),
     })
     expect(two?.params).toEqual({ wait: 'boolean = true' })
   })
@@ -1106,10 +1105,8 @@ describe('createTestIdTransform', () => {
       name: 'selectDatabaseTypeCloud',
       selector: {
         kind: 'withinTestIdByLabel',
-        rootFormattedDataTestId: 'MyPage-DatabaseType-radio',
-        rootPatternKind: 'static',
-        formattedLabel: 'Cloud',
-        labelPatternKind: 'static',
+        rootTestId: createPomStringPattern('MyPage-DatabaseType-radio', 'static'),
+        label: createPomStringPattern('Cloud', 'static'),
         exact: true,
       },
       params: { annotationText: 'string = ""' },
@@ -1190,10 +1187,8 @@ describe('createTestIdTransform', () => {
       name: 'selectDatabaseTypeCloud',
       selector: {
         kind: 'withinTestIdByLabel',
-        rootFormattedDataTestId: 'MyPage-DatabaseType-radio',
-        rootPatternKind: 'static',
-        formattedLabel: 'Cloud',
-        labelPatternKind: 'static',
+        rootTestId: createPomStringPattern('MyPage-DatabaseType-radio', 'static'),
+        label: createPomStringPattern('Cloud', 'static'),
         exact: true,
       },
       params: { annotationText: 'string = ""' },

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -79,7 +79,6 @@ function compileAndCaptureCode(source: string, options: CompilerOptions & { file
 function compileWithRuntimeTemplateOptions(
   source: string,
   options: {
-    clickInstrumentation?: boolean
     nativeWrappers?: NativeWrappersMap
     bindingMetadata?: BindingMetadata
   } = {},
@@ -88,7 +87,6 @@ function compileWithRuntimeTemplateOptions(
   const { templateCompilerOptions } = createVuePluginWithTestIds({
     existingIdBehavior: 'preserve',
     nameCollisionBehavior: 'error',
-    clickInstrumentation: options.clickInstrumentation,
     nativeWrappers: options.nativeWrappers ?? {},
     elementMetadata: new Map(),
     semanticNameMap: new Map(),
@@ -442,7 +440,7 @@ describe('createTestIdTransform', () => {
       nestedVForTemplate,
       {
         filename: '/src/components/MyComp.vue',
-        nodeTransforms: [createTestIdTransform('MyComp', componentHierarchyMap, {}, [], '/src/views', { clickInstrumentation: true })],
+        nodeTransforms: [createTestIdTransform('MyComp', componentHierarchyMap, {}, [], '/src/views')],
       },
     )
 
@@ -471,30 +469,6 @@ describe('createTestIdTransform', () => {
     expect(code).toContain('__testid_event__')
     expect(code).toContain('"data-click-instrumented": "1"')
     expect(code).toContain('"data-testid": `MyComp-${item.key ?? item.data?.id ?? item.id ?? item.value ?? item}-Remove-button`')
-  })
-
-  it('can disable click instrumentation explicitly', () => {
-    const code = compileWithRuntimeTemplateOptions(
-      `
-        <ImmyTable>
-          <template #actions="{ item }">
-            <ImmyButton @click="remove(item)">Remove</ImmyButton>
-          </template>
-        </ImmyTable>
-      `,
-      {
-        clickInstrumentation: false,
-        nativeWrappers: { ImmyButton: { role: 'button' } },
-        bindingMetadata: {
-          remove: BindingTypes.SETUP_CONST,
-        },
-      },
-    )
-
-    expect(code).toMatch(/onClick:\s*\$event =>\s*\(remove\(item\)\)/)
-    expect(code).toContain('"data-testid": `MyComp-${item.key ?? item.data?.id ?? item.id ?? item.value ?? item}-Remove-button`')
-    expect(code).not.toContain('__testid_event__')
-    expect(code).not.toContain('data-click-instrumented')
   })
 
   it('prefixes component-scope identifiers inside keyed router-link test ids', () => {

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -1056,6 +1056,41 @@ describe('createTestIdTransform', () => {
     expect(dataTestIdAttr?.value?.content).toBe('MyComp-SelectedGroup-vselect')
   })
 
+  it('registers v-select generated-method signatures from structured primary parameters', () => {
+    const componentHierarchyMap = new Map()
+    const nativeWrappers: NativeWrappersMap = {
+      'v-select': {
+        role: 'vselect',
+        requiresOptionDataTestIdPrefix: true,
+      },
+    }
+
+    compileAndCaptureAst(
+      readFixtureTemplate('MyComp_VSelect.vue'),
+      {
+        filename: '/src/components/MyComp.vue',
+        nodeTransforms: [createTestIdTransform('MyComp', componentHierarchyMap, nativeWrappers, [], '/src/views')],
+      },
+    )
+
+    const deps = componentHierarchyMap.get('MyComp') as IComponentDependencies | undefined
+    expect(deps).toBeTruthy()
+
+    const signature = deps?.generatedMethods?.get('selectSelectedGroup')
+    expect(signature).toEqual(createPomMethodSignature({
+      value: 'string',
+      timeOut: 'number = 500',
+      annotationText: 'string = ""',
+    }))
+
+    const pom = Array.from(deps?.dataTestIdSet ?? []).find(entry => entry.pom?.methodName === 'SelectedGroup')?.pom
+    expect(pom?.parameters).toEqual(normalizePomParameters({
+      value: 'string',
+      timeOut: 'number = 500',
+      annotationText: 'string = ""',
+    }))
+  })
+
   it('infers radio wrappers through nested local SFCs without nativeWrappers config', () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vue-pom-generator-transform-'))
     const radioPath = path.join(tempRoot, 'src', 'components', 'ImmyRadio.vue')

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -934,6 +934,7 @@ describe('createTestIdTransform', () => {
     expect(one?.keyLiteral).toBe('One')
     expect(one?.selector).toEqual({
       kind: 'testId',
+      patternKind: 'parameterized',
       formattedDataTestId: 'MyComp-${key}-Select-button',
     })
     expect(one?.params).toEqual({ wait: 'boolean = true' })
@@ -943,6 +944,7 @@ describe('createTestIdTransform', () => {
     expect(two?.keyLiteral).toBe('Two')
     expect(two?.selector).toEqual({
       kind: 'testId',
+      patternKind: 'parameterized',
       formattedDataTestId: 'MyComp-${key}-Select-button',
     })
     expect(two?.params).toEqual({ wait: 'boolean = true' })
@@ -1105,7 +1107,9 @@ describe('createTestIdTransform', () => {
       selector: {
         kind: 'withinTestIdByLabel',
         rootFormattedDataTestId: 'MyPage-DatabaseType-radio',
+        rootPatternKind: 'static',
         formattedLabel: 'Cloud',
+        labelPatternKind: 'static',
         exact: true,
       },
       params: { annotationText: 'string = ""' },
@@ -1187,7 +1191,9 @@ describe('createTestIdTransform', () => {
       selector: {
         kind: 'withinTestIdByLabel',
         rootFormattedDataTestId: 'MyPage-DatabaseType-radio',
+        rootPatternKind: 'static',
         formattedLabel: 'Cloud',
+        labelPatternKind: 'static',
         exact: true,
       },
       params: { annotationText: 'string = ""' },

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -468,7 +468,7 @@ describe('createTestIdTransform', () => {
       ].join('\n'),
       {
         filename: '/src/components/MyComp.vue',
-        nodeTransforms: [createTestIdTransform('MyComp', componentHierarchyMap, {}, [], '/src/views')],
+        nodeTransforms: [createTestIdTransform('MyComp', componentHierarchyMap, {}, [], '/src/views', { existingIdBehavior: 'preserve' })],
       },
     )
 
@@ -496,6 +496,7 @@ describe('createTestIdTransform', () => {
     expect(code).toContain('__testid_event__')
     expect(code).toContain('"data-click-instrumented": "1"')
     expect(code).toContain('"data-testid": `MyComp-${item.key ?? item.data?.id ?? item.id ?? item.value ?? item}-Remove-button`')
+    expect(code).not.toContain('__testid_click_event_strict__')
   })
 
   it('prefixes component-scope identifiers inside keyed router-link test ids', () => {
@@ -541,7 +542,7 @@ describe('createTestIdTransform', () => {
       '<button :key="activeTab" data-testid="target-visibility-selector" @click="select">Select</button>',
       {
         filename: '/src/components/MyComp.vue',
-        nodeTransforms: [createTestIdTransform('MyComp', componentHierarchyMap, {}, [], '/src/views')],
+        nodeTransforms: [createTestIdTransform('MyComp', componentHierarchyMap, {}, [], '/src/views', { existingIdBehavior: 'preserve' })],
       },
     )
 
@@ -882,29 +883,6 @@ describe('createTestIdTransform', () => {
         },
       )
     }).toThrow(/move complex inline logic into a named function/i)
-  })
-
-  it('preserves the old permissive fallback when missingSemanticNameBehavior is explicitly ignore', () => {
-    const componentHierarchyMap = new Map<string, IComponentDependencies>()
-    const nativeWrappers: NativeWrappersMap = {
-      LoadButton: { role: 'button' },
-    }
-
-    expect(() => {
-      compileAndCaptureAst(
-        `
-          <LoadButton :handler="() => person && impersonateUser(person.userId!)">
-            Impersonate
-          </LoadButton>
-        `,
-        {
-          filename: '/src/views/RbacUserDetailsPage.vue',
-          nodeTransforms: [createTestIdTransform('RbacUserDetailsPage', componentHierarchyMap, nativeWrappers, [], '/src/views', {
-            missingSemanticNameBehavior: 'ignore',
-          })],
-        },
-      )
-    }).not.toThrow()
   })
 
   it('emits per-key click methods when v-for iterates a static literal list', () => {

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -15,7 +15,7 @@ import { parse as parseSfc } from '@vue/compiler-sfc'
 
 
 import { describe, expect, it } from 'vitest'
-import { createPomMethodSignature, createPomParameterSpec, normalizePomParameters } from '../pom-params'
+import { createPomMethodSignature, createPomParameters } from '../pom-params'
 import { createPomStringPattern } from '../pom-patterns'
 import { createVuePluginWithTestIds } from '../plugin/vue-plugin'
 import { __internal, createTestIdTransform } from '../transform'
@@ -736,7 +736,7 @@ describe('createTestIdTransform', () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set(),
-      generatedMethods: new Map([['clickShowMediaLibrary', createPomMethodSignature([createPomParameterSpec('wait', 'boolean = true')])]]),
+      generatedMethods: new Map([['clickShowMediaLibrary', createPomMethodSignature(createPomParameters(['wait', 'boolean = true']))]]),
       reservedPomMemberNames: new Set(['ShowMediaLibraryButton', 'clickShowMediaLibrary']),
       isView: false,
     })
@@ -773,7 +773,7 @@ describe('createTestIdTransform', () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set(),
-      generatedMethods: new Map([['clickShowMediaLibrary', createPomMethodSignature([createPomParameterSpec('wait', 'boolean = true')])]]),
+      generatedMethods: new Map([['clickShowMediaLibrary', createPomMethodSignature(createPomParameters(['wait', 'boolean = true']))]]),
       reservedPomMemberNames: new Set(['ShowMediaLibraryButton', 'clickShowMediaLibrary']),
       isView: false,
     })
@@ -814,7 +814,7 @@ describe('createTestIdTransform', () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set(),
       dataTestIdSet: new Set(),
-      generatedMethods: new Map([['clickRunDeploymentAction', createPomMethodSignature([createPomParameterSpec('wait', 'boolean = true')])]]),
+      generatedMethods: new Map([['clickRunDeploymentAction', createPomMethodSignature(createPomParameters(['wait', 'boolean = true']))]]),
       reservedPomMemberNames: new Set(['RunDeploymentActionButton', 'clickRunDeploymentAction']),
       isView: false,
     })
@@ -922,10 +922,10 @@ describe('createTestIdTransform', () => {
     expect(deps).toBeTruthy()
 
     const sigOne = deps?.generatedMethods?.get('clickOneButton')
-    expect(sigOne).toEqual(createPomMethodSignature([createPomParameterSpec('wait', 'boolean = true')]))
+    expect(sigOne).toEqual(createPomMethodSignature(createPomParameters(['wait', 'boolean = true'])))
 
     const sigTwo = deps?.generatedMethods?.get('clickTwoButton')
-    expect(sigTwo).toEqual(createPomMethodSignature([createPomParameterSpec('wait', 'boolean = true')]))
+    expect(sigTwo).toEqual(createPomMethodSignature(createPomParameters(['wait', 'boolean = true'])))
 
     // With the IR-based generator, v-for static literal keys are represented as extra click method specs.
     const extras = deps?.pomExtraMethods ?? []
@@ -936,7 +936,7 @@ describe('createTestIdTransform', () => {
       kind: 'testId',
       testId: createPomStringPattern('MyComp-${key}-Select-button', 'parameterized'),
     })
-    expect(one?.parameters).toEqual(normalizePomParameters({ wait: 'boolean = true' }))
+    expect(one?.parameters).toEqual(createPomParameters(['wait', 'boolean = true']))
 
     const two = extras.find(m => m.kind === 'click' && m.name === 'clickTwoButton')
     expect(two).toBeTruthy()
@@ -945,7 +945,7 @@ describe('createTestIdTransform', () => {
       kind: 'testId',
       testId: createPomStringPattern('MyComp-${key}-Select-button', 'parameterized'),
     })
-    expect(two?.parameters).toEqual(normalizePomParameters({ wait: 'boolean = true' }))
+    expect(two?.parameters).toEqual(createPomParameters(['wait', 'boolean = true']))
   })
 
   it('treats v-for source with Math.random() as dynamic via constType', () => {
@@ -1002,7 +1002,7 @@ describe('createTestIdTransform', () => {
     const deps = componentHierarchyMap.get('MyComp') as IComponentDependencies | undefined
     expect(deps).toBeTruthy()
     const sig = deps?.generatedMethods?.get('clickDoThingByKey')
-    expect(sig).toEqual(createPomMethodSignature([createPomParameterSpec('key', 'string')]))
+    expect(sig).toEqual(createPomMethodSignature(createPomParameters(['key', 'string'])))
   })
 
   it('does not populate exp.ast in this test harness even when prefixIdentifiers is enabled', () => {
@@ -1077,18 +1077,18 @@ describe('createTestIdTransform', () => {
     expect(deps).toBeTruthy()
 
     const signature = deps?.generatedMethods?.get('selectSelectedGroup')
-    expect(signature).toEqual(createPomMethodSignature([
-      createPomParameterSpec('value', 'string'),
-      createPomParameterSpec('timeOut', 'number = 500'),
-      createPomParameterSpec('annotationText', 'string = ""'),
-    ]))
+    expect(signature).toEqual(createPomMethodSignature(createPomParameters(
+      ['value', 'string'],
+      ['timeOut', 'number = 500'],
+      ['annotationText', 'string = ""'],
+    )))
 
     const pom = Array.from(deps?.dataTestIdSet ?? []).find(entry => entry.pom?.methodName === 'SelectedGroup')?.pom
-    expect(pom?.parameters).toEqual(normalizePomParameters({
-      value: 'string',
-      timeOut: 'number = 500',
-      annotationText: 'string = ""',
-    }))
+    expect(pom?.parameters).toEqual(createPomParameters(
+      ['value', 'string'],
+      ['timeOut', 'number = 500'],
+      ['annotationText', 'string = ""'],
+    ))
   })
 
   it('infers radio wrappers through nested local SFCs without nativeWrappers config', () => {
@@ -1143,7 +1143,7 @@ describe('createTestIdTransform', () => {
         label: createPomStringPattern('Cloud', 'static'),
         exact: true,
       },
-      parameters: normalizePomParameters({ annotationText: 'string = ""' }),
+      parameters: createPomParameters(['annotationText', 'string = ""']),
     })
   })
 
@@ -1225,7 +1225,7 @@ describe('createTestIdTransform', () => {
         label: createPomStringPattern('Cloud', 'static'),
         exact: true,
       },
-      parameters: normalizePomParameters({ annotationText: 'string = ""' }),
+      parameters: createPomParameters(['annotationText', 'string = ""']),
     })
   })
 })

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -16,6 +16,7 @@ import { baseCompile, parse, parserOptions } from "@vue/compiler-dom";
 
 import { parseExpression } from "@babel/parser";
 
+import { createPomStringPattern } from "../pom-patterns";
 import {
   addComponentTestIds,
   applyResolvedDataTestId,
@@ -772,7 +773,7 @@ describe("utils.ts coverage", () => {
 
     const entries = Array.from(deps.dataTestIdSet);
     expect(entries.length).toBe(1);
-    expect(entries[0]?.pom?.formattedDataTestId).toBe("abc-${key}");
+    expect(entries[0]?.pom?.selector).toEqual(createPomStringPattern("abc-${key}", "parameterized"));
   });
 
   it("allows preserving an existing template when the required key fragment carries literal context", () => {
@@ -810,7 +811,7 @@ describe("utils.ts coverage", () => {
 
     const entries = Array.from(deps.dataTestIdSet);
     expect(entries.length).toBe(1);
-    expect(entries[0]?.pom?.formattedDataTestId).toBe("abc-line-${key}");
+    expect(entries[0]?.pom?.selector).toEqual(createPomStringPattern("abc-line-${key}", "parameterized"));
   });
 
   it("allows preserving an existing key-based template literal that uses a fallback branch access", () => {
@@ -848,7 +849,7 @@ describe("utils.ts coverage", () => {
 
     const entries = Array.from(deps.dataTestIdSet);
     expect(entries.length).toBe(1);
-    expect(entries[0]?.pom?.formattedDataTestId).toBe("abc-${key}");
+    expect(entries[0]?.pom?.selector).toEqual(createPomStringPattern("abc-${key}", "parameterized"));
   });
 
   it("allows preserving an existing simple member-expression data-testid", () => {
@@ -886,8 +887,8 @@ describe("utils.ts coverage", () => {
 
     const entries = Array.from(deps.dataTestIdSet);
     expect(entries.length).toBe(1);
-    expect(entries[0]?.value).toBe("${p.parameter.name}");
-    expect(entries[0]?.pom?.formattedDataTestId).toBe("${key}");
+    expect(entries[0]?.selectorValue).toEqual(createPomStringPattern("${p.parameter.name}", "parameterized"));
+    expect(entries[0]?.pom?.selector).toEqual(createPomStringPattern("${key}", "parameterized"));
   });
 
   it("drives applyResolvedDataTestId through option-driven radio handling and de-duping", () => {
@@ -919,7 +920,7 @@ describe("utils.ts coverage", () => {
       testIdAttribute: "data-testid",
       existingIdBehavior: "overwrite",
       addHtmlAttribute: false,
-      entryOverrides: { value: "MyComp-Foo-radio" },
+      entryOverrides: { selectorValue: createPomStringPattern("MyComp-Foo-radio", "static") },
     });
 
     // Should have generated per-option extra click methods (IR), not raw emitted method strings.
@@ -928,8 +929,8 @@ describe("utils.ts coverage", () => {
     expect(extras.every(e => e.kind === "click")).toBe(true);
     expect(extras.some(e => e.name.startsWith("select"))).toBe(true);
     expect(extras.every(e => e.selector.kind === "withinTestIdByLabel")).toBe(true);
-    expect(extras.some(e => e.selector.kind === "withinTestIdByLabel" && e.selector.rootFormattedDataTestId === "MyComp-Foo-radio")).toBe(true);
-    expect(extras.some(e => e.selector.kind === "withinTestIdByLabel" && e.selector.formattedLabel === "One")).toBe(true);
+    expect(extras.some(e => e.selector.kind === "withinTestIdByLabel" && e.selector.rootTestId.formatted === "MyComp-Foo-radio")).toBe(true);
+    expect(extras.some(e => e.selector.kind === "withinTestIdByLabel" && e.selector.label.formatted === "One")).toBe(true);
 
     const prevCount = extras.length;
 
@@ -946,7 +947,7 @@ describe("utils.ts coverage", () => {
       testIdAttribute: "data-testid",
       existingIdBehavior: "overwrite",
       addHtmlAttribute: false,
-      entryOverrides: { value: "MyComp-Foo-radio" },
+      entryOverrides: { selectorValue: createPomStringPattern("MyComp-Foo-radio", "static") },
     });
 
     // De-dupe: calling again should not add more extra methods.
@@ -1018,10 +1019,8 @@ describe("utils.ts coverage", () => {
     expect(method1).toBeTruthy();
     expect(method1?.selector).toEqual({
       kind: "withinTestIdByLabel",
-      rootFormattedDataTestId: "MyComp-radio",
-      rootPatternKind: "static",
-      formattedLabel: "${value}",
-      labelPatternKind: "parameterized",
+      rootTestId: createPomStringPattern("MyComp-radio", "static"),
+      label: createPomStringPattern("${value}", "parameterized"),
       exact: true,
     });
 
@@ -1029,10 +1028,8 @@ describe("utils.ts coverage", () => {
     expect(method2).toBeTruthy();
     expect(method2?.selector).toEqual({
       kind: "withinTestIdByLabel",
-      rootFormattedDataTestId: "MyComp2-radio",
-      rootPatternKind: "static",
-      formattedLabel: "${value}",
-      labelPatternKind: "parameterized",
+      rootTestId: createPomStringPattern("MyComp2-radio", "static"),
+      label: createPomStringPattern("${value}", "parameterized"),
       exact: true,
     });
   });
@@ -1281,8 +1278,8 @@ describe("utils.ts coverage", () => {
     }).not.toThrow();
 
     const entries = Array.from(deps.dataTestIdSet);
-    const selectEntry = entries.find(e => e.value === "MyComp-select");
-    const radioEntry = entries.find(e => e.value === "MyComp-radio");
+    const selectEntry = entries.find(e => e.selectorValue.formatted === "MyComp-select");
+    const radioEntry = entries.find(e => e.selectorValue.formatted === "MyComp-radio");
 
     expect(selectEntry?.pom?.methodName).toBe("ParameterDefaultValue");
     expect(radioEntry?.pom?.methodName).toBe("ParameterDefaultValueRadio");

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -28,6 +28,7 @@ import {
   getContainedInVForDirectiveKeyValue,
   getIdOrName,
   getKeyDirectiveValue,
+  getKeyDirectiveRuntimeValue,
   getNativeWrapperTransformInfo,
   getRouteNameKeyFromToDirective,
   getSelfClosingForDirectiveKeyAttrValue,
@@ -405,6 +406,11 @@ describe("utils.ts coverage", () => {
     const foo2 = firstElement(ast3);
     expect(Boolean(foo2.isSelfClosing)).toBe(false);
     expect(getSelfClosingForDirectiveKeyAttrValue(foo2)).toBeNull();
+
+    const ast4 = parseTemplate("<div :key=\"`line-${item.id}`\" />");
+    const el4 = firstElement(ast4);
+    expect(getKeyDirectiveValue(el4)).toBe("line-${item.id}");
+    expect(getKeyDirectiveRuntimeValue(el4)).toBe("line-${item.id}");
   });
 
   it("extracts id/name identifiers", () => {

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -16,7 +16,7 @@ import { baseCompile, parse, parserOptions } from "@vue/compiler-dom";
 
 import { parseExpression } from "@babel/parser";
 
-import { createPomMethodSignature, createPomParameterSpec } from "../pom-params";
+import { createPomMethodSignature, createPomParameters } from "../pom-params";
 import { createPomStringPattern } from "../pom-patterns";
 import {
   addComponentTestIds,
@@ -988,7 +988,7 @@ describe("utils.ts coverage", () => {
     expect(prev).not.toBeUndefined();
 
     // Force a collision on the next registration pass.
-    deps.generatedMethods!.set(some, createPomMethodSignature([createPomParameterSpec("x", "number")]));
+    deps.generatedMethods!.set(some, createPomMethodSignature(createPomParameters(["x", "number"])));
 
     applyResolvedDataTestId({
       element: el,
@@ -1008,12 +1008,12 @@ describe("utils.ts coverage", () => {
 
     // Because dynamic options use ensureUniqueGeneratedName, collisions produce a suffixed name
     // rather than poisoning the original signature.
-    expect(deps.generatedMethods!.get(some)).toEqual(createPomMethodSignature([createPomParameterSpec("x", "number")]));
+    expect(deps.generatedMethods!.get(some)).toEqual(createPomMethodSignature(createPomParameters(["x", "number"])));
     expect(deps.generatedMethods!.get("selectRadio2")).toEqual(
-      createPomMethodSignature([
-        createPomParameterSpec("value", "string"),
-        createPomParameterSpec("annotationText", "string = \"\""),
-      ]),
+      createPomMethodSignature(createPomParameters(
+        ["value", "string"],
+        ["annotationText", "string = \"\""],
+      )),
     );
 
     // Dynamic options should be represented as a single extra method that interpolates `${value}`.

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -39,7 +39,7 @@ import {
   nodeHandlerAttributeValue,
   nodeHasClickDirective,
   nodeHasToDirective,
-  renderTemplateLiteralExpressionFromFragment,
+  renderTemplateLiteralExpression,
   setResolveToComponentNameFn,
   setRouteNameToComponentNameMap,
   staticAttributeValue,
@@ -424,7 +424,11 @@ describe("utils.ts coverage", () => {
       template: "line-${item.id}",
       rawExpression: null,
     });
-    expect(renderTemplateLiteralExpressionFromFragment("line-${item.id}")).toBe("`line-${item.id}`");
+    const templateValue = templateAttributeValue("line-${item.id}");
+    expect(templateValue.kind).toBe("template");
+    if (templateValue.kind === "template") {
+      expect(renderTemplateLiteralExpression(templateValue)).toBe("`line-${item.id}`");
+    }
   });
 
   it("extracts id/name identifiers", () => {

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -26,10 +26,9 @@ import {
   getAttributeValueText,
   getComposedClickHandlerContent,
   getContainedInSlotDataKeyInfo,
-  getContainedInVForDirectiveKeyValue,
+  getContainedInVForDirectiveKeyInfo,
   getStaticIdOrNameHint,
-  getKeyDirectiveValue,
-  getKeyDirectiveRuntimeValue,
+  getKeyDirectiveInfo,
   getNativeWrapperTransformInfo,
   getRouteNameKeyFromToDirective,
   getSelfClosingForDirectiveKeyAttrValue,
@@ -396,10 +395,11 @@ describe("utils.ts coverage", () => {
   it("handles :key extraction paths", () => {
     const ast = parseTemplate("<div :key=\"item.id\" />");
     const el = firstElement(ast);
-    expect(getKeyDirectiveValue(el)).toBe("${item.id}");
-    // The selector-facing helper still produces the same placeholder even though key resolution
-    // now flows through the shared key-info object rather than a context-sensitive branch.
-    expect(getKeyDirectiveValue(el, {} as TransformContext)).toBe("${item.id}");
+    expect(getKeyDirectiveInfo(el)).toEqual({
+      selectorFragment: "${item.id}",
+      runtimeFragment: "${item.id}",
+      rawExpression: "item.id",
+    });
 
     const ast2 = parseTemplate("<Foo v-for=\"x in xs\" :key=\"x.id\" />");
     const foo = firstElement(ast2);
@@ -413,8 +413,11 @@ describe("utils.ts coverage", () => {
 
     const ast4 = parseTemplate("<div :key=\"`line-${item.id}`\" />");
     const el4 = firstElement(ast4);
-    expect(getKeyDirectiveValue(el4)).toBe("line-${item.id}");
-    expect(getKeyDirectiveRuntimeValue(el4)).toBe("line-${item.id}");
+    expect(getKeyDirectiveInfo(el4)).toEqual({
+      selectorFragment: "line-${item.id}",
+      runtimeFragment: "line-${item.id}",
+      rawExpression: null,
+    });
   });
 
   it("normalizes key fragments into template-safe output", () => {
@@ -490,8 +493,12 @@ describe("utils.ts coverage", () => {
     const span = findFirstTag(ast, "span");
     const map = buildHierarchyMap(ast);
 
-    expect(getContainedInVForDirectiveKeyValue({ scopes: { vFor: 0 } } as TransformContext, span, map)).toBeNull();
-    expect(getContainedInVForDirectiveKeyValue({ scopes: { vFor: 1 } } as TransformContext, span, map)).toBe("${item.id}");
+    expect(getContainedInVForDirectiveKeyInfo({ scopes: { vFor: 0 } } as TransformContext, span, map)).toBeNull();
+    expect(getContainedInVForDirectiveKeyInfo({ scopes: { vFor: 1 } } as TransformContext, span, map)).toEqual({
+      selectorFragment: "${item.id}",
+      runtimeFragment: "${item.id}",
+      rawExpression: "item.id",
+    });
 
     const astStatic = compileAndCaptureAst(
       "<div v-for=\"item in ['One','Two']\" :key=\"item\"><span /></div>",

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -21,6 +21,7 @@ import { createPomStringPattern } from "../pom-patterns";
 import {
   addComponentTestIds,
   applyResolvedDataTestId,
+  analyzeToDirectiveTarget,
   findDataTestIdAttribute,
   findTestIdAttribute,
   formatTagName,
@@ -241,6 +242,22 @@ function setBindAst(node: ElementNode, argName: string, expAstSource: string) {
     directiveNode.exp.ast = parseExpression(expAstSource, { plugins: ["typescript"] });
 }
 
+function clearBindAst(node: ElementNode, argName: string) {
+  const dir = node.props.find(
+    (p)  =>
+      p.type === NodeTypes.DIRECTIVE
+      && p.name === "bind"
+      && p.arg?.type === NodeTypes.SIMPLE_EXPRESSION
+      && p.arg.content === argName,
+  );
+  const directiveNode = dir as DirectiveNode;
+  if (!directiveNode || directiveNode === undefined || directiveNode.exp === undefined) {
+    throw new Error(`Missing :${argName} directive with SIMPLE_EXPRESSION`);
+  }
+  else
+    (directiveNode.exp as { ast?: unknown }).ast = null;
+}
+
 describe("utils.ts coverage", () => {
   it("covers simple type helpers and click detection", () => {
     expect(toPascalCase("hello world")).toBe("HelloWorld");
@@ -264,6 +281,12 @@ describe("utils.ts coverage", () => {
     const toDir = nodeHasToDirective(el);
     expect(toDir).toBeTruthy();
 
+    expect(analyzeToDirectiveTarget(toDir!)).toMatchObject({
+      kind: "resolved",
+      routeNameKey: "Users",
+      paramKeys: [],
+    });
+
     // Fallback map path
     setResolveToComponentNameFn(null);
     setRouteNameToComponentNameMap(new Map([["Users", "UsersPage"]]));
@@ -283,7 +306,28 @@ describe("utils.ts coverage", () => {
     const ast2 = parseTemplate("<RouterLink :to=\"{ name: 'users', params: { id: foo } }\">Users</RouterLink>");
     const el2 = firstElement(ast2);
     const toDir2 = nodeHasToDirective(el2);
+    expect(analyzeToDirectiveTarget(toDir2!)).toMatchObject({
+      kind: "resolved",
+      routeNameKey: "Users",
+      paramKeys: ["id"],
+    });
     expect(tryResolveToDirectiveTargetComponentName(toDir2!)).toBe("UsersViaResolve");
+  });
+
+  it("distinguishes unsupported and parse-error :to directive shapes", () => {
+    const unsupportedAst = parseTemplate("<RouterLink :to=\"routeTarget\">Users</RouterLink>");
+    const unsupportedDir = nodeHasToDirective(firstElement(unsupportedAst));
+    expect(analyzeToDirectiveTarget(unsupportedDir!)).toMatchObject({
+      kind: "unsupported",
+      reason: "dynamic-expression",
+    });
+
+    const parseErrorAst = parseTemplate("<RouterLink :to=\"foo(\">Users</RouterLink>");
+    const parseErrorDir = nodeHasToDirective(firstElement(parseErrorAst));
+    expect(analyzeToDirectiveTarget(parseErrorDir!)).toMatchObject({
+      kind: "parse-error",
+      reason: "parse-error",
+    });
   });
 
   it("derives :handler semanticNameHint from literal call arguments", () => {
@@ -708,6 +752,19 @@ describe("utils.ts coverage", () => {
     expect(info?.rawExpression).toBe("p.parameter.name");
   });
 
+  it("re-parses existing bound test ids through the shared Vue-expression AST helper when compiler ast is absent", () => {
+    const node = firstElement(parseTemplate("<div :data-testid=\"p.parameter.name\" />"));
+    clearBindAst(node, "data-testid");
+
+    const info = tryGetExistingElementDataTestId(node);
+    expect(info?.isDynamic).toBe(true);
+    expect(info?.isStaticLiteral).toBe(false);
+    expect(info?.value).toBe("p.parameter.name");
+    expect(info?.template).toBe("${p.parameter.name}");
+    expect(info?.templateExpressionCount).toBe(1);
+    expect(info?.rawExpression).toBe("p.parameter.name");
+  });
+
   it("throws when preserving an existing dynamic data-testid expression (unusable selector)", () => {
     const el = firstElement(parseTemplate("<button :data-testid=\"__props.name\" />"));
 
@@ -920,6 +977,7 @@ describe("utils.ts coverage", () => {
       keyInfo: null,
       testIdAttribute: "data-testid",
       existingIdBehavior: "overwrite",
+      nameCollisionBehavior: "suffix",
       addHtmlAttribute: false,
       entryOverrides: { selectorValue: createPomStringPattern("MyComp-Foo-radio", "static") },
     });
@@ -947,6 +1005,7 @@ describe("utils.ts coverage", () => {
       keyInfo: null,
       testIdAttribute: "data-testid",
       existingIdBehavior: "overwrite",
+      nameCollisionBehavior: "suffix",
       addHtmlAttribute: false,
       entryOverrides: { selectorValue: createPomStringPattern("MyComp-Foo-radio", "static") },
     });
@@ -980,6 +1039,7 @@ describe("utils.ts coverage", () => {
       keyInfo: null,
       testIdAttribute: "data-testid",
       existingIdBehavior: "overwrite",
+      nameCollisionBehavior: "suffix",
       addHtmlAttribute: false,
     });
 
@@ -1003,6 +1063,7 @@ describe("utils.ts coverage", () => {
       keyInfo: null,
       testIdAttribute: "data-testid",
       existingIdBehavior: "overwrite",
+      nameCollisionBehavior: "suffix",
       addHtmlAttribute: false,
     });
 

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -435,7 +435,9 @@ describe("utils.ts coverage", () => {
     expect(getIdOrName(firstElement(parseTemplate("<div id=\"foo-bar\" />")))).toBe("FooBar");
     expect(getIdOrName(firstElement(parseTemplate("<div name=\"foo_bar\" />")))).toBe("FooBar");
     const dyn = firstElement(parseTemplate("<div :id=\"something\" />"));
-    expect(getIdOrName(dyn)).toContain("someUniqueValueToDifferentiateInstanceFromOthersOnPageUsuallyAnId");
+    expect(getIdOrName(dyn)).toBe("");
+    const dynName = firstElement(parseTemplate("<div :name=\"something\" />"));
+    expect(getIdOrName(dynName)).toBe("");
   });
 
   it("extracts :handler semantic hints from common patterns", () => {

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -39,10 +39,12 @@ import {
   nodeHandlerAttributeValue,
   nodeHasClickDirective,
   nodeHasToDirective,
+  renderTemplateLiteralExpressionFromFragment,
   setResolveToComponentNameFn,
   setRouteNameToComponentNameMap,
   staticAttributeValue,
   templateAttributeValue,
+  toInterpolatedTemplateFragment,
   toPascalCase,
   tryGetClickDirective,
   tryGetContainedInStaticVForSourceLiteralValues,
@@ -411,6 +413,18 @@ describe("utils.ts coverage", () => {
     const el4 = firstElement(ast4);
     expect(getKeyDirectiveValue(el4)).toBe("line-${item.id}");
     expect(getKeyDirectiveRuntimeValue(el4)).toBe("line-${item.id}");
+  });
+
+  it("normalizes key fragments into template-safe output", () => {
+    expect(toInterpolatedTemplateFragment("item.id")).toEqual({
+      template: "${item.id}",
+      rawExpression: "item.id",
+    });
+    expect(toInterpolatedTemplateFragment("line-${item.id}")).toEqual({
+      template: "line-${item.id}",
+      rawExpression: null,
+    });
+    expect(renderTemplateLiteralExpressionFromFragment("line-${item.id}")).toBe("`line-${item.id}`");
   });
 
   it("extracts id/name identifiers", () => {

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -16,6 +16,7 @@ import { baseCompile, parse, parserOptions } from "@vue/compiler-dom";
 
 import { parseExpression } from "@babel/parser";
 
+import { createPomMethodSignature } from "../pom-params";
 import { createPomStringPattern } from "../pom-patterns";
 import {
   addComponentTestIds,
@@ -987,7 +988,7 @@ describe("utils.ts coverage", () => {
     expect(prev).not.toBeUndefined();
 
     // Force a collision on the next registration pass.
-    deps.generatedMethods!.set(some, { params: "x: number", argNames: ["x"] });
+    deps.generatedMethods!.set(some, createPomMethodSignature({ x: "number" }));
 
     applyResolvedDataTestId({
       element: el,
@@ -1007,11 +1008,10 @@ describe("utils.ts coverage", () => {
 
     // Because dynamic options use ensureUniqueGeneratedName, collisions produce a suffixed name
     // rather than poisoning the original signature.
-    expect(deps.generatedMethods!.get(some)).toEqual({ params: "x: number", argNames: ["x"] });
-    expect(deps.generatedMethods!.get("selectRadio2")).toEqual({
-      params: "value: string, annotationText: string = \"\"",
-      argNames: ["value", "annotationText"],
-    });
+    expect(deps.generatedMethods!.get(some)).toEqual(createPomMethodSignature({ x: "number" }));
+    expect(deps.generatedMethods!.get("selectRadio2")).toEqual(
+      createPomMethodSignature({ value: "string", annotationText: "string = \"\"" }),
+    );
 
     // Dynamic options should be represented as a single extra method that interpolates `${value}`.
     const extras = deps.pomExtraMethods ?? [];

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -16,7 +16,7 @@ import { baseCompile, parse, parserOptions } from "@vue/compiler-dom";
 
 import { parseExpression } from "@babel/parser";
 
-import { createPomMethodSignature } from "../pom-params";
+import { createPomMethodSignature, createPomParameterSpec } from "../pom-params";
 import { createPomStringPattern } from "../pom-patterns";
 import {
   addComponentTestIds,
@@ -988,7 +988,7 @@ describe("utils.ts coverage", () => {
     expect(prev).not.toBeUndefined();
 
     // Force a collision on the next registration pass.
-    deps.generatedMethods!.set(some, createPomMethodSignature({ x: "number" }));
+    deps.generatedMethods!.set(some, createPomMethodSignature([createPomParameterSpec("x", "number")]));
 
     applyResolvedDataTestId({
       element: el,
@@ -1008,9 +1008,12 @@ describe("utils.ts coverage", () => {
 
     // Because dynamic options use ensureUniqueGeneratedName, collisions produce a suffixed name
     // rather than poisoning the original signature.
-    expect(deps.generatedMethods!.get(some)).toEqual(createPomMethodSignature({ x: "number" }));
+    expect(deps.generatedMethods!.get(some)).toEqual(createPomMethodSignature([createPomParameterSpec("x", "number")]));
     expect(deps.generatedMethods!.get("selectRadio2")).toEqual(
-      createPomMethodSignature({ value: "string", annotationText: "string = \"\"" }),
+      createPomMethodSignature([
+        createPomParameterSpec("value", "string"),
+        createPomParameterSpec("annotationText", "string = \"\""),
+      ]),
     );
 
     // Dynamic options should be represented as a single extra method that interpolates `${value}`.

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -25,8 +25,9 @@ import {
   generateToDirectiveDataTestId,
   getAttributeValueText,
   getComposedClickHandlerContent,
+  getContainedInSlotDataKeyInfo,
   getContainedInVForDirectiveKeyValue,
-  getIdOrName,
+  getStaticIdOrNameHint,
   getKeyDirectiveValue,
   getKeyDirectiveRuntimeValue,
   getNativeWrapperTransformInfo,
@@ -396,7 +397,8 @@ describe("utils.ts coverage", () => {
     const ast = parseTemplate("<div :key=\"item.id\" />");
     const el = firstElement(ast);
     expect(getKeyDirectiveValue(el)).toBe("${item.id}");
-    // any non-null context triggers stringifyExpression branch
+    // The selector-facing helper still produces the same placeholder even though key resolution
+    // now flows through the shared key-info object rather than a context-sensitive branch.
     expect(getKeyDirectiveValue(el, {} as TransformContext)).toBe("${item.id}");
 
     const ast2 = parseTemplate("<Foo v-for=\"x in xs\" :key=\"x.id\" />");
@@ -432,12 +434,12 @@ describe("utils.ts coverage", () => {
   });
 
   it("extracts id/name identifiers", () => {
-    expect(getIdOrName(firstElement(parseTemplate("<div id=\"foo-bar\" />")))).toBe("FooBar");
-    expect(getIdOrName(firstElement(parseTemplate("<div name=\"foo_bar\" />")))).toBe("FooBar");
+    expect(getStaticIdOrNameHint(firstElement(parseTemplate("<div id=\"foo-bar\" />")))).toBe("FooBar");
+    expect(getStaticIdOrNameHint(firstElement(parseTemplate("<div name=\"foo_bar\" />")))).toBe("FooBar");
     const dyn = firstElement(parseTemplate("<div :id=\"something\" />"));
-    expect(getIdOrName(dyn)).toBe("");
+    expect(getStaticIdOrNameHint(dyn)).toBe("");
     const dynName = firstElement(parseTemplate("<div :name=\"something\" />"));
-    expect(getIdOrName(dynName)).toBe("");
+    expect(getStaticIdOrNameHint(dynName)).toBe("");
   });
 
   it("extracts :handler semantic hints from common patterns", () => {
@@ -466,6 +468,21 @@ describe("utils.ts coverage", () => {
     const map2 = buildHierarchyMap(withoutData);
     const span2 = findFirstTag(withoutData, "span");
     expect(isNodeContainedInTemplateWithData(span2, map2)).toBe(false);
+  });
+
+  it("extracts slot-scope key info from compiled slot bindings", () => {
+    const compiled = compileAndCaptureAst(
+      "<MyList><template #item=\"{ data }\"><div><span>Hi</span></div></template></MyList>",
+      { filename: "/src/components/Test.vue" },
+    );
+    const map = buildHierarchyMap(compiled);
+    const span = findFirstTag(compiled, "span");
+
+    expect(getContainedInSlotDataKeyInfo(span, map)).toEqual({
+      selectorFragment: "${data.key ?? data.data?.id ?? data.id ?? data.value ?? data}",
+      runtimeFragment: "${data.key ?? data.data?.id ?? data.id ?? data.value ?? data}",
+      rawExpression: "data.key ?? data.data?.id ?? data.id ?? data.value ?? data",
+    });
   });
 
   it("walks v-for scopes for :key and infers static iterable literals", () => {
@@ -705,7 +722,7 @@ describe("utils.ts coverage", () => {
         generatedMethodContentByComponent,
         nativeRole: "button",
         preferredGeneratedValue: staticAttributeValue("MyComp-Foo-button"),
-        bestKeyPlaceholder: null,
+        keyInfo: null,
         testIdAttribute: "data-testid",
         existingIdBehavior: "preserve",
         addHtmlAttribute: false,
@@ -736,7 +753,11 @@ describe("utils.ts coverage", () => {
       generatedMethodContentByComponent,
       nativeRole: "button",
       preferredGeneratedValue: staticAttributeValue("ignored"),
-      bestKeyPlaceholder: "${item.id}",
+      keyInfo: {
+        selectorFragment: "${item.id}",
+        runtimeFragment: "${item.id}",
+        rawExpression: "item.id",
+      },
       testIdAttribute: "data-testid",
       existingIdBehavior: "preserve",
       addHtmlAttribute: false,
@@ -770,7 +791,11 @@ describe("utils.ts coverage", () => {
       generatedMethodContentByComponent,
       nativeRole: "button",
       preferredGeneratedValue: staticAttributeValue("ignored"),
-      bestKeyPlaceholder: "line-${item.id}",
+      keyInfo: {
+        selectorFragment: "line-${item.id}",
+        runtimeFragment: "line-${item.id}",
+        rawExpression: null,
+      },
       testIdAttribute: "data-testid",
       existingIdBehavior: "preserve",
       addHtmlAttribute: false,
@@ -804,8 +829,11 @@ describe("utils.ts coverage", () => {
       generatedMethodContentByComponent,
       nativeRole: "button",
       preferredGeneratedValue: staticAttributeValue("ignored"),
-      bestKeyPlaceholder: "${data.key ?? data.data?.id ?? data.id ?? data.value ?? data}",
-      bestKeyVariable: "data.key ?? data.data?.id ?? data.id ?? data.value ?? data",
+      keyInfo: {
+        selectorFragment: "${data.key ?? data.data?.id ?? data.id ?? data.value ?? data}",
+        runtimeFragment: "${data.key ?? data.data?.id ?? data.id ?? data.value ?? data}",
+        rawExpression: "data.key ?? data.data?.id ?? data.id ?? data.value ?? data",
+      },
       testIdAttribute: "data-testid",
       existingIdBehavior: "preserve",
       addHtmlAttribute: false,
@@ -839,8 +867,11 @@ describe("utils.ts coverage", () => {
       generatedMethodContentByComponent,
       nativeRole: "button",
       preferredGeneratedValue: staticAttributeValue("ignored"),
-      bestKeyPlaceholder: "${p.parameter.name}",
-      bestKeyVariable: "p.parameter.name",
+      keyInfo: {
+        selectorFragment: "${p.parameter.name}",
+        runtimeFragment: "${p.parameter.name}",
+        rawExpression: "p.parameter.name",
+      },
       testIdAttribute: "data-testid",
       existingIdBehavior: "preserve",
       addHtmlAttribute: false,
@@ -877,7 +908,7 @@ describe("utils.ts coverage", () => {
       generatedMethodContentByComponent,
       nativeRole: "radio",
       preferredGeneratedValue: staticAttributeValue("MyComp-Foo-radio"),
-      bestKeyPlaceholder: null,
+      keyInfo: null,
       testIdAttribute: "data-testid",
       existingIdBehavior: "overwrite",
       addHtmlAttribute: false,
@@ -904,7 +935,7 @@ describe("utils.ts coverage", () => {
       generatedMethodContentByComponent,
       nativeRole: "radio",
       preferredGeneratedValue: staticAttributeValue("MyComp-Foo-radio"),
-      bestKeyPlaceholder: null,
+      keyInfo: null,
       testIdAttribute: "data-testid",
       existingIdBehavior: "overwrite",
       addHtmlAttribute: false,
@@ -937,7 +968,7 @@ describe("utils.ts coverage", () => {
       generatedMethodContentByComponent,
       nativeRole: "radio",
       preferredGeneratedValue: staticAttributeValue("MyComp-radio"),
-      bestKeyPlaceholder: null,
+      keyInfo: null,
       testIdAttribute: "data-testid",
       existingIdBehavior: "overwrite",
       addHtmlAttribute: false,
@@ -960,7 +991,7 @@ describe("utils.ts coverage", () => {
       // Change the wrapper prefix so the extra method is not semantically de-duped,
       // and the generator has to pick a unique name.
       preferredGeneratedValue: staticAttributeValue("MyComp2-radio"),
-      bestKeyPlaceholder: null,
+      keyInfo: null,
       testIdAttribute: "data-testid",
       existingIdBehavior: "overwrite",
       addHtmlAttribute: false,
@@ -1022,7 +1053,7 @@ describe("utils.ts coverage", () => {
         generatedMethodContentByComponent,
         nativeRole: "button",
         preferredGeneratedValue: staticAttributeValue("MyComp-A-button"),
-        bestKeyPlaceholder: null,
+        keyInfo: null,
         testIdAttribute: "data-testid",
         existingIdBehavior: "overwrite",
         addHtmlAttribute: false,
@@ -1038,7 +1069,7 @@ describe("utils.ts coverage", () => {
           generatedMethodContentByComponent,
           nativeRole: "button",
           preferredGeneratedValue: staticAttributeValue("MyComp-B-button"),
-          bestKeyPlaceholder: null,
+          keyInfo: null,
           testIdAttribute: "data-testid",
           existingIdBehavior: "overwrite",
           addHtmlAttribute: false,
@@ -1061,7 +1092,7 @@ describe("utils.ts coverage", () => {
         generatedMethodContentByComponent,
         nativeRole: "button",
         preferredGeneratedValue: staticAttributeValue("MyComp-A-button"),
-        bestKeyPlaceholder: null,
+        keyInfo: null,
         testIdAttribute: "data-testid",
         existingIdBehavior: "overwrite",
         addHtmlAttribute: false,
@@ -1077,7 +1108,7 @@ describe("utils.ts coverage", () => {
         generatedMethodContentByComponent,
         nativeRole: "button",
         preferredGeneratedValue: staticAttributeValue("MyComp-B-button"),
-        bestKeyPlaceholder: null,
+        keyInfo: null,
         testIdAttribute: "data-testid",
         existingIdBehavior: "overwrite",
         addHtmlAttribute: false,
@@ -1107,7 +1138,7 @@ describe("utils.ts coverage", () => {
         generatedMethodContentByComponent,
         nativeRole: "button",
         preferredGeneratedValue: staticAttributeValue("MyComp-A-button"),
-        bestKeyPlaceholder: null,
+        keyInfo: null,
         testIdAttribute: "data-testid",
         existingIdBehavior: "overwrite",
         addHtmlAttribute: false,
@@ -1123,7 +1154,7 @@ describe("utils.ts coverage", () => {
         generatedMethodContentByComponent,
         nativeRole: "button",
         preferredGeneratedValue: staticAttributeValue("MyComp-B-button"),
-        bestKeyPlaceholder: null,
+        keyInfo: null,
         testIdAttribute: "data-testid",
         existingIdBehavior: "overwrite",
         addHtmlAttribute: false,
@@ -1163,7 +1194,7 @@ describe("utils.ts coverage", () => {
         generatedMethodContentByComponent,
         nativeRole: "button",
         preferredGeneratedValue: templateAttributeValue("MyComp-${value}-immynavitem"),
-        bestKeyPlaceholder: null,
+        keyInfo: null,
         testIdAttribute: "data-testid",
         existingIdBehavior: "overwrite",
         addHtmlAttribute: false,
@@ -1213,7 +1244,7 @@ describe("utils.ts coverage", () => {
       nativeRole: "select",
       semanticNameHint: "ParameterDefaultValue",
       preferredGeneratedValue: staticAttributeValue("MyComp-select"),
-      bestKeyPlaceholder: null,
+      keyInfo: null,
       testIdAttribute: "data-testid",
       existingIdBehavior: "overwrite",
       addHtmlAttribute: false,
@@ -1230,7 +1261,7 @@ describe("utils.ts coverage", () => {
         nativeRole: "radio",
         semanticNameHint: "ParameterDefaultValue",
         preferredGeneratedValue: staticAttributeValue("MyComp-radio"),
-        bestKeyPlaceholder: null,
+        keyInfo: null,
         testIdAttribute: "data-testid",
         existingIdBehavior: "overwrite",
         addHtmlAttribute: false,
@@ -1268,7 +1299,7 @@ describe("utils.ts coverage", () => {
       generatedMethodContentByComponent,
       nativeRole: "radio",
       preferredGeneratedValue: staticAttributeValue("MyComp-radio"),
-      bestKeyPlaceholder: null,
+      keyInfo: null,
       testIdAttribute: "data-testid",
       existingIdBehavior: "overwrite",
       addHtmlAttribute: false,

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -745,6 +745,40 @@ describe("utils.ts coverage", () => {
     expect(entries[0]?.pom?.formattedDataTestId).toBe("abc-${key}");
   });
 
+  it("allows preserving an existing template when the required key fragment carries literal context", () => {
+    const el = firstElement(parseTemplate("<button :data-testid=\"`abc-line-${item.id}`\" />"));
+    setBindAst(el, "data-testid", "`abc-line-${item.id}`");
+
+    const deps: IComponentDependencies = {
+      filePath: "/src/components/MyComp.vue",
+      childrenComponentSet: new Set(),
+      usedComponentSet: new Set(),
+      dataTestIdSet: new Set<IDataTestId>(),
+      generatedMethods: new Map(),
+      isView: false,
+    };
+
+    const generatedMethodContentByComponent = new Map<string, Set<string>>();
+
+    applyResolvedDataTestId({
+      element: el,
+      componentName: "MyComp",
+      parentComponentName: "MyComp",
+      dependencies: deps,
+      generatedMethodContentByComponent,
+      nativeRole: "button",
+      preferredGeneratedValue: staticAttributeValue("ignored"),
+      bestKeyPlaceholder: "line-${item.id}",
+      testIdAttribute: "data-testid",
+      existingIdBehavior: "preserve",
+      addHtmlAttribute: false,
+    });
+
+    const entries = Array.from(deps.dataTestIdSet);
+    expect(entries.length).toBe(1);
+    expect(entries[0]?.pom?.formattedDataTestId).toBe("abc-line-${key}");
+  });
+
   it("allows preserving an existing key-based template literal that uses a fallback branch access", () => {
     const el = firstElement(parseTemplate("<button :data-testid=\"`abc-${data.id}`\" />"));
     setBindAst(el, "data-testid", "`abc-${data.id}`");

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -1019,7 +1019,9 @@ describe("utils.ts coverage", () => {
     expect(method1?.selector).toEqual({
       kind: "withinTestIdByLabel",
       rootFormattedDataTestId: "MyComp-radio",
+      rootPatternKind: "static",
       formattedLabel: "${value}",
+      labelPatternKind: "parameterized",
       exact: true,
     });
 
@@ -1028,7 +1030,9 @@ describe("utils.ts coverage", () => {
     expect(method2?.selector).toEqual({
       kind: "withinTestIdByLabel",
       rootFormattedDataTestId: "MyComp2-radio",
+      rootPatternKind: "static",
       formattedLabel: "${value}",
+      labelPatternKind: "parameterized",
       exact: true,
     });
   });

--- a/transform.ts
+++ b/transform.ts
@@ -32,6 +32,7 @@ import {
   getContainedInVForDirectiveKeyValue,
   getContainedInVForDirectiveKeyRuntimeValue,
   getContainedInSlotDataKeyValue,
+  hasTemplateInterpolationExpressions,
   tryGetContainedInStaticVForSourceLiteralValues,
   getKeyDirectiveValue,
   getKeyDirectiveRuntimeValue,
@@ -1111,11 +1112,15 @@ export function createTestIdTransform(
 
     const bestKeyInferred = getBestAvailableKeyValue();
     const bestRuntimeKeyInferred = getBestAvailableRuntimeKeyValue();
-    const isSlotKey = bestKeyInferred && !bestKeyInferred.startsWith("${");
-    const bestKeyPlaceholder = isSlotKey ? `\${${bestKeyInferred}}` : bestKeyInferred;
-    const isRuntimeSlotKey = bestRuntimeKeyInferred && !bestRuntimeKeyInferred.startsWith("${");
-    const bestRuntimeKeyPlaceholder = isRuntimeSlotKey ? `\${${bestRuntimeKeyInferred}}` : bestRuntimeKeyInferred;
-    const bestKeyVariable = isSlotKey ? bestKeyInferred : null;
+    const bestKeyNeedsInterpolation = !!bestKeyInferred && !hasTemplateInterpolationExpressions(bestKeyInferred);
+    const bestKeyPlaceholder = bestKeyInferred
+      ? (bestKeyNeedsInterpolation ? `\${${bestKeyInferred}}` : bestKeyInferred)
+      : null;
+    const bestRuntimeKeyNeedsInterpolation = !!bestRuntimeKeyInferred && !hasTemplateInterpolationExpressions(bestRuntimeKeyInferred);
+    const bestRuntimeKeyPlaceholder = bestRuntimeKeyInferred
+      ? (bestRuntimeKeyNeedsInterpolation ? `\${${bestRuntimeKeyInferred}}` : bestRuntimeKeyInferred)
+      : null;
+    const bestKeyVariable = bestKeyNeedsInterpolation ? bestKeyInferred : null;
 
     // If we can prove the v-for iterable is a static literal list, capture the concrete
     // values (e.g. ['One', 'Two']). Downstream codegen can use this to:

--- a/transform.ts
+++ b/transform.ts
@@ -19,7 +19,7 @@ import { parseExpression } from "@babel/parser";
 import path from "node:path";
 import fs from "node:fs";
 import process from "node:process";
-import { TESTID_CLICK_EVENT_NAME, TESTID_CLICK_EVENT_STRICT_FLAG } from "./click-instrumentation";
+import { TESTID_CLICK_EVENT_NAME } from "./click-instrumentation";
 import {
   isAsciiDigitCode,
   isAsciiLetterCode,
@@ -754,16 +754,12 @@ function tryWrapClickDirectiveForTestEvents(
         __w.dispatchEvent(new __CustomEvent('${CLICK_EVENT_NAME}', { detail: { testId: __testId, phase, err: err ? String(err) : undefined } }));
       }
     } catch (e) {
-      // Instrumentation must never hide failures during e2e strict mode.
-      // In strict mode we rethrow so tests fail fast and the underlying problem is visible.
-      // Outside strict mode we log and continue so we don't break real user clicks.
+      // Instrumentation failures should never be silent. Log the root cause and fail fast.
       const __w = __win || (__target && __target.ownerDocument && __target.ownerDocument.defaultView);
       if (__w && __w.console && typeof __w.console.error === 'function') {
         __w.console.error('[testid-click-event] failed to emit ${CLICK_EVENT_NAME}', e);
       }
-      if (__w && (__w[${JSON.stringify(TESTID_CLICK_EVENT_STRICT_FLAG)}] === true)) {
-        throw e;
-      }
+      throw e;
     }
   };
     const __w2 = __win || (__target && __target.ownerDocument && __target.ownerDocument.defaultView);
@@ -806,16 +802,12 @@ function tryWrapClickDirectiveForTestEvents(
         __w.dispatchEvent(new __CustomEvent('${CLICK_EVENT_NAME}', { detail: { testId: __testId, phase, err: err ? String(err) : undefined } }));
       }
     } catch (e) {
-      // Instrumentation must never hide failures during e2e strict mode.
-      // In strict mode we rethrow so tests fail fast and the underlying problem is visible.
-      // Outside strict mode we log and continue so we don't break real user clicks.
+      // Instrumentation failures should never be silent. Log the root cause and fail fast.
       const __w = __win || (__target && __target.ownerDocument && __target.ownerDocument.defaultView);
       if (__w && __w.console && typeof __w.console.error === 'function') {
         __w.console.error('[testid-click-event] failed to emit ${CLICK_EVENT_NAME}', e);
       }
-      if (__w && (__w[${JSON.stringify(TESTID_CLICK_EVENT_STRICT_FLAG)}] === true)) {
-        throw e;
-      }
+      throw e;
     }
   };
     const __w2 = __win || (__target && __target.ownerDocument && __target.ownerDocument.defaultView);
@@ -868,16 +860,14 @@ export function createTestIdTransform(
     existingIdBehavior?: "preserve" | "overwrite" | "error";
     testIdAttribute?: string;
     nameCollisionBehavior?: "error" | "warn" | "suffix";
-    missingSemanticNameBehavior?: "ignore" | "error";
     warn?: (message: string) => void;
     vueFilesPathMap?: Map<string, string>;
     wrapperSearchRoots?: string[];
   } = {},
 ): NodeTransform {
-  const existingIdBehavior = options.existingIdBehavior ?? "preserve";
+  const existingIdBehavior = options.existingIdBehavior ?? "error";
   const testIdAttribute = (options.testIdAttribute || "data-testid").trim() || "data-testid";
-  const nameCollisionBehavior = options.nameCollisionBehavior ?? "suffix";
-  const missingSemanticNameBehavior = options.missingSemanticNameBehavior ?? "error";
+  const nameCollisionBehavior = options.nameCollisionBehavior ?? "error";
   const warn = options.warn;
   const vueFilesPathMap = options.vueFilesPathMap;
   const wrapperSearchRoots = options.wrapperSearchRoots ?? [];
@@ -1295,12 +1285,7 @@ export function createTestIdTransform(
     }) ?? null;
     const handlerInfo = handlerDirective ? nodeHandlerAttributeInfo(element) : null;
 
-    if (
-      missingSemanticNameBehavior === "error"
-      && nativeWrappers[element.tag]?.role === "button"
-      && handlerDirective
-      && !handlerInfo
-    ) {
+    if (nativeWrappers[element.tag]?.role === "button" && handlerDirective && !handlerInfo) {
       const loc = element.loc?.start;
       const locationHint = loc ? `${loc.line}:${loc.column}` : "unknown";
       const handlerSource = (handlerDirective.exp?.loc?.source ?? "").trim() || "<unknown>";
@@ -1310,8 +1295,7 @@ export function createTestIdTransform(
         + `Element: <${element.tag}>\n`
         + `Handler: ${handlerSource}\n\n`
         + `Fix: move complex inline logic into a named function (for example, const onAction = () => ...; then bind :handler="onAction"), `
-        + `or simplify the handler to a direct identifier/call the generator can name. `
-        + `You can also set errorBehavior = "ignore" to keep generic fallback behavior.`,
+        + `or simplify the handler to a direct identifier/call the generator can name.`,
       );
     }
 

--- a/transform.ts
+++ b/transform.ts
@@ -56,7 +56,6 @@ import {
 } from "./utils";
 
 const CLICK_EVENT_NAME = TESTID_CLICK_EVENT_NAME;
-const DEFAULT_CLICK_INSTRUMENTATION = true;
 // Cache inferred wrapper configs across transforms/build passes.
 const inferredNativeWrapperConfigByLookup = new Map<string, { role: string }>();
 const inferredSfcPathByLookup = new Map<string, string | null>();
@@ -873,7 +872,6 @@ export function createTestIdTransform(
     testIdAttribute?: string;
     nameCollisionBehavior?: "error" | "warn" | "suffix";
     missingSemanticNameBehavior?: "ignore" | "error";
-    clickInstrumentation?: boolean;
     warn?: (message: string) => void;
     vueFilesPathMap?: Map<string, string>;
     wrapperSearchRoots?: string[];
@@ -883,7 +881,6 @@ export function createTestIdTransform(
   const testIdAttribute = (options.testIdAttribute || "data-testid").trim() || "data-testid";
   const nameCollisionBehavior = options.nameCollisionBehavior ?? "suffix";
   const missingSemanticNameBehavior = options.missingSemanticNameBehavior ?? "error";
-  const enableClickInstrumentation = options.clickInstrumentation ?? DEFAULT_CLICK_INSTRUMENTATION;
   const warn = options.warn;
   const vueFilesPathMap = options.vueFilesPathMap;
   const wrapperSearchRoots = options.wrapperSearchRoots ?? [];
@@ -1547,9 +1544,7 @@ export function createTestIdTransform(
 
       // Instrument @click handlers so Playwright can wait on deterministic UI-side events
       // without relying on network inspection.
-      if (enableClickInstrumentation) {
-        tryWrapClickDirectiveForTestEvents(element, testIdAttribute, resolvedDataTestId.runtimeValue);
-      }
+      tryWrapClickDirectiveForTestEvents(element, testIdAttribute, resolvedDataTestId.runtimeValue);
       return;
     }
 

--- a/transform.ts
+++ b/transform.ts
@@ -32,7 +32,7 @@ import {
   getContainedInVForDirectiveKeyValue,
   getContainedInVForDirectiveKeyRuntimeValue,
   getContainedInSlotDataKeyValue,
-  hasTemplateInterpolationExpressions,
+  renderTemplateLiteralExpressionFromFragment,
   tryGetContainedInStaticVForSourceLiteralValues,
   getKeyDirectiveValue,
   getKeyDirectiveRuntimeValue,
@@ -53,6 +53,7 @@ import {
   NativeWrappersMap,
   NativeRole,
   applyResolvedDataTestId,
+  toInterpolatedTemplateFragment,
   tryGetExistingElementDataTestId,
 } from "./utils";
 
@@ -685,7 +686,7 @@ function tryWrapClickDirectiveForTestEvents(
       return jsStringLiteral(resolvedRuntimeTestId.value);
     }
 
-    return `(\`${resolvedRuntimeTestId.template}\`)`;
+    return `(${renderTemplateLiteralExpressionFromFragment(resolvedRuntimeTestId.template)})`;
   };
 
   const testIdExpression = getTestIdExpressionForNode();
@@ -1112,15 +1113,11 @@ export function createTestIdTransform(
 
     const bestKeyInferred = getBestAvailableKeyValue();
     const bestRuntimeKeyInferred = getBestAvailableRuntimeKeyValue();
-    const bestKeyNeedsInterpolation = !!bestKeyInferred && !hasTemplateInterpolationExpressions(bestKeyInferred);
-    const bestKeyPlaceholder = bestKeyInferred
-      ? (bestKeyNeedsInterpolation ? `\${${bestKeyInferred}}` : bestKeyInferred)
-      : null;
-    const bestRuntimeKeyNeedsInterpolation = !!bestRuntimeKeyInferred && !hasTemplateInterpolationExpressions(bestRuntimeKeyInferred);
-    const bestRuntimeKeyPlaceholder = bestRuntimeKeyInferred
-      ? (bestRuntimeKeyNeedsInterpolation ? `\${${bestRuntimeKeyInferred}}` : bestRuntimeKeyInferred)
-      : null;
-    const bestKeyVariable = bestKeyNeedsInterpolation ? bestKeyInferred : null;
+    const bestKeyTemplateFragment = toInterpolatedTemplateFragment(bestKeyInferred);
+    const bestRuntimeKeyTemplateFragment = toInterpolatedTemplateFragment(bestRuntimeKeyInferred);
+    const bestKeyPlaceholder = bestKeyTemplateFragment?.template ?? null;
+    const bestRuntimeKeyPlaceholder = bestRuntimeKeyTemplateFragment?.template ?? null;
+    const bestKeyVariable = bestKeyTemplateFragment?.rawExpression ?? null;
 
     // If we can prove the v-for iterable is a static literal list, capture the concrete
     // values (e.g. ['One', 'Two']). Downstream codegen can use this to:

--- a/transform.ts
+++ b/transform.ts
@@ -11,7 +11,7 @@ import type {
   IfBranchNode,
   ForNode,
 } from "@vue/compiler-core";
-import type { AttributeValue, HierarchyMap } from "./utils";
+import type { AttributeValue, HierarchyMap, ResolvedKeyInfo } from "./utils";
 import { NodeTypes } from "@vue/compiler-core";
 import { parse as parseSfc } from "@vue/compiler-sfc";
 import { parse as parseTemplate } from "@vue/compiler-dom";
@@ -27,16 +27,14 @@ import {
   upsertAttribute,
   formatTagName,
   getComposedClickHandlerContent,
-  getIdOrName,
+  getStaticIdOrNameHint,
   getInnerText,
-  getContainedInVForDirectiveKeyValue,
-  getContainedInVForDirectiveKeyRuntimeValue,
-  getContainedInSlotDataKeyValue,
+  getContainedInSlotDataKeyInfo,
+  getContainedInVForDirectiveKeyInfo,
   getVueExpressionSource,
   renderTemplateLiteralExpression,
   tryGetContainedInStaticVForSourceLiteralValues,
-  getKeyDirectiveValue,
-  getKeyDirectiveRuntimeValue,
+  getKeyDirectiveInfo,
   getModelBindingValues,
   getNativeWrapperTransformInfo,
   nodeHandlerAttributeValue,
@@ -54,7 +52,6 @@ import {
   NativeWrappersMap,
   NativeRole,
   applyResolvedDataTestId,
-  toInterpolatedTemplateFragment,
   tryGetExistingElementDataTestId,
 } from "./utils";
 
@@ -1085,48 +1082,30 @@ export function createTestIdTransform(
       }
     }
 
-      const getBestAvailableKeyInfo = () => {
+      const getBestAvailableKeyInfo = (): ResolvedKeyInfo | null => {
         const parentNode = (context.parent && typeof context.parent === "object") ? context.parent as { type?: number } : null;
         const isDirectVForChild = parentNode?.type === NodeTypes.FOR;
 
-        const selectorFragment = (isDirectVForChild ? getKeyDirectiveValue(element, context) : null)
-          || getContainedInVForDirectiveKeyValue(context, element, hierarchyMap);
-        const runtimeFragment = (isDirectVForChild ? getKeyDirectiveRuntimeValue(element) : null)
-          || getContainedInVForDirectiveKeyRuntimeValue(context, element, hierarchyMap);
-        if (selectorFragment || runtimeFragment) {
-          return {
-            selectorFragment: selectorFragment ?? runtimeFragment,
-            runtimeFragment: runtimeFragment ?? selectorFragment,
-            rawExpression: null,
-          };
+        const vForKeyInfo = (isDirectVForChild ? getKeyDirectiveInfo(element) : null)
+          || getContainedInVForDirectiveKeyInfo(context, element, hierarchyMap);
+        if (vForKeyInfo) {
+          return vForKeyInfo;
         }
 
-        const slotKeyFragment = toInterpolatedTemplateFragment(getContainedInSlotDataKeyValue(element, hierarchyMap));
-        if (!slotKeyFragment) {
-          return null;
-        }
-
-        return {
-          selectorFragment: slotKeyFragment.template,
-          runtimeFragment: slotKeyFragment.template,
-          rawExpression: slotKeyFragment.rawExpression,
-        };
+        return getContainedInSlotDataKeyInfo(element, hierarchyMap);
       };
 
-    // `bestKeyPlaceholder` and `bestRuntimeKeyPlaceholder` are already-final template fragments
-    // that get concatenated directly into generated `data-testid` template literals later on.
-    // They are not string-replaced after the fact.
-    //
-    // Expected shapes:
-    // - direct v-for key `item.id`        -> `${item.id}`
-    // - template-literal key `line-${id}` -> `line-${id}`
-    //
-    // `bestKeyVariable` is only populated for raw expressions (typically slot-scope fallbacks)
-    // so downstream method generation can still expose a stable `key` parameter name instead of
-    // collapsing every keyed helper into a generic `...ByKey(key: string)` signature.
+      // `bestKeyInfo` carries the keyed selector shape end-to-end:
+      // - selectorFragment: the fragment used in generated selector-side templates
+      // - runtimeFragment: the fragment used when preserving/matching runtime-facing ids
+      // - rawExpression: the author-visible raw expression when the fragment came from wrapping
+      //   a plain expression like `item.id` instead of reusing an existing template literal
+      //
+      // Expected fragments:
+      // - direct v-for key `item.id`        -> selector `${_ctx.item.id}` / runtime `${item.id}`
+      // - template-literal key `line-${id}` -> `line-${_ctx.id}` / `line-${id}`
       const bestKeyInfo = getBestAvailableKeyInfo();
       const bestKeyPlaceholder = bestKeyInfo?.selectorFragment ?? null;
-      const bestKeyVariable = bestKeyInfo?.rawExpression ?? null;
 
       // Runtime click wrappers use the same normalization, but only need the runtime fragment itself.
       const bestRuntimeKeyPlaceholder = bestKeyInfo?.runtimeFragment ?? null;
@@ -1290,9 +1269,7 @@ export function createTestIdTransform(
         nativeRole,
         preferredGeneratedValue: args.preferredGeneratedValue,
         preferredRuntimeValue: args.preferredRuntimeValue,
-        bestKeyPlaceholder,
-        bestKeyPreservePlaceholder: bestRuntimeKeyPlaceholder,
-        bestKeyVariable,
+        keyInfo: bestKeyInfo,
         keyValuesOverride,
         entryOverrides: args.entryOverrides,
         semanticNameHint: args.semanticNameHint,
@@ -1526,7 +1503,7 @@ export function createTestIdTransform(
       // Derive a semantic hint from the click suffix (which is already derived from AST and/or innerText).
       // This is NOT derived by parsing the final data-testid.
       const clickHint = trimLeadingSeparators(clickSuffix) || undefined;
-      const idOrName = getIdOrName(element) || undefined;
+      const idOrName = getStaticIdOrNameHint(element) || undefined;
 
       const semanticHintCandidates = [clickHint, idOrName, innerText, conditionalHint]
         .map(value => (value ?? "").trim())
@@ -1585,7 +1562,7 @@ export function createTestIdTransform(
       // 2) handler attribute
       // 3) inner text (labels)
       // 4) the data-testid value itself (last resort hint)
-      const identifierHint = getIdOrName(element)
+      const identifierHint = getStaticIdOrNameHint(element)
         || nodeHandlerAttributeValue(element)
         || innerText
         || existingElementDataTestId.value
@@ -1605,7 +1582,7 @@ export function createTestIdTransform(
     const isSubmit = (element.props.find((p): p is AttributeNode => p.type === NodeTypes.ATTRIBUTE && p.name === "type")?.value?.content === "submit");
     if (isSubmit) {
       // Prefer explicit identity (id/name), otherwise fall back to literal inner text.
-      const identifier = getIdOrName(element) || innerText;
+      const identifier = getStaticIdOrNameHint(element) || innerText;
       if (!identifier) {
         const loc = element.loc?.start;
         const locationHint = loc ? `${loc.line}:${loc.column}` : "unknown";

--- a/transform.ts
+++ b/transform.ts
@@ -1111,13 +1111,10 @@ export function createTestIdTransform(
       return getContainedInSlotDataKeyValue(element, hierarchyMap);
     };
 
-    const bestKeyInferred = getBestAvailableKeyValue();
-    const bestRuntimeKeyInferred = getBestAvailableRuntimeKeyValue();
-    const bestKeyTemplateFragment = toInterpolatedTemplateFragment(bestKeyInferred);
-    const bestRuntimeKeyTemplateFragment = toInterpolatedTemplateFragment(bestRuntimeKeyInferred);
+    const bestKeyTemplateFragment = toInterpolatedTemplateFragment(getBestAvailableKeyValue());
     const bestKeyPlaceholder = bestKeyTemplateFragment?.template ?? null;
-    const bestRuntimeKeyPlaceholder = bestRuntimeKeyTemplateFragment?.template ?? null;
     const bestKeyVariable = bestKeyTemplateFragment?.rawExpression ?? null;
+    const bestRuntimeKeyPlaceholder = toInterpolatedTemplateFragment(getBestAvailableRuntimeKeyValue())?.template ?? null;
 
     // If we can prove the v-for iterable is a static literal list, capture the concrete
     // values (e.g. ['One', 'Two']). Downstream codegen can use this to:

--- a/transform.ts
+++ b/transform.ts
@@ -11,7 +11,7 @@ import type {
   IfBranchNode,
   ForNode,
 } from "@vue/compiler-core";
-import type { AttributeValue, HierarchyMap, ResolvedKeyInfo } from "./utils";
+import type { AttributeValue, DataTestIdEntryOverrides, HierarchyMap, ResolvedKeyInfo } from "./utils";
 import { NodeTypes } from "@vue/compiler-core";
 import { parse as parseSfc } from "@vue/compiler-sfc";
 import { parse as parseTemplate } from "@vue/compiler-dom";
@@ -1251,7 +1251,7 @@ export function createTestIdTransform(
       preferredGeneratedValue: AttributeValue;
       preferredRuntimeValue?: AttributeValue;
       nativeRoleOverride?: string;
-      entryOverrides?: Partial<IDataTestId>;
+      entryOverrides?: DataTestIdEntryOverrides;
       addHtmlAttribute?: boolean;
       semanticNameHint?: string;
       semanticNameHintAlternates?: string[];

--- a/transform.ts
+++ b/transform.ts
@@ -25,20 +25,21 @@ import {
   isAsciiLetterCode,
   isAsciiUppercaseLetterCode,
   upsertAttribute,
-  findTestIdAttribute,
   formatTagName,
   getComposedClickHandlerContent,
   getIdOrName,
   getInnerText,
-   getContainedInVForDirectiveKeyValue,
-   getContainedInSlotDataKeyValue,
-   tryGetContainedInStaticVForSourceLiteralValues,
-   getKeyDirectiveValue,
-   getModelBindingValues,
-   getNativeWrapperTransformInfo,
-   nodeHandlerAttributeValue,
-   nodeHandlerAttributeInfo,
-   tryGetClickDirective,
+  getContainedInVForDirectiveKeyValue,
+  getContainedInVForDirectiveKeyRuntimeValue,
+  getContainedInSlotDataKeyValue,
+  tryGetContainedInStaticVForSourceLiteralValues,
+  getKeyDirectiveValue,
+  getKeyDirectiveRuntimeValue,
+  getModelBindingValues,
+  getNativeWrapperTransformInfo,
+  nodeHandlerAttributeValue,
+  nodeHandlerAttributeInfo,
+  tryGetClickDirective,
   nodeHasToDirective,
   generateToDirectiveDataTestId,
   toDirectiveObjectFieldNameValue,
@@ -55,7 +56,7 @@ import {
 } from "./utils";
 
 const CLICK_EVENT_NAME = TESTID_CLICK_EVENT_NAME;
-const ENABLE_CLICK_INSTRUMENTATION = true;
+const DEFAULT_CLICK_INSTRUMENTATION = true;
 // Cache inferred wrapper configs across transforms/build passes.
 const inferredNativeWrapperConfigByLookup = new Map<string, { role: string }>();
 const inferredSfcPathByLookup = new Map<string, string | null>();
@@ -665,41 +666,26 @@ function tryInferNativeWrapperRoleFromSfc(
   return null;
 }
 
-function tryWrapClickDirectiveForTestEvents(element: ElementNode, testIdAttribute: string): void {
+function tryWrapClickDirectiveForTestEvents(
+  element: ElementNode,
+  testIdAttribute: string,
+  resolvedRuntimeTestId: AttributeValue | null | undefined,
+): void {
   const jsStringLiteral = (value: string) => {
     // Use JSON.stringify to safely escape quotes/newlines.
     return JSON.stringify(value);
   };
 
-  // Prefer using the template node's data-testid (static or bound) so wrapper components
-  // like <AppButton data-testid="..."> still emit the expected id even though the
-  // underlying DOM <button> doesn't have the attribute.
   const getTestIdExpressionForNode = (): string => {
-    const existing = findTestIdAttribute(element, testIdAttribute);
-    if (!existing) {
+    if (!resolvedRuntimeTestId) {
       return "undefined";
     }
 
-    if (existing.type === NodeTypes.ATTRIBUTE) {
-      const v = existing.value?.content;
-      if (!v) {
-        return "undefined";
-      }
-      return jsStringLiteral(v);
+    if (resolvedRuntimeTestId.kind === "static") {
+      return jsStringLiteral(resolvedRuntimeTestId.value);
     }
 
-    // :<attr>="..." / v-bind:<attr>="..."
-    const directive = existing as DirectiveNode;
-    const exp = directive.exp;
-    if (!exp || exp.type !== NodeTypes.SIMPLE_EXPRESSION) {
-      return "undefined";
-    }
-    const content = (exp.content ?? "").trim();
-    if (!content) {
-      return "undefined";
-    }
-    // Use the bound expression verbatim; it will be evaluated in the same scope as the handler.
-    return `(${content})`;
+    return `(\`${resolvedRuntimeTestId.template}\`)`;
   };
 
   const testIdExpression = getTestIdExpressionForNode();
@@ -887,6 +873,7 @@ export function createTestIdTransform(
     testIdAttribute?: string;
     nameCollisionBehavior?: "error" | "warn" | "suffix";
     missingSemanticNameBehavior?: "ignore" | "error";
+    clickInstrumentation?: boolean;
     warn?: (message: string) => void;
     vueFilesPathMap?: Map<string, string>;
     wrapperSearchRoots?: string[];
@@ -896,6 +883,7 @@ export function createTestIdTransform(
   const testIdAttribute = (options.testIdAttribute || "data-testid").trim() || "data-testid";
   const nameCollisionBehavior = options.nameCollisionBehavior ?? "suffix";
   const missingSemanticNameBehavior = options.missingSemanticNameBehavior ?? "error";
+  const enableClickInstrumentation = options.clickInstrumentation ?? DEFAULT_CLICK_INSTRUMENTATION;
   const warn = options.warn;
   const vueFilesPathMap = options.vueFilesPathMap;
   const wrapperSearchRoots = options.wrapperSearchRoots ?? [];
@@ -1113,9 +1101,23 @@ export function createTestIdTransform(
       return getContainedInSlotDataKeyValue(element, hierarchyMap);
     };
 
+    const getBestAvailableRuntimeKeyValue = () => {
+      const parentNode = (context.parent && typeof context.parent === "object") ? context.parent as { type?: number } : null;
+      const isDirectVForChild = parentNode?.type === NodeTypes.FOR;
+
+      const vForKey = (isDirectVForChild ? getKeyDirectiveRuntimeValue(element) : null)
+        || getContainedInVForDirectiveKeyRuntimeValue(context, element, hierarchyMap);
+      if (vForKey) return vForKey;
+
+      return getContainedInSlotDataKeyValue(element, hierarchyMap);
+    };
+
     const bestKeyInferred = getBestAvailableKeyValue();
+    const bestRuntimeKeyInferred = getBestAvailableRuntimeKeyValue();
     const isSlotKey = bestKeyInferred && !bestKeyInferred.startsWith("${");
     const bestKeyPlaceholder = isSlotKey ? `\${${bestKeyInferred}}` : bestKeyInferred;
+    const isRuntimeSlotKey = bestRuntimeKeyInferred && !bestRuntimeKeyInferred.startsWith("${");
+    const bestRuntimeKeyPlaceholder = isRuntimeSlotKey ? `\${${bestRuntimeKeyInferred}}` : bestRuntimeKeyInferred;
     const bestKeyVariable = isSlotKey ? bestKeyInferred : null;
 
     // If we can prove the v-for iterable is a static literal list, capture the concrete
@@ -1246,6 +1248,13 @@ export function createTestIdTransform(
         : staticAttributeValue(`${componentName}${clickSuffix}${tagSuffix}`);
     };
 
+    const getClickRuntimeDataTestId = (clickSuffix: string): AttributeValue => {
+      const tagSuffix = getTagSuffix();
+      return bestRuntimeKeyPlaceholder
+        ? templateAttributeValue(`${componentName}-${bestRuntimeKeyPlaceholder}${clickSuffix}${tagSuffix}`)
+        : staticAttributeValue(`${componentName}${clickSuffix}${tagSuffix}`);
+    };
+
     const getSubmitDataTestId = (identifier: string): string => {
       const tagSuffix = getTagSuffix();
       return `${componentName}-${identifier}${tagSuffix}`;
@@ -1254,15 +1263,16 @@ export function createTestIdTransform(
 
     const applyResolvedDataTestIdForElement = (args: {
       preferredGeneratedValue: AttributeValue;
+      preferredRuntimeValue?: AttributeValue;
       nativeRoleOverride?: string;
       entryOverrides?: Partial<IDataTestId>;
       addHtmlAttribute?: boolean;
       semanticNameHint?: string;
       semanticNameHintAlternates?: string[];
       pomMergeKey?: string;
-    }): void => {
+    }) => {
       const nativeRole = args.nativeRoleOverride ?? getNativeRoleFromTagSuffix();
-      applyResolvedDataTestId({
+      return applyResolvedDataTestId({
         element,
         componentName,
         parentComponentName,
@@ -1272,7 +1282,9 @@ export function createTestIdTransform(
         generatedMethodContentByComponent,
         nativeRole,
         preferredGeneratedValue: args.preferredGeneratedValue,
+        preferredRuntimeValue: args.preferredRuntimeValue,
         bestKeyPlaceholder,
+        bestKeyPreservePlaceholder: bestRuntimeKeyPlaceholder,
         bestKeyVariable,
         keyValuesOverride,
         entryOverrides: args.entryOverrides,
@@ -1523,9 +1535,11 @@ export function createTestIdTransform(
       const pomMergeKey = clickHint ? `click:hint:${clickHint}` : undefined;
 
       const testId = getClickDataTestId(clickSuffix);
+      const runtimeTestId = getClickRuntimeDataTestId(clickSuffix);
 
-      applyResolvedDataTestIdForElement({
+      const resolvedDataTestId = applyResolvedDataTestIdForElement({
         preferredGeneratedValue: testId,
+        preferredRuntimeValue: runtimeTestId,
         semanticNameHint,
         semanticNameHintAlternates,
         pomMergeKey,
@@ -1533,8 +1547,8 @@ export function createTestIdTransform(
 
       // Instrument @click handlers so Playwright can wait on deterministic UI-side events
       // without relying on network inspection.
-      if (ENABLE_CLICK_INSTRUMENTATION) {
-        tryWrapClickDirectiveForTestEvents(element, testIdAttribute);
+      if (enableClickInstrumentation) {
+        tryWrapClickDirectiveForTestEvents(element, testIdAttribute, resolvedDataTestId.runtimeValue);
       }
       return;
     }

--- a/transform.ts
+++ b/transform.ts
@@ -32,7 +32,7 @@ import {
   getContainedInVForDirectiveKeyValue,
   getContainedInVForDirectiveKeyRuntimeValue,
   getContainedInSlotDataKeyValue,
-  renderTemplateLiteralExpressionFromFragment,
+  renderTemplateLiteralExpression,
   tryGetContainedInStaticVForSourceLiteralValues,
   getKeyDirectiveValue,
   getKeyDirectiveRuntimeValue,
@@ -689,7 +689,7 @@ function tryWrapClickDirectiveForTestEvents(
     // Template AttributeValues keep only the fragment body (`line-${item.id}`), because most call sites
     // splice that fragment into a larger generated template. Click instrumentation needs a standalone
     // JavaScript template-literal expression again, so we rebuild it here from the parsed quasis/spans.
-    return `(${renderTemplateLiteralExpressionFromFragment(resolvedRuntimeTestId.template)})`;
+    return `(${renderTemplateLiteralExpression(resolvedRuntimeTestId)})`;
   };
 
   const testIdExpression = getTestIdExpressionForNode();
@@ -1114,13 +1114,17 @@ export function createTestIdTransform(
       return getContainedInSlotDataKeyValue(element, hierarchyMap);
     };
 
-    // `bestKeyPlaceholder` is the selector-side template fragment we splice into generated
-    // `data-testid` values. Expected shapes:
+    // `bestKeyPlaceholder` and `bestRuntimeKeyPlaceholder` are already-final template fragments
+    // that get concatenated directly into generated `data-testid` template literals later on.
+    // They are not string-replaced after the fact.
+    //
+    // Expected shapes:
     // - direct v-for key `item.id`        -> `${item.id}`
     // - template-literal key `line-${id}` -> `line-${id}`
     //
     // `bestKeyVariable` is only populated for raw expressions (typically slot-scope fallbacks)
-    // so downstream method generation can still expose a stable `key` parameter name.
+    // so downstream method generation can still expose a stable `key` parameter name instead of
+    // collapsing every keyed helper into a generic `...ByKey(key: string)` signature.
     const bestKeyTemplateFragment = toInterpolatedTemplateFragment(getBestAvailableKeyValue());
     const bestKeyPlaceholder = bestKeyTemplateFragment?.template ?? null;
     const bestKeyVariable = bestKeyTemplateFragment?.rawExpression ?? null;

--- a/transform.ts
+++ b/transform.ts
@@ -12,7 +12,7 @@ import type {
   ForNode,
 } from "@vue/compiler-core";
 import type { AttributeValue, HierarchyMap } from "./utils";
-import { NodeTypes, stringifyExpression } from "@vue/compiler-core";
+import { NodeTypes } from "@vue/compiler-core";
 import { parse as parseSfc } from "@vue/compiler-sfc";
 import { parse as parseTemplate } from "@vue/compiler-dom";
 import { parseExpression } from "@babel/parser";
@@ -32,6 +32,7 @@ import {
   getContainedInVForDirectiveKeyValue,
   getContainedInVForDirectiveKeyRuntimeValue,
   getContainedInSlotDataKeyValue,
+  getVueExpressionSource,
   renderTemplateLiteralExpression,
   tryGetContainedInStaticVForSourceLiteralValues,
   getKeyDirectiveValue,
@@ -398,9 +399,7 @@ function getConditionalDirectiveInfo(element: ElementNode): { kind: "if" | "else
   if (directive.name === "else") {
     const exp = directive.exp;
     if (exp && (exp.type === NodeTypes.SIMPLE_EXPRESSION || exp.type === NodeTypes.COMPOUND_EXPRESSION)) {
-      const source = (exp.type === NodeTypes.SIMPLE_EXPRESSION
-        ? (exp as SimpleExpressionNode).content
-        : stringifyExpression(exp)).trim();
+      const source = getVueExpressionSource(exp as SimpleExpressionNode | CompoundExpressionNode, "content", "compiled");
       return { kind: "else-if", source };
     }
     return { kind: "else", source: "" };
@@ -411,9 +410,7 @@ function getConditionalDirectiveInfo(element: ElementNode): { kind: "if" | "else
     const exp = directive.exp;
     if (!exp || (exp.type !== NodeTypes.SIMPLE_EXPRESSION && exp.type !== NodeTypes.COMPOUND_EXPRESSION))
       return null;
-    const source = (exp.type === NodeTypes.SIMPLE_EXPRESSION
-      ? (exp as SimpleExpressionNode).content
-      : stringifyExpression(exp)).trim();
+    const source = getVueExpressionSource(exp as SimpleExpressionNode | CompoundExpressionNode, "content", "compiled");
     return { kind: "else-if", source };
   }
 
@@ -421,9 +418,7 @@ function getConditionalDirectiveInfo(element: ElementNode): { kind: "if" | "else
   if (!exp || (exp.type !== NodeTypes.SIMPLE_EXPRESSION && exp.type !== NodeTypes.COMPOUND_EXPRESSION))
     return null;
 
-  const source = (exp.type === NodeTypes.SIMPLE_EXPRESSION
-    ? (exp as SimpleExpressionNode).content
-    : stringifyExpression(exp)).trim();
+  const source = getVueExpressionSource(exp as SimpleExpressionNode | CompoundExpressionNode, "content", "compiled");
   return { kind: directive.name as "if" | "else-if", source };
 }
 
@@ -713,13 +708,13 @@ function tryWrapClickDirectiveForTestEvents(
     return;
 
   // Avoid double-wrapping if transform runs multiple times (SSR + client passes).
-  const existingSource = (exp.loc?.source ?? (exp.type === NodeTypes.SIMPLE_EXPRESSION ? exp.content : "")).trim();
+  const existingSource = getVueExpressionSource(exp as SimpleExpressionNode | CompoundExpressionNode, "loc", "content");
   if (existingSource.includes(CLICK_EVENT_NAME))
     return;
 
   // Best-effort extract of the original handler expression.
   // For SIMPLE_EXPRESSION, prefer content; otherwise fall back to loc.source.
-  const originalExpression = (exp.type === NodeTypes.SIMPLE_EXPRESSION ? exp.content : exp.loc?.source ?? "").trim();
+  const originalExpression = getVueExpressionSource(exp as SimpleExpressionNode | CompoundExpressionNode, "content", "loc");
   if (!originalExpression)
     return;
 
@@ -990,9 +985,7 @@ export function createTestIdTransform(
           continue;
         }
 
-        const condSource = (cond.type === NodeTypes.SIMPLE_EXPRESSION
-          ? (cond as SimpleExpressionNode).content
-          : stringifyExpression(cond)).trim();
+        const condSource = getVueExpressionSource(cond, "content", "compiled");
         const stable = tryExtractStableHintFromConditionalExpressionSource(condSource);
 
         if (stable) {
@@ -1092,27 +1085,33 @@ export function createTestIdTransform(
       }
     }
 
-    const getBestAvailableKeyValue = () => {
-      const parentNode = (context.parent && typeof context.parent === "object") ? context.parent as { type?: number } : null;
-      const isDirectVForChild = parentNode?.type === NodeTypes.FOR;
+      const getBestAvailableKeyInfo = () => {
+        const parentNode = (context.parent && typeof context.parent === "object") ? context.parent as { type?: number } : null;
+        const isDirectVForChild = parentNode?.type === NodeTypes.FOR;
 
-      const vForKey = (isDirectVForChild ? getKeyDirectiveValue(element, context) : null)
-        || getContainedInVForDirectiveKeyValue(context, element, hierarchyMap);
-      if (vForKey) return vForKey;
+        const selectorFragment = (isDirectVForChild ? getKeyDirectiveValue(element, context) : null)
+          || getContainedInVForDirectiveKeyValue(context, element, hierarchyMap);
+        const runtimeFragment = (isDirectVForChild ? getKeyDirectiveRuntimeValue(element) : null)
+          || getContainedInVForDirectiveKeyRuntimeValue(context, element, hierarchyMap);
+        if (selectorFragment || runtimeFragment) {
+          return {
+            selectorFragment: selectorFragment ?? runtimeFragment,
+            runtimeFragment: runtimeFragment ?? selectorFragment,
+            rawExpression: null,
+          };
+        }
 
-      return getContainedInSlotDataKeyValue(element, hierarchyMap);
-    };
+        const slotKeyFragment = toInterpolatedTemplateFragment(getContainedInSlotDataKeyValue(element, hierarchyMap));
+        if (!slotKeyFragment) {
+          return null;
+        }
 
-    const getBestAvailableRuntimeKeyValue = () => {
-      const parentNode = (context.parent && typeof context.parent === "object") ? context.parent as { type?: number } : null;
-      const isDirectVForChild = parentNode?.type === NodeTypes.FOR;
-
-      const vForKey = (isDirectVForChild ? getKeyDirectiveRuntimeValue(element) : null)
-        || getContainedInVForDirectiveKeyRuntimeValue(context, element, hierarchyMap);
-      if (vForKey) return vForKey;
-
-      return getContainedInSlotDataKeyValue(element, hierarchyMap);
-    };
+        return {
+          selectorFragment: slotKeyFragment.template,
+          runtimeFragment: slotKeyFragment.template,
+          rawExpression: slotKeyFragment.rawExpression,
+        };
+      };
 
     // `bestKeyPlaceholder` and `bestRuntimeKeyPlaceholder` are already-final template fragments
     // that get concatenated directly into generated `data-testid` template literals later on.
@@ -1125,12 +1124,12 @@ export function createTestIdTransform(
     // `bestKeyVariable` is only populated for raw expressions (typically slot-scope fallbacks)
     // so downstream method generation can still expose a stable `key` parameter name instead of
     // collapsing every keyed helper into a generic `...ByKey(key: string)` signature.
-    const bestKeyTemplateFragment = toInterpolatedTemplateFragment(getBestAvailableKeyValue());
-    const bestKeyPlaceholder = bestKeyTemplateFragment?.template ?? null;
-    const bestKeyVariable = bestKeyTemplateFragment?.rawExpression ?? null;
+      const bestKeyInfo = getBestAvailableKeyInfo();
+      const bestKeyPlaceholder = bestKeyInfo?.selectorFragment ?? null;
+      const bestKeyVariable = bestKeyInfo?.rawExpression ?? null;
 
-    // Runtime click wrappers use the same normalization, but only need the template fragment itself.
-    const bestRuntimeKeyPlaceholder = toInterpolatedTemplateFragment(getBestAvailableRuntimeKeyValue())?.template ?? null;
+      // Runtime click wrappers use the same normalization, but only need the runtime fragment itself.
+      const bestRuntimeKeyPlaceholder = bestKeyInfo?.runtimeFragment ?? null;
 
     // If we can prove the v-for iterable is a static literal list, capture the concrete
     // values (e.g. ['One', 'Two']). Downstream codegen can use this to:
@@ -1197,9 +1196,7 @@ export function createTestIdTransform(
         if (!cond) {
           conditionalHint = "else";
         } else {
-          const condSource = (cond.type === NodeTypes.SIMPLE_EXPRESSION
-            ? (cond as SimpleExpressionNode).content
-            : stringifyExpression(cond)).trim();
+          const condSource = getVueExpressionSource(cond, "content", "compiled");
           conditionalHint = tryExtractStableHintFromConditionalExpressionSource(condSource) ?? "if";
         }
       }
@@ -1212,9 +1209,7 @@ export function createTestIdTransform(
     });
     if (showDirective?.exp && (showDirective.exp.type === NodeTypes.SIMPLE_EXPRESSION || showDirective.exp.type === NodeTypes.COMPOUND_EXPRESSION)) {
       const exp = showDirective.exp as SimpleExpressionNode | CompoundExpressionNode;
-      const source = (exp.type === NodeTypes.SIMPLE_EXPRESSION
-        ? (exp as SimpleExpressionNode).content
-        : stringifyExpression(exp)).trim();
+      const source = getVueExpressionSource(exp, "content", "compiled");
       const showHint = tryExtractStableHintFromConditionalExpressionSource(source);
       if (showHint) {
         conditionalHint = conditionalHint ? `${conditionalHint} ${showHint}` : showHint;

--- a/transform.ts
+++ b/transform.ts
@@ -686,6 +686,9 @@ function tryWrapClickDirectiveForTestEvents(
       return jsStringLiteral(resolvedRuntimeTestId.value);
     }
 
+    // Template AttributeValues keep only the fragment body (`line-${item.id}`), because most call sites
+    // splice that fragment into a larger generated template. Click instrumentation needs a standalone
+    // JavaScript template-literal expression again, so we rebuild it here from the parsed quasis/spans.
     return `(${renderTemplateLiteralExpressionFromFragment(resolvedRuntimeTestId.template)})`;
   };
 
@@ -1111,9 +1114,18 @@ export function createTestIdTransform(
       return getContainedInSlotDataKeyValue(element, hierarchyMap);
     };
 
+    // `bestKeyPlaceholder` is the selector-side template fragment we splice into generated
+    // `data-testid` values. Expected shapes:
+    // - direct v-for key `item.id`        -> `${item.id}`
+    // - template-literal key `line-${id}` -> `line-${id}`
+    //
+    // `bestKeyVariable` is only populated for raw expressions (typically slot-scope fallbacks)
+    // so downstream method generation can still expose a stable `key` parameter name.
     const bestKeyTemplateFragment = toInterpolatedTemplateFragment(getBestAvailableKeyValue());
     const bestKeyPlaceholder = bestKeyTemplateFragment?.template ?? null;
     const bestKeyVariable = bestKeyTemplateFragment?.rawExpression ?? null;
+
+    // Runtime click wrappers use the same normalization, but only need the template fragment itself.
     const bestRuntimeKeyPlaceholder = toInterpolatedTemplateFragment(getBestAvailableRuntimeKeyValue())?.template ?? null;
 
     // If we can prove the v-for iterable is a static literal list, capture the concrete

--- a/utils.ts
+++ b/utils.ts
@@ -126,6 +126,12 @@ export type AttributeValue =
 
 type VueExpressionNode = SimpleExpressionNode | CompoundExpressionNode;
 
+export interface ResolvedKeyInfo {
+  selectorFragment: string;
+  runtimeFragment: string;
+  rawExpression: string | null;
+}
+
 export function staticAttributeValue(value: string): AttributeValue {
   return { kind: "static", value };
 }
@@ -295,15 +301,7 @@ export function nodeHasClickDirective(node: ElementNode): boolean {
   return tryGetClickDirective(node) !== undefined;
 }
 
-/**
- * Detects if a node is a <template> element with slot scope data and returns the scope expression.
- *
- * This detects template elements with v-slot directives that have parameters,
- * such as <template #item="{ data }"> or <template v-slot="item">.
- *
- * @internal
- */
-function getTemplateSlotScope(node: ElementNode): string | null {
+function findTemplateSlotScopeExpression(node: ElementNode): VueExpressionNode | null {
   if (node.tag !== "template") {
     return null;
   }
@@ -312,11 +310,9 @@ function getTemplateSlotScope(node: ElementNode): string | null {
     return prop.type === NodeTypes.DIRECTIVE && prop.name === "slot";
   });
 
-  if (slotProp?.exp && (slotProp.exp.type === NodeTypes.SIMPLE_EXPRESSION || slotProp.exp.type === NodeTypes.COMPOUND_EXPRESSION)) {
-    return getVueExpressionSource(slotProp.exp as VueExpressionNode, "content", "compiled") || null;
-  }
-
-  return null;
+  return slotProp?.exp && (slotProp.exp.type === NodeTypes.SIMPLE_EXPRESSION || slotProp.exp.type === NodeTypes.COMPOUND_EXPRESSION)
+    ? slotProp.exp as VueExpressionNode
+    : null;
 }
 
 /**
@@ -330,7 +326,7 @@ function getTemplateSlotScope(node: ElementNode): string | null {
  * @internal
  */
 function isTemplateWithData(node: ElementNode): boolean {
-  return getTemplateSlotScope(node) !== null;
+  return findTemplateSlotScopeExpression(node) !== null;
 }
 
 /**
@@ -492,52 +488,77 @@ function tryGetSlotScopeKeyCandidate(node: BabelNode | null | undefined): SlotSc
   return best;
 }
 
-function tryGetTemplateSlotScopeKeyExpression(scope: string): string | null {
-  const trimmed = scope.trim();
-  if (!trimmed) {
+function tryGetTemplateSlotScopeBindingNode(expression: VueExpressionNode): BabelNode | null {
+  const ast = ("ast" in expression ? expression.ast : null) as BabelNode | null | false | undefined;
+  if (ast) {
+    if (isArrowFunctionExpression(ast)) {
+      return ast.params[0] as BabelNode | undefined ?? null;
+    }
+    return ast;
+  }
+
+  const rawSource = getVueExpressionSource(expression, "content", "loc", "compiled");
+  if (!rawSource) {
     return null;
   }
 
-  if (isSimpleScopeIdentifier(trimmed)) {
-    return buildSlotScopeFallbackKeyExpression(trimmed);
+  try {
+    return parseExpression(rawSource, { plugins: ["typescript"] }) as BabelNode;
+  }
+  catch {
+    // Slot-scope destructuring like `{ data }` is not a standalone expression, so parse it as
+    // the parameter list of a synthetic arrow function to recover the binding pattern AST.
   }
 
   try {
-    const parsed = parse(`(${trimmed}) => {}`, {
+    const parsed = parse(`(${rawSource}) => {}`, {
       sourceType: "module",
       plugins: ["typescript"],
     });
     const statement = parsed.program.body[0];
     if (statement && isExpressionStatement(statement) && isArrowFunctionExpression(statement.expression)) {
-      return tryGetSlotScopeKeyCandidate(statement.expression.params[0])?.expression ?? null;
+      return statement.expression.params[0] as BabelNode | undefined ?? null;
     }
   }
   catch {
-    // Fall back to the prior best-effort string parsing below.
+    return null;
   }
 
-  if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
-    const inner = trimmed.slice(1, -1).trim();
-    let cutIdx = -1;
-    const commaIdx = inner.indexOf(",");
-    const colonIdx = inner.indexOf(":");
-    if (commaIdx !== -1 && colonIdx !== -1) {
-      cutIdx = Math.min(commaIdx, colonIdx);
-    }
-    else if (commaIdx !== -1) {
-      cutIdx = commaIdx;
-    }
-    else if (colonIdx !== -1) {
-      cutIdx = colonIdx;
-    }
+  return null;
+}
 
-    const first = (cutIdx === -1 ? inner : inner.slice(0, cutIdx)).trim();
-    if (first && isSimpleScopeIdentifier(first)) {
-      return buildSlotScopeFallbackKeyExpression(first);
-    }
+function toResolvedTemplateFragment(source: string): InterpolatedTemplateFragment | null {
+  const templateLiteral = tryUnwrapTemplateLiteralSource(source);
+  if (templateLiteral) {
+    return {
+      template: templateLiteral.template,
+      rawExpression: null,
+    };
   }
 
-  return trimmed;
+  return toInterpolatedTemplateFragment(source);
+}
+
+function toResolvedKeyInfo(selectorSource: string | null, runtimeSource: string | null = selectorSource): ResolvedKeyInfo | null {
+  const selectorFragment = selectorSource ? toResolvedTemplateFragment(selectorSource) : null;
+  const runtimeFragment = runtimeSource ? toResolvedTemplateFragment(runtimeSource) : null;
+  const selectorTemplate = selectorFragment?.template ?? runtimeFragment?.template ?? null;
+  const runtimeTemplate = runtimeFragment?.template ?? selectorFragment?.template ?? null;
+  if (!selectorTemplate || !runtimeTemplate) {
+    return null;
+  }
+
+  return {
+    selectorFragment: selectorTemplate,
+    runtimeFragment: runtimeTemplate,
+    rawExpression: runtimeFragment?.rawExpression ?? selectorFragment?.rawExpression ?? null,
+  };
+}
+
+function tryGetTemplateSlotScopeKeyInfo(expression: VueExpressionNode): ResolvedKeyInfo | null {
+  const bindingNode = tryGetTemplateSlotScopeBindingNode(expression);
+  const candidateExpression = bindingNode ? tryGetSlotScopeKeyCandidate(bindingNode)?.expression ?? null : null;
+  return candidateExpression ? toResolvedKeyInfo(candidateExpression) : null;
 }
 
 /**
@@ -844,11 +865,6 @@ export function renderTemplateLiteralExpression(templateValue: Extract<Attribute
  *
  * @internal
  */
-interface KeyDirectiveFragments {
-  selectorFragment: string;
-  runtimeFragment: string;
-}
-
 function getKeyDirectiveExpression(node: ElementNode): VueExpressionNode | null {
   const keyDirective = getKeyDirective(node);
   return keyDirective?.exp && (
@@ -859,12 +875,7 @@ function getKeyDirectiveExpression(node: ElementNode): VueExpressionNode | null 
     : null;
 }
 
-function toTemplateInterpolationFragment(source: string): string {
-  const templateLiteral = tryUnwrapTemplateLiteralSource(source);
-  return templateLiteral ? templateLiteral.template : `\${${source}}`;
-}
-
-function getKeyDirectiveFragments(node: ElementNode): KeyDirectiveFragments | null {
+export function getKeyDirectiveInfo(node: ElementNode): ResolvedKeyInfo | null {
   const keyExpression = getKeyDirectiveExpression(node);
   if (!keyExpression) {
     return null;
@@ -872,26 +883,15 @@ function getKeyDirectiveFragments(node: ElementNode): KeyDirectiveFragments | nu
 
   const selectorSource = getVueExpressionSource(keyExpression, "compiled", "loc");
   const runtimeSource = getVueExpressionSource(keyExpression, "loc", "compiled");
-  if (!selectorSource && !runtimeSource) {
-    return null;
-  }
-
-  return {
-    // Selector-side generation lives inside Vue-compiled output, so it prefers the compiler
-    // rewritten source when available (`_ctx.*`) and falls back to author-written source.
-    selectorFragment: toTemplateInterpolationFragment(selectorSource || runtimeSource),
-    // Runtime-side matching needs the author-visible/local-scope form first so v-for/slot
-    // locals like `item.id` stay intact for comparisons and preserve-mode checks.
-    runtimeFragment: toTemplateInterpolationFragment(runtimeSource || selectorSource),
-  };
+  return toResolvedKeyInfo(selectorSource, runtimeSource);
 }
 
 export function getKeyDirectiveValue(node: ElementNode, _context: TransformContext | null = null): string | null {
-  return getKeyDirectiveFragments(node)?.selectorFragment ?? null;
+  return getKeyDirectiveInfo(node)?.selectorFragment ?? null;
 }
 
 export function getKeyDirectiveRuntimeValue(node: ElementNode): string | null {
-  return getKeyDirectiveFragments(node)?.runtimeFragment ?? null;
+  return getKeyDirectiveInfo(node)?.runtimeFragment ?? null;
 }
 
 /**
@@ -932,7 +932,7 @@ export function getSelfClosingForDirectiveKeyAttrValue(node: ElementNode): strin
     const hasForDirective = nodeHasForDirective(node);
 
     if (hasForDirective) {
-      return getKeyDirectiveValue(node);
+      return getKeyDirectiveInfo(node)?.selectorFragment ?? null;
     }
   }
   return null;
@@ -948,7 +948,7 @@ export function getSelfClosingForDirectiveKeyAttrValue(node: ElementNode): strin
  *
  * @internal
  */
-export function getIdOrName(node: ElementNode): string {
+export function getStaticIdOrNameHint(node: ElementNode): string {
   // Get id or name attribute (static)
   let idAttr = findAttributeByKey(node, "id");
   if (!idAttr) {
@@ -1013,12 +1013,16 @@ export function isNodeContainedInTemplateWithData(node: ElementNode, hierarchyMa
  * @internal
  */
 export function getContainedInSlotDataKeyValue(node: ElementNode, hierarchyMap: HierarchyMap): string | null {
+  return getContainedInSlotDataKeyInfo(node, hierarchyMap)?.selectorFragment ?? null;
+}
+
+export function getContainedInSlotDataKeyInfo(node: ElementNode, hierarchyMap: HierarchyMap): ResolvedKeyInfo | null {
   let parent = getParent(hierarchyMap, node);
   while (parent) {
     if (parent.type === NodeTypes.ELEMENT && parent.tag === "template") {
-      const scope = getTemplateSlotScope(parent);
-      if (scope) {
-        return tryGetTemplateSlotScopeKeyExpression(scope);
+      const slotScopeExpression = findTemplateSlotScopeExpression(parent);
+      if (slotScopeExpression) {
+        return tryGetTemplateSlotScopeKeyInfo(slotScopeExpression);
       }
     }
     parent = getParent(hierarchyMap, parent);
@@ -1034,11 +1038,11 @@ export function getContainedInSlotDataKeyValue(node: ElementNode, hierarchyMap: 
  * @internal
  */
 export function getContainedInVForDirectiveKeyValue(context: TransformContext, node: ElementNode, hierarchyMap: HierarchyMap): string | null {
-  const keyFragments = getContainedInVForDirectiveKeyFragments(context, node, hierarchyMap);
+  const keyFragments = getContainedInVForDirectiveKeyInfo(context, node, hierarchyMap);
   return keyFragments?.selectorFragment ?? null;
 }
 
-function getContainedInVForDirectiveKeyFragments(context: TransformContext, node: ElementNode, hierarchyMap: HierarchyMap): KeyDirectiveFragments | null {
+export function getContainedInVForDirectiveKeyInfo(context: TransformContext, node: ElementNode, hierarchyMap: HierarchyMap): ResolvedKeyInfo | null {
   // Check if we're in a v-for scope
   if (!context.scopes.vFor || context.scopes.vFor === 0) {
     return null;
@@ -1050,7 +1054,7 @@ function getContainedInVForDirectiveKeyFragments(context: TransformContext, node
     if (parent.type === NodeTypes.ELEMENT) {
       const forDirective = findDirectiveByName(parent as ElementNode, "for");
       if (forDirective) {
-        return getKeyDirectiveFragments(parent as ElementNode);
+        return getKeyDirectiveInfo(parent as ElementNode);
       }
     }
     parent = getParent(hierarchyMap, parent);
@@ -1059,7 +1063,7 @@ function getContainedInVForDirectiveKeyFragments(context: TransformContext, node
 }
 
 export function getContainedInVForDirectiveKeyRuntimeValue(context: TransformContext, node: ElementNode, hierarchyMap: HierarchyMap): string | null {
-  const keyFragments = getContainedInVForDirectiveKeyFragments(context, node, hierarchyMap);
+  const keyFragments = getContainedInVForDirectiveKeyInfo(context, node, hierarchyMap);
   return keyFragments?.runtimeFragment ?? null;
 }
 
@@ -2600,10 +2604,7 @@ export function applyResolvedDataTestId(args: {
   nativeRole: string;
   preferredGeneratedValue: AttributeValue;
   preferredRuntimeValue?: AttributeValue;
-  bestKeyPlaceholder: string | null;
-  bestKeyPreservePlaceholder?: string | null;
-  /** Optional variable name that must be present in a placeholder (e.g. "data" from slot scope). */
-  bestKeyVariable?: string | null;
+  keyInfo: ResolvedKeyInfo | null;
   /** Optional enumerable key values (e.g. derived from v-for="item in ['One','Two']"). */
   keyValuesOverride?: string[] | null;
   entryOverrides?: Partial<IDataTestId>;
@@ -2673,7 +2674,8 @@ export function applyResolvedDataTestId(args: {
   let dataTestId = args.preferredGeneratedValue;
   let runtimeDataTestId = args.preferredRuntimeValue ?? args.preferredGeneratedValue;
   let fromExisting = false;
-  const bestKeyPreservePlaceholder = args.bestKeyPreservePlaceholder ?? args.bestKeyPlaceholder;
+  const bestKeyPreservePlaceholder = args.keyInfo?.runtimeFragment ?? null;
+  const bestKeyVariable = args.keyInfo?.rawExpression ?? null;
 
   const existing = tryGetExistingElementDataTestId(args.element, testIdAttribute);
   if (existing) {
@@ -2721,7 +2723,7 @@ export function applyResolvedDataTestId(args: {
           const hasExact = requiredKeyTemplateValue
             ? templateFragmentContainsSingleExpression(existingTemplateValue.parsedTemplate, requiredKeyTemplateValue.parsedTemplate)
             : false;
-          const hasVarAccess = getBestKeyAccessCandidates(args.bestKeyVariable)
+          const hasVarAccess = getBestKeyAccessCandidates(bestKeyVariable)
             .some(candidate => existingTemplateFragment.expressionSource === candidate);
 
           if (!hasExact && !hasVarAccess && bestKeyPreservePlaceholder) {
@@ -2730,7 +2732,7 @@ export function applyResolvedDataTestId(args: {
               + `Component: ${args.componentName}\n`
               + `File: ${file}:${locationHint}\n`
               + `Existing ${attrLabel}: ${JSON.stringify(existing.value)}\n`
-              + `Required placeholder: ${JSON.stringify(bestKeyPreservePlaceholder)}${args.bestKeyVariable ? ` or an access on "${args.bestKeyVariable}"` : ""}\n\n`
+              + `Required placeholder: ${JSON.stringify(bestKeyPreservePlaceholder)}${bestKeyVariable ? ` or an access on "${bestKeyVariable}"` : ""}\n\n`
               + `Fix: either (1) include ${bestKeyPreservePlaceholder} in your :${attrLabel} template literal, or (2) remove the explicit ${attrLabel} so it can be auto-generated.`,
             );
           }
@@ -2757,7 +2759,7 @@ export function applyResolvedDataTestId(args: {
             + `Component: ${args.componentName}\n`
             + `File: ${file}:${locationHint}\n`
             + `Existing ${attrLabel}: ${JSON.stringify(existing.value)}\n`
-            + `Required placeholder: ${JSON.stringify(bestKeyPreservePlaceholder)}${args.bestKeyVariable ? ` or an access on "${args.bestKeyVariable}"` : ""}\n\n`
+            + `Required placeholder: ${JSON.stringify(bestKeyPreservePlaceholder)}${bestKeyVariable ? ` or an access on "${bestKeyVariable}"` : ""}\n\n`
             + `Fix: either (1) include ${bestKeyPreservePlaceholder} in your :${attrLabel} template literal, or (2) remove the explicit ${attrLabel} so it can be auto-generated.`,
           );
         }

--- a/utils.ts
+++ b/utils.ts
@@ -53,7 +53,7 @@ import {
   isTemplateLiteral,
 } from "@babel/types";
 import { parse, parseExpression } from "@babel/parser";
-import type { PomPatternKind } from "./pom-patterns";
+import { createPomStringPattern, pomStringPatternEquals, type PomPatternKind, type PomStringPattern } from "./pom-patterns";
 import { createTypeScriptWriter } from "./typescript-codegen";
 
 export { isSimpleExpressionNode } from "./compiler/ast-guards";
@@ -2856,6 +2856,7 @@ export function applyResolvedDataTestId(args: {
     ? toPomKeyPattern(dataTestId)
     : dataTestId.value;
   const selectorPatternKind: PomPatternKind = dataTestId.kind === "template" ? "parameterized" : "static";
+  const selectorPattern = createPomStringPattern(formattedDataTestIdForPom, selectorPatternKind);
   const selectorIsParameterized = selectorPatternKind === "parameterized";
 
   const deriveBaseMethodNameFromHint = (hint: string | undefined) => {
@@ -3011,10 +3012,10 @@ export function applyResolvedDataTestId(args: {
     }
 
     const existingSelectors = [
-      existingPom.formattedDataTestId,
-      ...(existingPom.alternateFormattedDataTestIds ?? []),
+      existingPom.selector,
+      ...(existingPom.alternateSelectors ?? []),
     ];
-    const sharesSelectorIdentity = existingSelectors.includes(formattedDataTestIdForPom);
+    const sharesSelectorIdentity = existingSelectors.some(existingSelector => pomStringPatternEquals(existingSelector, selectorPattern));
 
     // Parameterized selectors are only safe to merge when both entries already resolve to the exact
     // same selector pattern. Distinct dynamic lists should still force authors to
@@ -3041,18 +3042,15 @@ export function applyResolvedDataTestId(args: {
     }
 
     // Merge the selector(s) into the existing primary.
-    if (existingPom.formattedDataTestId !== formattedDataTestIdForPom) {
-      existingPom.alternateFormattedDataTestIds ??= [];
-      if (!existingPom.alternateFormattedDataTestIds.includes(formattedDataTestIdForPom)) {
-        existingPom.alternateFormattedDataTestIds.push(formattedDataTestIdForPom);
+    if (!pomStringPatternEquals(existingPom.selector, selectorPattern)) {
+      existingPom.alternateSelectors ??= [];
+      if (!(existingPom.alternateSelectors ?? []).some(existingSelector => pomStringPatternEquals(existingSelector, selectorPattern))) {
+        existingPom.alternateSelectors.push(selectorPattern);
       }
     }
 
-    if (selectorIsParameterized) {
-      existingPom.selectorPatternKind = "parameterized";
-      if (!Object.prototype.hasOwnProperty.call(existingPom.params, "key")) {
-        existingPom.params.key = keyTypeFromValues;
-      }
+    if (selectorIsParameterized && !Object.prototype.hasOwnProperty.call(existingPom.params, "key")) {
+      existingPom.params.key = keyTypeFromValues;
     }
 
     return true;
@@ -3254,7 +3252,10 @@ export function applyResolvedDataTestId(args: {
 
   const childComponentName = args.element.tag;
   const dataTestIdEntry: IDataTestId = {
-    value: getAttributeValueText(dataTestId),
+    selectorValue: createPomStringPattern(
+      getAttributeValueText(dataTestId),
+      dataTestId.kind === "template" ? "parameterized" : "static",
+    ),
     templateLiteral: undefined,
     ...entryOverrides,
   };
@@ -3265,9 +3266,8 @@ export function applyResolvedDataTestId(args: {
     nativeRole: normalizedRole,
     methodName,
     getterNameOverride,
-    selectorPatternKind,
-    formattedDataTestId: formattedDataTestIdForPom,
-    alternateFormattedDataTestIds: undefined,
+    selector: selectorPattern,
+    alternateSelectors: undefined,
     mergeKey: args.pomMergeKey,
     params,
     keyValuesOverride: args.keyValuesOverride ?? null,
@@ -3349,20 +3349,21 @@ export function applyResolvedDataTestId(args: {
       ? Object.fromEntries(Object.entries(pom.params).sort((a, b) => a[0].localeCompare(b[0])))
       : undefined;
 
-    const alternates = (pom.alternateFormattedDataTestIds ?? []).slice().sort();
+    const alternates = (pom.alternateSelectors ?? [])
+      .slice()
+      .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
 
     // Deduplicate by a stable key rather than by emitted code strings.
-    const key = JSON.stringify({
-      kind: "primary",
-      role: pom.nativeRole,
-      methodName: pom.methodName,
-      getterNameOverride: pom.getterNameOverride ?? null,
-      selectorPatternKind: pom.selectorPatternKind,
-      formattedDataTestId: pom.formattedDataTestId,
-      alternateFormattedDataTestIds: alternates.length ? alternates : undefined,
-      params: stableParams,
-      target: dataTestIdEntry.targetPageObjectModelClass ?? null,
-      emitPrimary: pom.emitPrimary ?? true,
+      const key = JSON.stringify({
+        kind: "primary",
+        role: pom.nativeRole,
+        methodName: pom.methodName,
+        getterNameOverride: pom.getterNameOverride ?? null,
+        selector: pom.selector,
+        alternateSelectors: alternates.length ? alternates : undefined,
+        params: stableParams,
+        target: dataTestIdEntry.targetPageObjectModelClass ?? null,
+        emitPrimary: pom.emitPrimary ?? true,
     });
 
     const seen = args.generatedMethodContentByComponent.get(args.parentComponentName) ?? new Set<string>();
@@ -3561,10 +3562,8 @@ export function applyResolvedDataTestId(args: {
           name: generatedName,
           selector: {
             kind: "withinTestIdByLabel",
-            rootFormattedDataTestId: wrapperTestId,
-            rootPatternKind: selectorPatternKind,
-            formattedLabel: label,
-            labelPatternKind: "static",
+            rootTestId: createPomStringPattern(wrapperTestId, selectorPatternKind),
+            label: createPomStringPattern(label, "static"),
             exact: true,
           },
           params: { annotationText: `string = ""` },
@@ -3593,10 +3592,8 @@ export function applyResolvedDataTestId(args: {
       name: generatedName,
       selector: {
         kind: "withinTestIdByLabel",
-        rootFormattedDataTestId: wrapperTestId,
-        rootPatternKind: selectorPatternKind,
-        formattedLabel: "${value}",
-        labelPatternKind: "parameterized",
+        rootTestId: createPomStringPattern(wrapperTestId, selectorPatternKind),
+        label: createPomStringPattern("${value}", "parameterized"),
         exact: true,
       },
       params: { value: "string", annotationText: `string = ""` },
@@ -3649,8 +3646,7 @@ export function applyResolvedDataTestId(args: {
         name: generatedName,
         selector: {
           kind: "testId",
-          formattedDataTestId: formattedDataTestIdForPom,
-          patternKind: selectorPatternKind,
+          testId: selectorPattern,
         },
         keyLiteral: rawValue,
         params: { wait: "boolean = true" },
@@ -3685,7 +3681,7 @@ export function applyResolvedDataTestId(args: {
 }
 
 export interface IDataTestId {
-  value: string;
+  selectorValue: PomStringPattern;
 
   /** Optional parsed/constructed template literal for AST-based formatting in codegen. */
   templateLiteral?: TemplateLiteral;
@@ -3704,7 +3700,7 @@ export interface IDataTestId {
 /**
  * Structured representation of a generated element for POM emission.
  *
- * - `selectorPatternKind` tells emitters whether this selector is static or parameterized.
+ * - `selector` carries both the rendered selector text and whether it is static or parameterized.
  * - `params` is TypeScript-flavored today because TS is our reference emitter;
  *   C# emission maps these params to C# types.
  */
@@ -3714,12 +3710,10 @@ export interface PomPrimarySpec {
   methodName: string;
   /** Optional override for the generated locator getter name (used for edge-case collision avoidance). */
   getterNameOverride?: string;
-  /** Whether the selector is a plain test id or a parameterized `${key}` template pattern. */
-  selectorPatternKind: PomPatternKind;
   /** Test id pattern used by generated POM methods. Parameterized patterns still render with `${key}`. */
-  formattedDataTestId: string;
-  /** Additional test id patterns that should be treated as equivalent to formattedDataTestId (merge-by-action). */
-  alternateFormattedDataTestIds?: string[];
+  selector: PomStringPattern;
+  /** Additional selector patterns that should be treated as equivalent to `selector` (merge-by-action). */
+  alternateSelectors?: PomStringPattern[];
 
   /** Optional key used to decide whether distinct elements should be merged into one POM member. */
   mergeKey?: string;
@@ -3735,18 +3729,15 @@ export interface PomPrimarySpec {
 export type PomSelectorSpec =
   | {
     kind: "testId";
-    patternKind: PomPatternKind;
     /** Static or parameterized test id; parameterized patterns render with `${key}`. */
-    formattedDataTestId: string;
+    testId: PomStringPattern;
   }
   | {
     kind: "withinTestIdByLabel";
-    rootPatternKind: PomPatternKind;
     /** Wrapper/root test id to scope the label search under. */
-    rootFormattedDataTestId: string;
-    labelPatternKind: PomPatternKind;
+    rootTestId: PomStringPattern;
     /** Visible label text; parameterized labels may contain `${value}`. */
-    formattedLabel: string;
+    label: PomStringPattern;
     exact?: boolean;
   };
 

--- a/utils.ts
+++ b/utils.ts
@@ -528,30 +528,74 @@ function getKeyDirective(node: ElementNode): DirectiveNode | null {
   return findDirectiveByName(node, "bind", "key") ?? null;
 }
 
-function tryUnwrapTemplateLiteralExpressionSource(source: string): { template: string; expressionCount: number } | null {
-  const trimmed = source.trim();
-  if (!trimmed) {
+/**
+ * Attempts to unwrap a template-literal expression into its body text.
+ *
+ * Accepts either the original Vue `SimpleExpressionNode` or a raw expression string.
+ *
+ * @example
+ * tryUnwrapTemplateLiteralExpressionSource("`row-${item.id}`")
+ * // => { template: "row-${item.id}", expressionCount: 1 }
+ *
+ * @example
+ * tryUnwrapTemplateLiteralExpressionSource("item.id")
+ * // => null
+ */
+function tryUnwrapTemplateLiteralExpressionSource(expression: SimpleExpressionNode | string | null | undefined): { template: string; expressionCount: number } | null {
+  const rawSource = typeof expression === "string"
+    ? expression.trim()
+    : (expression?.content ?? "").trim();
+  if (!rawSource) {
     return null;
   }
 
-  try {
-    const ast = parseExpression(trimmed, { plugins: ["typescript"] }) as BabelNode;
-    if (!isTemplateLiteral(ast)) {
+  let ast = typeof expression === "string"
+    ? null
+    : (expression?.ast as BabelNode | null | false | undefined);
+  if (!ast || !isTemplateLiteral(ast)) {
+    try {
+      ast = parseExpression(rawSource, { plugins: ["typescript"] }) as BabelNode;
+    }
+    catch {
       return null;
     }
+  }
 
+  if (!isTemplateLiteral(ast)) {
+    return null;
+  }
+
+  const cooked = ast.quasis.map(quasi => quasi.value.cooked ?? "").join("");
+  try {
     const start = typeof ast.start === "number" ? ast.start + 1 : 1;
-    const end = typeof ast.end === "number" ? ast.end - 1 : trimmed.length - 1;
+    const end = typeof ast.end === "number" ? ast.end - 1 : rawSource.length - 1;
     return {
-      template: trimmed.slice(start, end),
+      template: rawSource.slice(start, end) || cooked,
       expressionCount: ast.expressions.length,
     };
   }
   catch {
-    return null;
+    return {
+      template: cooked,
+      expressionCount: ast.expressions.length,
+    };
   }
 }
 
+/**
+ * Parses the inside of a template literal as a `TemplateLiteral` AST node.
+ *
+ * `parseExpression()` only accepts complete JavaScript expressions, so fragments like
+ * `line-${item.id}` need synthetic backticks before they can be parsed.
+ *
+ * @example
+ * tryParseTemplateFragment("line-${item.id}")?.expressions.length
+ * // => 1
+ *
+ * @example
+ * tryParseTemplateFragment("plain-text")?.expressions.length
+ * // => 0
+ */
 function tryParseTemplateFragment(fragment: string): TemplateLiteral | null {
   if (!fragment) {
     return null;
@@ -568,6 +612,17 @@ function tryParseTemplateFragment(fragment: string): TemplateLiteral | null {
   }
 }
 
+/**
+ * Returns `true` when a template fragment already contains one or more `${...}` interpolations.
+ *
+ * @example
+ * hasTemplateInterpolationExpressions("line-${item.id}")
+ * // => true
+ *
+ * @example
+ * hasTemplateInterpolationExpressions("item.id")
+ * // => false
+ */
 export function hasTemplateInterpolationExpressions(fragment: string): boolean {
   return (tryParseTemplateFragment(fragment)?.expressions.length ?? 0) > 0;
 }
@@ -577,6 +632,20 @@ export interface InterpolatedTemplateFragment {
   rawExpression: string | null;
 }
 
+/**
+ * Normalizes a fragment into something safe to splice into a template literal.
+ *
+ * Raw expressions become `${...}` placeholders; fragments that already contain template
+ * interpolations are returned as-is.
+ *
+ * @example
+ * toInterpolatedTemplateFragment("item.id")
+ * // => { template: "${item.id}", rawExpression: "item.id" }
+ *
+ * @example
+ * toInterpolatedTemplateFragment("line-${item.id}")
+ * // => { template: "line-${item.id}", rawExpression: null }
+ */
 export function toInterpolatedTemplateFragment(fragment: string | null): InterpolatedTemplateFragment | null {
   if (!fragment) {
     return null;
@@ -592,6 +661,17 @@ export function toInterpolatedTemplateFragment(fragment: string | null): Interpo
   };
 }
 
+/**
+ * Reconstructs a full template-literal expression from a fragment using the parsed quasis/expressions.
+ *
+ * @example
+ * renderTemplateLiteralExpressionFromFragment("line-${item.id}")
+ * // => "`line-${item.id}`"
+ *
+ * @example
+ * renderTemplateLiteralExpressionFromFragment("plain-text")
+ * // => "`plain-text`"
+ */
 export function renderTemplateLiteralExpressionFromFragment(fragment: string): string {
   const templateLiteralSource = `\`${fragment}\``;
   const templateLiteral = tryParseTemplateFragment(fragment);
@@ -599,6 +679,8 @@ export function renderTemplateLiteralExpressionFromFragment(fragment: string): s
     return templateLiteralSource;
   }
 
+  // Render through the shared TypeScript writer so this codegen path follows the same
+  // quoting/newline conventions as the rest of the repo's generated TypeScript output.
   const writer = createTypeScriptWriter();
   writer.write("`");
   for (let i = 0; i < templateLiteral.quasis.length; i += 1) {
@@ -2205,35 +2287,22 @@ export function tryGetExistingElementDataTestId(node: ElementNode, attributeName
     return null;
   }
 
-  // Prefer AST-based detection when available.
-  // Vue's compiler attaches Babel AST to SimpleExpressionNode.exp.ast.
   const simpleExp = exp as SimpleExpressionNode;
   const ast = simpleExp.ast;
 
-  // Template literal: :data-testid="`Foo-${bar}`"
-  // - If it has zero expressions, it's effectively a static string.
-  // - If it has expressions, it's dynamic.
-  if (ast && typeof ast === "object" && "type" in ast && (ast as { type: string }).type === "TemplateLiteral") {
-    const tl = ast as { quasis: Array<{ value?: { cooked?: string } }>; expressions: unknown[] };
-    const cooked = (tl.quasis ?? []).map(q => q.value?.cooked ?? "").join("");
-    const expressionCount = (tl.expressions ?? []).length;
-    const isStatic = expressionCount === 0;
-
-    // Prefer the raw template (so callers can validate placeholders / preserve interpolation),
-    // but fall back to cooked content when we can't confidently unwrap.
-    const raw = (simpleExp.content ?? "").trim();
-    const unwrappedTemplate = tryUnwrapTemplateLiteralExpressionSource(raw)?.template ?? cooked;
-
+  const unwrappedTemplateLiteral = tryUnwrapTemplateLiteralExpressionSource(simpleExp);
+  if (unwrappedTemplateLiteral) {
+    const isStatic = unwrappedTemplateLiteral.expressionCount === 0;
     if (isStatic) {
-      return { value: unwrappedTemplate, isDynamic: false, isStaticLiteral: true };
+      return { value: unwrappedTemplateLiteral.template, isDynamic: false, isStaticLiteral: true };
     }
 
     return {
-      value: unwrappedTemplate,
+      value: unwrappedTemplateLiteral.template,
       isDynamic: true,
       isStaticLiteral: false,
-      template: unwrappedTemplate,
-      templateExpressionCount: expressionCount,
+      template: unwrappedTemplateLiteral.template,
+      templateExpressionCount: unwrappedTemplateLiteral.expressionCount,
     };
   }
 
@@ -2259,53 +2328,36 @@ export function tryGetExistingElementDataTestId(node: ElementNode, attributeName
     };
   }
 
-  // Fallback: we have no parseable AST shape from Vue compiler.
-  // Attempt to parse manually to detect template literals (common for data-testid).
   const raw = (simpleExp.content ?? "").trim();
   if (!raw) {
     return null;
   }
 
-  try {
-    const ast = parseExpression(raw, { plugins: ["typescript"] });
-    if (ast && typeof ast === "object" && "type" in ast && (ast as { type: string }).type === "TemplateLiteral") {
-      const tl = ast as { quasis: Array<{ value?: { cooked?: string } }>; expressions: unknown[] };
-      const cooked = (tl.quasis ?? []).map(q => q.value?.cooked ?? "").join("");
-      const expressionCount = (tl.expressions ?? []).length;
-      const isStatic = expressionCount === 0;
-      const unwrappedTemplate = tryUnwrapTemplateLiteralExpressionSource(raw)?.template ?? cooked;
-
-      if (isStatic) {
-        return { value: unwrappedTemplate, isDynamic: false, isStaticLiteral: true };
-      }
-
-      return {
-        value: unwrappedTemplate,
-        isDynamic: true,
-        isStaticLiteral: false,
-        template: unwrappedTemplate,
-        templateExpressionCount: expressionCount,
-      };
+  let fallbackAst = ast as BabelNode | null | false | undefined;
+  if (!fallbackAst) {
+    try {
+      fallbackAst = parseExpression(raw, { plugins: ["typescript"] }) as BabelNode;
     }
-
-    if (ast && typeof ast === "object" && "type" in ast && (ast as { type: string }).type === "StringLiteral") {
-      const sl = ast as { value?: string };
-      return { value: sl.value ?? "", isDynamic: false, isStaticLiteral: true };
+    catch {
+      fallbackAst = null;
     }
+  }
 
-    const preservableReference = tryGetPreservableDynamicReferenceExpression(ast as BabelNode | null | false | undefined);
-    if (preservableReference) {
-      return {
-        value: preservableReference,
-        isDynamic: true,
-        isStaticLiteral: false,
-        template: `\${${preservableReference}}`,
-        templateExpressionCount: 1,
-        rawExpression: preservableReference,
-      };
-    }
-  } catch {
-    // Ignore parse errors; fall through to generic dynamic fallback.
+  if (fallbackAst && typeof fallbackAst === "object" && "type" in fallbackAst && (fallbackAst as { type: string }).type === "StringLiteral") {
+    const sl = fallbackAst as { value?: string };
+    return { value: sl.value ?? "", isDynamic: false, isStaticLiteral: true };
+  }
+
+  const fallbackPreservableReference = tryGetPreservableDynamicReferenceExpression(fallbackAst);
+  if (fallbackPreservableReference) {
+    return {
+      value: fallbackPreservableReference,
+      isDynamic: true,
+      isStaticLiteral: false,
+      template: `\${${fallbackPreservableReference}}`,
+      templateExpressionCount: 1,
+      rawExpression: fallbackPreservableReference,
+    };
   }
 
   return { value: raw, isDynamic: true, isStaticLiteral: false, rawExpression: raw };

--- a/utils.ts
+++ b/utils.ts
@@ -124,6 +124,8 @@ export type AttributeValue =
   | { kind: "static"; value: string }
   | { kind: "template"; template: string; parsedTemplate: ParsedTemplateFragment };
 
+type VueExpressionNode = SimpleExpressionNode | CompoundExpressionNode;
+
 export function staticAttributeValue(value: string): AttributeValue {
   return { kind: "static", value };
 }
@@ -139,6 +141,52 @@ export function templateAttributeValue(template: string): Extract<AttributeValue
 
 export function getAttributeValueText(value: AttributeValue): string {
   return value.kind === "static" ? value.value : value.template;
+}
+
+/**
+ * Reads source text from a Vue compiler expression using the preferred view order.
+ *
+ * - `content`: original SIMPLE_EXPRESSION content
+ * - `loc`: author-written template source from `loc.source`
+ * - `compiled`: compiler-rewritten source from `stringifyExpression()`
+ */
+export function getVueExpressionSource(
+  expression: VueExpressionNode | null | undefined,
+  ...preferredViews: Array<"content" | "loc" | "compiled">
+): string {
+  if (!expression) {
+    return "";
+  }
+
+  for (const view of preferredViews) {
+    let value = "";
+    switch (view) {
+      case "content":
+        value = expression.type === NodeTypes.SIMPLE_EXPRESSION ? expression.content : "";
+        break;
+      case "loc":
+        value = expression.loc?.source ?? "";
+        break;
+      case "compiled":
+        try {
+          value = stringifyExpression(expression);
+        }
+        catch {
+          value = "";
+        }
+        break;
+      default:
+        value = "";
+        break;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return "";
 }
 
 /**
@@ -264,13 +312,8 @@ function getTemplateSlotScope(node: ElementNode): string | null {
     return prop.type === NodeTypes.DIRECTIVE && prop.name === "slot";
   });
 
-  if (slotProp?.exp) {
-    if (slotProp.exp.type === NodeTypes.SIMPLE_EXPRESSION) {
-      return slotProp.exp.content;
-    }
-    if (slotProp.exp.type === NodeTypes.COMPOUND_EXPRESSION) {
-      return stringifyExpression(slotProp.exp);
-    }
+  if (slotProp?.exp && (slotProp.exp.type === NodeTypes.SIMPLE_EXPRESSION || slotProp.exp.type === NodeTypes.COMPOUND_EXPRESSION)) {
+    return getVueExpressionSource(slotProp.exp as VueExpressionNode, "content", "compiled") || null;
   }
 
   return null;
@@ -612,9 +655,7 @@ function tryUnwrapTemplateLiteralSource(source: string): { template: string; exp
  * // => null
  */
 function tryUnwrapTemplateLiteralExpressionSource(expression: SimpleExpressionNode | CompoundExpressionNode | null): { template: string; expressionCount: number } | null {
-  const rawSource = expression
-    ? (expression.loc?.source ?? stringifyExpression(expression)).trim()
-    : "";
+  const rawSource = getVueExpressionSource(expression, "loc", "compiled");
   return rawSource ? tryUnwrapTemplateLiteralSource(rawSource) : null;
 }
 
@@ -803,62 +844,54 @@ export function renderTemplateLiteralExpression(templateValue: Extract<Attribute
  *
  * @internal
  */
-export function getKeyDirectiveValue(node: ElementNode, _context: TransformContext | null = null): string | null {
+interface KeyDirectiveFragments {
+  selectorFragment: string;
+  runtimeFragment: string;
+}
+
+function getKeyDirectiveExpression(node: ElementNode): VueExpressionNode | null {
   const keyDirective = getKeyDirective(node);
-  const keyExpression = keyDirective?.exp && (
+  return keyDirective?.exp && (
     keyDirective.exp.type === NodeTypes.SIMPLE_EXPRESSION
     || keyDirective.exp.type === NodeTypes.COMPOUND_EXPRESSION
   )
     ? keyDirective.exp as SimpleExpressionNode | CompoundExpressionNode
     : null;
+}
 
-  if (keyExpression) {
-    const value = stringifyExpression(keyExpression).trim();
-    if (value) {
-      // Inline template-literal keys directly into the generated data-testid template so the
-      // resulting expression uses the compiler-prefixed component scope (`_ctx.*`) while still
-      // preserving local v-for / slot bindings without nesting an extra template literal.
-      const templateLiteral = tryUnwrapTemplateLiteralSource(value);
-      if (templateLiteral) {
-        return templateLiteral.template;
-      }
+function toTemplateInterpolationFragment(source: string): string {
+  const templateLiteral = tryUnwrapTemplateLiteralSource(source);
+  return templateLiteral ? templateLiteral.template : `\${${source}}`;
+}
 
-      return `\${${value}}`;
-    }
+function getKeyDirectiveFragments(node: ElementNode): KeyDirectiveFragments | null {
+  const keyExpression = getKeyDirectiveExpression(node);
+  if (!keyExpression) {
+    return null;
   }
 
-  const rawSource = keyExpression?.loc.source?.trim();
-  if (rawSource) {
-    const templateLiteral = tryUnwrapTemplateLiteralExpressionSource(keyExpression);
-    return templateLiteral ? templateLiteral.template : `\${${rawSource}}`;
+  const selectorSource = getVueExpressionSource(keyExpression, "compiled", "loc");
+  const runtimeSource = getVueExpressionSource(keyExpression, "loc", "compiled");
+  if (!selectorSource && !runtimeSource) {
+    return null;
   }
 
-  return null;
+  return {
+    // Selector-side generation lives inside Vue-compiled output, so it prefers the compiler
+    // rewritten source when available (`_ctx.*`) and falls back to author-written source.
+    selectorFragment: toTemplateInterpolationFragment(selectorSource || runtimeSource),
+    // Runtime-side matching needs the author-visible/local-scope form first so v-for/slot
+    // locals like `item.id` stay intact for comparisons and preserve-mode checks.
+    runtimeFragment: toTemplateInterpolationFragment(runtimeSource || selectorSource),
+  };
+}
+
+export function getKeyDirectiveValue(node: ElementNode, _context: TransformContext | null = null): string | null {
+  return getKeyDirectiveFragments(node)?.selectorFragment ?? null;
 }
 
 export function getKeyDirectiveRuntimeValue(node: ElementNode): string | null {
-  const keyDirective = getKeyDirective(node);
-  const keyExpression = keyDirective?.exp && (
-    keyDirective.exp.type === NodeTypes.SIMPLE_EXPRESSION
-    || keyDirective.exp.type === NodeTypes.COMPOUND_EXPRESSION
-  )
-    ? keyDirective.exp as SimpleExpressionNode | CompoundExpressionNode
-    : null;
-  const rawSource = keyExpression?.loc.source?.trim();
-  if (rawSource) {
-    const templateLiteral = tryUnwrapTemplateLiteralExpressionSource(keyExpression);
-    return templateLiteral ? templateLiteral.template : `\${${rawSource}}`;
-  }
-
-  if (keyExpression) {
-    const value = stringifyExpression(keyExpression).trim();
-    if (value) {
-      const templateLiteral = tryUnwrapTemplateLiteralExpressionSource(keyExpression);
-      return templateLiteral ? templateLiteral.template : `\${${value}}`;
-    }
-  }
-
-  return null;
+  return getKeyDirectiveFragments(node)?.runtimeFragment ?? null;
 }
 
 /**
@@ -871,8 +904,8 @@ export function getModelBindingValues(node: ElementNode): { vModel: string; mode
   let vModel = "";
   const vModelDirective = findDirectiveByName(node, "model");
 
-  if (vModelDirective?.exp?.loc.source) {
-    vModel = toPascalCase(vModelDirective.exp.loc.source);
+  if (vModelDirective?.exp && (vModelDirective.exp.type === NodeTypes.SIMPLE_EXPRESSION || vModelDirective.exp.type === NodeTypes.COMPOUND_EXPRESSION)) {
+    vModel = toPascalCase(getVueExpressionSource(vModelDirective.exp as VueExpressionNode, "loc", "content"));
   }
 
   let modelValue: string | null = null;
@@ -908,8 +941,10 @@ export function getSelfClosingForDirectiveKeyAttrValue(node: ElementNode): strin
 /**
  * Gets the id or name attribute value from a node
  *
- * Returns the identifier, converting dashes and underscores to PascalCase
- * Returns a placeholder if a dynamic :id is found
+ * Returns the identifier, converting dashes and underscores to PascalCase.
+ *
+ * Dynamic `:id` / `:name` bindings are intentionally ignored here because they are not stable
+ * semantic hints for generated POM member names.
  *
  * @internal
  */
@@ -922,12 +957,12 @@ export function getIdOrName(node: ElementNode): string {
 
   let identifier = idAttr?.value?.content ?? "";
 
-  // If no static id or name attribute is found, check for a dynamic v-bind:id directive
+  // Dynamic id/name bindings are not stable identifiers for naming hints, so treat them as absent.
   if (!identifier) {
     const dynamicIdAttr = findDirectiveByName(node, "bind", "id");
-    if (dynamicIdAttr?.exp) {
-      // TODO: Make sure this is still necessary and if so maybe pick a better name
-      identifier = `\${someUniqueValueToDifferentiateInstanceFromOthersOnPageUsuallyAnId}`;
+    const dynamicNameAttr = findDirectiveByName(node, "bind", "name");
+    if (dynamicIdAttr?.exp || dynamicNameAttr?.exp) {
+      return "";
     }
   }
 
@@ -999,6 +1034,11 @@ export function getContainedInSlotDataKeyValue(node: ElementNode, hierarchyMap: 
  * @internal
  */
 export function getContainedInVForDirectiveKeyValue(context: TransformContext, node: ElementNode, hierarchyMap: HierarchyMap): string | null {
+  const keyFragments = getContainedInVForDirectiveKeyFragments(context, node, hierarchyMap);
+  return keyFragments?.selectorFragment ?? null;
+}
+
+function getContainedInVForDirectiveKeyFragments(context: TransformContext, node: ElementNode, hierarchyMap: HierarchyMap): KeyDirectiveFragments | null {
   // Check if we're in a v-for scope
   if (!context.scopes.vFor || context.scopes.vFor === 0) {
     return null;
@@ -1010,9 +1050,7 @@ export function getContainedInVForDirectiveKeyValue(context: TransformContext, n
     if (parent.type === NodeTypes.ELEMENT) {
       const forDirective = findDirectiveByName(parent as ElementNode, "for");
       if (forDirective) {
-        // Found the v-for element, now look for :key
-        const keyValue = getKeyDirectiveValue(parent as ElementNode);
-        return keyValue;
+        return getKeyDirectiveFragments(parent as ElementNode);
       }
     }
     parent = getParent(hierarchyMap, parent);
@@ -1021,21 +1059,8 @@ export function getContainedInVForDirectiveKeyValue(context: TransformContext, n
 }
 
 export function getContainedInVForDirectiveKeyRuntimeValue(context: TransformContext, node: ElementNode, hierarchyMap: HierarchyMap): string | null {
-  if (!context.scopes.vFor || context.scopes.vFor === 0) {
-    return null;
-  }
-
-  let parent = getParent(hierarchyMap, node);
-  while (parent) {
-    if (parent.type === NodeTypes.ELEMENT) {
-      const forDirective = findDirectiveByName(parent as ElementNode, "for");
-      if (forDirective) {
-        return getKeyDirectiveRuntimeValue(parent as ElementNode);
-      }
-    }
-    parent = getParent(hierarchyMap, parent);
-  }
-  return null;
+  const keyFragments = getContainedInVForDirectiveKeyFragments(context, node, hierarchyMap);
+  return keyFragments?.runtimeFragment ?? null;
 }
 
 /**
@@ -1084,14 +1109,7 @@ export function tryGetContainedInStaticVForSourceLiteralValues(
     return null;
   }
 
-  const iterableRaw = (() => {
-    try {
-      return stringifyExpression(simpleSourceExp).trim();
-    }
-    catch {
-      return (simpleSourceExp.loc?.source ?? "").trim();
-    }
-  })();
+  const iterableRaw = getVueExpressionSource(simpleSourceExp, "compiled", "loc");
 
   if (!iterableRaw) {
     return null;
@@ -1183,9 +1201,7 @@ export function nodeHandlerAttributeInfo(node: ElementNode): HandlerAttributeInf
   }
 
   const exp = handlerDirective.exp as SimpleExpressionNode | CompoundExpressionNode;
-  const source = (exp.type === NodeTypes.SIMPLE_EXPRESSION
-    ? (exp as SimpleExpressionNode).content
-    : stringifyExpression(exp)).trim();
+  const source = getVueExpressionSource(exp, "content", "compiled");
   if (!source) {
     return null;
   }
@@ -1673,7 +1689,7 @@ function getDataTestIdValueFromValueAttribute(
 
   const attrDynamic = findDirectiveByName(node, "bind", attributeKey);
   if (attrDynamic && 'exp' in attrDynamic && attrDynamic.exp && 'ast' in attrDynamic.exp && attrDynamic.exp.ast) {
-    let value = attrDynamic.exp.loc.source;
+    let value = getVueExpressionSource(attrDynamic.exp as VueExpressionNode, "loc", "compiled");
 
     if (attrDynamic.exp.ast?.type === "MemberExpression") {
       // eslint-disable-next-line no-restricted-syntax
@@ -1681,7 +1697,7 @@ function getDataTestIdValueFromValueAttribute(
     }
 
     if (attrDynamic.exp.ast?.type === "CallExpression") {
-      value = stringifyExpression(attrDynamic.exp);
+      value = getVueExpressionSource(attrDynamic.exp as VueExpressionNode, "compiled", "loc");
       return templateAttributeValue(`${actualFileName}-\${${value}}-${role}`);
     }
     return staticAttributeValue(`${actualFileName}-${value}-${role}`);
@@ -1700,7 +1716,7 @@ export function generateToDirectiveDataTestId(componentName: string, node: Eleme
         return null;
       }
 
-      const source = stringifyExpression(toDirective.exp);
+      const source = getVueExpressionSource(toDirective.exp as VueExpressionNode, "compiled", "loc");
 
       const toAst = toDirective.exp.ast;
       const interpolated = (toAst !== undefined && toAst !== null && toAst !== false) && isTemplateLiteral(toAst as BabelNode);
@@ -1817,9 +1833,7 @@ export function getComposedClickHandlerContent(
 
   if (click.exp) {
     const exp = click.exp as SimpleExpressionNode | CompoundExpressionNode;
-    const source = (exp.type === NodeTypes.SIMPLE_EXPRESSION
-      ? (exp as SimpleExpressionNode).content
-      : stringifyExpression(exp)).trim();
+    const source = getVueExpressionSource(exp, "content", "compiled");
 
     if (source) {
       const parsed = tryParseBabelAstFromHandlerSource(source);
@@ -2544,13 +2558,13 @@ function safeMethodNameFromParts(parts: string[]) {
 }
 
 /**
- * Replaces any `${...}` interpolation in a template string with the stable placeholder `${key}`.
+ * Replaces any `${...}` interpolation in a template string with the stable POM placeholder `${key}`.
  *
  * This is only for the generated POM selector shape. Runtime/test-id generation keeps the real
  * interpolation expressions; the POM layer just needs to know that a keyed slot exists and where
  * it sits relative to the surrounding literal text.
  */
-function replaceAllTemplateExpressionsWithKey(templateValue: Extract<AttributeValue, { kind: "template" }>): string {
+function toPomKeyPattern(templateValue: Extract<AttributeValue, { kind: "template" }>): string {
   const { templateLiteral } = templateValue.parsedTemplate;
   let out = "";
   for (let i = 0; i < templateLiteral.quasis.length; i += 1) {
@@ -2567,7 +2581,7 @@ export const __internal = {
   isSimpleScopeIdentifier,
   safeMethodNameFromParts,
   splitNullishCoalescingExpression,
-  replaceAllTemplateExpressionsWithKey,
+  toPomKeyPattern,
 };
 
 /**
@@ -2796,7 +2810,7 @@ export function applyResolvedDataTestId(args: {
 
   // Keyed-ness is represented in the selector pattern, not derived by parsing the test id.
   const formattedDataTestIdForPom = dataTestId.kind === "template"
-    ? replaceAllTemplateExpressionsWithKey(dataTestId)
+    ? toPomKeyPattern(dataTestId)
     : dataTestId.value;
 
   const isKeyed = formattedDataTestIdForPom.includes("${key}");
@@ -3379,7 +3393,11 @@ export function applyResolvedDataTestId(args: {
 
     // Fallback: parse the expression source.
     try {
-      const raw = args.context ? stringifyExpression(exp) : exp.loc.source;
+      const raw = getVueExpressionSource(
+        exp as VueExpressionNode,
+        args.context ? "compiled" : "loc",
+        args.context ? "loc" : "compiled",
+      );
       return parseExpression(raw, { plugins: ["typescript"] }) as BabelNode;
     }
     catch {

--- a/utils.ts
+++ b/utils.ts
@@ -54,6 +54,14 @@ import {
 } from "@babel/types";
 import { parse, parseExpression } from "@babel/parser";
 import { createPomStringPattern, pomStringPatternEquals, type PomPatternKind, type PomStringPattern } from "./pom-patterns";
+import {
+  createPomMethodSignature,
+  createPomParameterSpec,
+  normalizePomParameters,
+  pomMethodSignatureEquals,
+  type PomMethodSignature,
+  type PomParameterSpec,
+} from "./pom-params";
 import { createTypeScriptWriter } from "./typescript-codegen";
 
 export { isSimpleExpressionNode } from "./compiler/ast-guards";
@@ -3049,8 +3057,8 @@ export function applyResolvedDataTestId(args: {
       }
     }
 
-    if (selectorIsParameterized && !Object.prototype.hasOwnProperty.call(existingPom.params, "key")) {
-      existingPom.params.key = keyTypeFromValues;
+    if (selectorIsParameterized && !existingPom.parameters.some(param => param.name === "key")) {
+      existingPom.parameters = [createPomParameterSpec("key", keyTypeFromValues), ...existingPom.parameters];
     }
 
     return true;
@@ -3244,6 +3252,7 @@ export function applyResolvedDataTestId(args: {
   if (keyTypeFromValues !== "string" && Object.prototype.hasOwnProperty.call(params, "key")) {
     params.key = keyTypeFromValues;
   }
+  const normalizedParameters = normalizePomParameters(params);
 
   // 3) Apply attribute (only when we generated it) and register for POM generation.
   if (addHtmlAttribute && !fromExisting) {
@@ -3269,7 +3278,7 @@ export function applyResolvedDataTestId(args: {
     selector: selectorPattern,
     alternateSelectors: undefined,
     mergeKey: args.pomMergeKey,
-    params,
+    parameters: normalizedParameters,
     keyValuesOverride: args.keyValuesOverride ?? null,
     // emitPrimary defaults to true; special cases (including merge) may set it to false below.
   };
@@ -3314,41 +3323,37 @@ export function applyResolvedDataTestId(args: {
 
     if (isNavigation) {
       if (needsKey) {
-        return { params: `key: ${keyType}`, argNames: ["key"] };
+        return createPomMethodSignature({ key: keyType });
       }
-      return { params: "", argNames: [] };
+      return createPomMethodSignature([]);
     }
 
     switch (role) {
       case "input":
         return needsKey
-          ? { params: `key: ${keyType}, text: string, annotationText: string = ""`, argNames: ["key", "text", "annotationText"] }
-          : { params: "text: string, annotationText: string = \"\"", argNames: ["text", "annotationText"] };
+          ? createPomMethodSignature({ key: keyType, text: "string", annotationText: "string = \"\"" })
+          : createPomMethodSignature({ text: "string", annotationText: "string = \"\"" });
       case "select":
         return needsKey
-          ? { params: `key: ${keyType}, value: string, annotationText: string = ""`, argNames: ["key", "value", "annotationText"] }
-          : { params: "value: string, annotationText: string = \"\"", argNames: ["value", "annotationText"] };
+          ? createPomMethodSignature({ key: keyType, value: "string", annotationText: "string = \"\"" })
+          : createPomMethodSignature({ value: "string", annotationText: "string = \"\"" });
       case "vselect":
         return needsKey
-          ? { params: `key: ${keyType}, value: string, timeOut = 500`, argNames: ["key", "value", "timeOut"] }
-          : { params: "value: string, timeOut = 500", argNames: ["value", "timeOut"] };
+          ? createPomMethodSignature({ key: keyType, value: "string", timeOut: "number = 500" })
+          : createPomMethodSignature({ value: "string", timeOut: "number = 500" });
       case "radio":
         return needsKey
-          ? { params: `key: ${keyType}, annotationText: string = ""`, argNames: ["key", "annotationText"] }
-          : { params: "annotationText: string = \"\"", argNames: ["annotationText"] };
+          ? createPomMethodSignature({ key: keyType, annotationText: "string = \"\"" })
+          : createPomMethodSignature({ annotationText: "string = \"\"" });
       default:
         if (needsKey) {
-          return { params: `key: ${keyType}`, argNames: ["key"] };
+          return createPomMethodSignature({ key: keyType });
         }
-        return { params: "", argNames: [] };
+        return createPomMethodSignature([]);
     }
   };
 
   const registerPrimaryOnce = (pom: PomPrimarySpec) => {
-    const stableParams = pom.params
-      ? Object.fromEntries(Object.entries(pom.params).sort((a, b) => a[0].localeCompare(b[0])))
-      : undefined;
-
     const alternates = (pom.alternateSelectors ?? [])
       .slice()
       .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
@@ -3361,7 +3366,7 @@ export function applyResolvedDataTestId(args: {
         getterNameOverride: pom.getterNameOverride ?? null,
         selector: pom.selector,
         alternateSelectors: alternates.length ? alternates : undefined,
-        params: stableParams,
+        parameters: pom.parameters,
         target: dataTestIdEntry.targetPageObjectModelClass ?? null,
         emitPrimary: pom.emitPrimary ?? true,
     });
@@ -3377,15 +3382,11 @@ export function applyResolvedDataTestId(args: {
   };
 
   const addExtraClickMethod = (spec: PomExtraClickMethodSpec): boolean => {
-    const stableParams = spec.params
-      ? Object.fromEntries(Object.entries(spec.params).sort((a, b) => a[0].localeCompare(b[0])))
-      : undefined;
-
     // IMPORTANT:
-    // De-dupe based on semantic identity (testId+params+keyLiteral), not the emitted method name.
+    // De-dupe based on semantic identity (testId+parameters+keyLiteral), not the emitted method name.
     // This prevents repeated passes over the same element from generating new unique names
     // (e.g. selectFoo -> selectFoo2) and growing the output.
-    const key = JSON.stringify({ kind: spec.kind, selector: spec.selector, keyLiteral: spec.keyLiteral ?? null, params: stableParams });
+    const key = JSON.stringify({ kind: spec.kind, selector: spec.selector, keyLiteral: spec.keyLiteral ?? null, parameters: spec.parameters });
     const seen = args.generatedMethodContentByComponent.get(args.parentComponentName) ?? new Set<string>();
     if (!args.generatedMethodContentByComponent.has(args.parentComponentName)) {
       args.generatedMethodContentByComponent.set(args.parentComponentName, seen);
@@ -3399,8 +3400,8 @@ export function applyResolvedDataTestId(args: {
     return true;
   };
 
-  const registerGeneratedMethodSignature = (name: string, signature: { params: string; argNames: string[] } | null) => {
-    args.dependencies.generatedMethods ??= new Map<string, { params: string; argNames: string[] } | null>();
+  const registerGeneratedMethodSignature = (name: string, signature: PomMethodSignature | null) => {
+    args.dependencies.generatedMethods ??= new Map<string, PomMethodSignature | null>();
     const prev = args.dependencies.generatedMethods.get(name);
     if (prev === undefined) {
       args.dependencies.generatedMethods.set(name, signature);
@@ -3409,7 +3410,7 @@ export function applyResolvedDataTestId(args: {
     if (prev === null) {
       return;
     }
-    if (signature === null || prev.params !== signature.params) {
+    if (signature === null || !pomMethodSignatureEquals(prev, signature)) {
       args.dependencies.generatedMethods.set(name, null);
     }
   };
@@ -3566,11 +3567,11 @@ export function applyResolvedDataTestId(args: {
             label: createPomStringPattern(label, "static"),
             exact: true,
           },
-          params: { annotationText: `string = ""` },
+          parameters: normalizePomParameters({ annotationText: `string = ""` }),
         });
 
         if (added) {
-          registerGeneratedMethodSignature(generatedName, { params: `annotationText: string = ""`, argNames: ["annotationText"] });
+          registerGeneratedMethodSignature(generatedName, createPomMethodSignature({ annotationText: `string = ""` }));
         }
       }
 
@@ -3596,11 +3597,11 @@ export function applyResolvedDataTestId(args: {
         label: createPomStringPattern("${value}", "parameterized"),
         exact: true,
       },
-      params: { value: "string", annotationText: `string = ""` },
+      parameters: normalizePomParameters({ value: "string", annotationText: `string = ""` }),
     });
 
     if (added) {
-      registerGeneratedMethodSignature(generatedName, { params: `value: string, annotationText: string = ""`, argNames: ["value", "annotationText"] });
+      registerGeneratedMethodSignature(generatedName, createPomMethodSignature({ value: "string", annotationText: `string = ""` }));
     }
     return { selectorValue: dataTestId, runtimeValue: runtimeDataTestId, fromExisting };
   }
@@ -3649,11 +3650,11 @@ export function applyResolvedDataTestId(args: {
           testId: selectorPattern,
         },
         keyLiteral: rawValue,
-        params: { wait: "boolean = true" },
+        parameters: normalizePomParameters({ wait: "boolean = true" }),
       });
 
       if (added) {
-        registerGeneratedMethodSignature(generatedName, { params: `wait: boolean = true`, argNames: ["wait"] });
+        registerGeneratedMethodSignature(generatedName, createPomMethodSignature({ wait: "boolean = true" }));
       }
     }
 
@@ -3707,8 +3708,8 @@ export interface DataTestIdEntryOverrides {
  * Structured representation of a generated element for POM emission.
  *
  * - `selector` carries both the rendered selector text and whether it is static or parameterized.
- * - `params` is TypeScript-flavored today because TS is our reference emitter;
- *   C# emission maps these params to C# types.
+ * - `parameters` are TypeScript-flavored today because TS is our reference emitter;
+ *   C# emission maps these parameters to C# types.
  */
 export interface PomPrimarySpec {
   nativeRole: NativeRole;
@@ -3723,8 +3724,8 @@ export interface PomPrimarySpec {
 
   /** Optional key used to decide whether distinct elements should be merged into one POM member. */
   mergeKey?: string;
-  /** TypeScript param blocks used by the TS emitter (and signature metadata). */
-  params: Record<string, string>;
+  /** Structured method parameters used by emitters and signature metadata. */
+  parameters: PomParameterSpec[];
   /** Optional enum values for key when derived from a static v-for list. */
   keyValuesOverride?: string[] | null;
 
@@ -3760,7 +3761,7 @@ export interface PomExtraClickMethodSpec {
   selector: PomSelectorSpec;
   /** Optional fixed key to substitute into `${key}` in the method body. */
   keyLiteral?: string;
-  params: Record<string, string>;
+  parameters: PomParameterSpec[];
 }
 
 export interface IComponentDependencies {
@@ -3784,10 +3785,10 @@ export interface IComponentDependencies {
    * without re-parsing the generated TypeScript.
    *
    * - key: method name
-   * - value: { params, argNames } when the signature is known and consistent
+   * - value: structured parameters when the signature is known and consistent
    *          null when multiple distinct signatures were observed for the same name
    */
-  generatedMethods?: Map<string, { params: string; argNames: string[] } | null>;
+  generatedMethods?: Map<string, PomMethodSignature | null>;
   isView?: boolean;
 
   /**

--- a/utils.ts
+++ b/utils.ts
@@ -125,6 +125,8 @@ export type AttributeValue =
   | { kind: "template"; template: string; parsedTemplate: ParsedTemplateFragment };
 
 type VueExpressionNode = SimpleExpressionNode | CompoundExpressionNode;
+type VueExpressionSourceView = "content" | "loc" | "compiled";
+type BabelParserPluginName = "typescript" | "jsx";
 
 export interface ResolvedKeyInfo {
   selectorFragment: string;
@@ -158,7 +160,7 @@ export function getAttributeValueText(value: AttributeValue): string {
  */
 export function getVueExpressionSource(
   expression: VueExpressionNode | null | undefined,
-  ...preferredViews: Array<"content" | "loc" | "compiled">
+  ...preferredViews: VueExpressionSourceView[]
 ): string {
   if (!expression) {
     return "";
@@ -193,6 +195,69 @@ export function getVueExpressionSource(
   }
 
   return "";
+}
+
+function tryGetExistingVueExpressionAst(expression: VueExpressionNode | null | undefined): BabelNode | null {
+  if (!expression) {
+    return null;
+  }
+
+  const ast = ("ast" in expression ? expression.ast : null) as object | null | false | undefined;
+  return ast && "type" in ast ? ast as BabelNode : null;
+}
+
+function tryParseBabelExpressionFromSource(source: string, plugins: BabelParserPluginName[]): BabelNode | null {
+  const trimmed = source.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    return parseExpression(trimmed, { plugins }) as BabelNode;
+  }
+  catch {
+    return null;
+  }
+}
+
+function tryGetVueExpressionAst(
+  expression: VueExpressionNode | null | undefined,
+  options?: {
+    preferredViews?: VueExpressionSourceView[];
+    plugins?: BabelParserPluginName[];
+    preferExistingAst?: boolean;
+  },
+): BabelNode | null {
+  if (!expression) {
+    return null;
+  }
+
+  if (options?.preferExistingAst !== false) {
+    const existingAst = tryGetExistingVueExpressionAst(expression);
+    if (existingAst) {
+      return existingAst;
+    }
+  }
+
+  const source = getVueExpressionSource(expression, ...(options?.preferredViews ?? ["content", "loc", "compiled"]));
+  return source ? tryParseBabelExpressionFromSource(source, options?.plugins ?? ["typescript"]) : null;
+}
+
+function tryGetDirectiveBabelAst(
+  directive: DirectiveNode,
+  options?: {
+    preferredViews?: VueExpressionSourceView[];
+    plugins?: BabelParserPluginName[];
+    preferExistingAst?: boolean;
+  },
+): BabelNode | null {
+  const exp = directive.exp && (
+    directive.exp.type === NodeTypes.SIMPLE_EXPRESSION
+    || directive.exp.type === NodeTypes.COMPOUND_EXPRESSION
+  )
+    ? directive.exp as VueExpressionNode
+    : null;
+  return tryGetVueExpressionAst(exp, options);
 }
 
 /**
@@ -489,7 +554,7 @@ function tryGetSlotScopeKeyCandidate(node: BabelNode | null | undefined): SlotSc
 }
 
 function tryGetTemplateSlotScopeBindingNode(expression: VueExpressionNode): BabelNode | null {
-  const ast = ("ast" in expression ? expression.ast : null) as BabelNode | null | false | undefined;
+  const ast = tryGetExistingVueExpressionAst(expression);
   if (ast) {
     if (isArrowFunctionExpression(ast)) {
       return ast.params[0] as BabelNode | undefined ?? null;
@@ -886,14 +951,6 @@ export function getKeyDirectiveInfo(node: ElementNode): ResolvedKeyInfo | null {
   return toResolvedKeyInfo(selectorSource, runtimeSource);
 }
 
-export function getKeyDirectiveValue(node: ElementNode, _context: TransformContext | null = null): string | null {
-  return getKeyDirectiveInfo(node)?.selectorFragment ?? null;
-}
-
-export function getKeyDirectiveRuntimeValue(node: ElementNode): string | null {
-  return getKeyDirectiveInfo(node)?.runtimeFragment ?? null;
-}
-
 /**
  * Gets both v-model and :model-value directive values in a single pass
  * Consolidates the previous getVModelDirectiveValue and getModelValueValue helpers
@@ -911,8 +968,15 @@ export function getModelBindingValues(node: ElementNode): { vModel: string; mode
   let modelValue: string | null = null;
   const modelValueDirective = findDirectiveByName(node, "bind", "modelValue");
 
-  if (modelValueDirective?.exp?.ast) {
-    const { name: mv } = getClickHandlerNameFromAst(modelValueDirective.exp.ast as BabelNode);
+  const modelValueAst = modelValueDirective
+    ? tryGetDirectiveBabelAst(modelValueDirective, {
+      preferredViews: ["loc", "compiled"],
+      plugins: ["typescript"],
+      preferExistingAst: false,
+    })
+    : null;
+  if (modelValueAst) {
+    const { name: mv } = getClickHandlerNameFromAst(modelValueAst);
     modelValue = mv;
   }
 
@@ -1004,18 +1068,6 @@ export function isNodeContainedInTemplateWithData(node: ElementNode, hierarchyMa
   return false;
 }
 
-/**
- * Extracts a key placeholder from a parent <template> with slot scope data.
- *
- * If the node is within a slot that has scope variables (e.g. #item="{ data }"),
- * returns a placeholder derived from that scope.
- *
- * @internal
- */
-export function getContainedInSlotDataKeyValue(node: ElementNode, hierarchyMap: HierarchyMap): string | null {
-  return getContainedInSlotDataKeyInfo(node, hierarchyMap)?.selectorFragment ?? null;
-}
-
 export function getContainedInSlotDataKeyInfo(node: ElementNode, hierarchyMap: HierarchyMap): ResolvedKeyInfo | null {
   let parent = getParent(hierarchyMap, node);
   while (parent) {
@@ -1028,18 +1080,6 @@ export function getContainedInSlotDataKeyInfo(node: ElementNode, hierarchyMap: H
     parent = getParent(hierarchyMap, parent);
   }
   return null;
-}
-
-/**
- * Extracts the key value expression from a v-for directive on a parent element
- *
- * If the node is within a v-for that has a :key directive, returns the key expression.
- *
- * @internal
- */
-export function getContainedInVForDirectiveKeyValue(context: TransformContext, node: ElementNode, hierarchyMap: HierarchyMap): string | null {
-  const keyFragments = getContainedInVForDirectiveKeyInfo(context, node, hierarchyMap);
-  return keyFragments?.selectorFragment ?? null;
 }
 
 export function getContainedInVForDirectiveKeyInfo(context: TransformContext, node: ElementNode, hierarchyMap: HierarchyMap): ResolvedKeyInfo | null {
@@ -1060,11 +1100,6 @@ export function getContainedInVForDirectiveKeyInfo(context: TransformContext, no
     parent = getParent(hierarchyMap, parent);
   }
   return null;
-}
-
-export function getContainedInVForDirectiveKeyRuntimeValue(context: TransformContext, node: ElementNode, hierarchyMap: HierarchyMap): string | null {
-  const keyFragments = getContainedInVForDirectiveKeyInfo(context, node, hierarchyMap);
-  return keyFragments?.runtimeFragment ?? null;
 }
 
 /**
@@ -1214,11 +1249,14 @@ export function nodeHandlerAttributeInfo(node: ElementNode): HandlerAttributeInf
   // NOTE: We intentionally do not normalize via regex/string parsing helpers in this package.
   const mergeKey = `handler:expr:${source}`;
 
-  let expr: object;
-  try {
-    expr = parseExpression(source, { plugins: ["typescript", "jsx"] });
-  }
-  catch {
+  const expr = tryGetDirectiveBabelAst(handlerDirective, {
+    preferredViews: ["content", "compiled"],
+    plugins: ["typescript", "jsx"],
+    // Vue's compiler AST can encode `_ctx.foo` as an Identifier name instead of a MemberExpression.
+    // That is fine for Vue codegen, but our semantic-name extraction needs a normal Babel parse tree.
+    preferExistingAst: false,
+  });
+  if (!expr) {
     // Even if parsing fails, still provide a merge identity.
     return null;
   }
@@ -1692,15 +1730,22 @@ function getDataTestIdValueFromValueAttribute(
   }
 
   const attrDynamic = findDirectiveByName(node, "bind", attributeKey);
-  if (attrDynamic && 'exp' in attrDynamic && attrDynamic.exp && 'ast' in attrDynamic.exp && attrDynamic.exp.ast) {
+  const attrDynamicAst = attrDynamic
+    ? tryGetDirectiveBabelAst(attrDynamic, {
+      preferredViews: ["loc", "compiled"],
+      plugins: ["typescript"],
+      preferExistingAst: false,
+    })
+    : null;
+  if (attrDynamic?.exp && attrDynamicAst) {
     let value = getVueExpressionSource(attrDynamic.exp as VueExpressionNode, "loc", "compiled");
 
-    if (attrDynamic.exp.ast?.type === "MemberExpression") {
+    if (isMemberExpression(attrDynamicAst) || isOptionalMemberExpression(attrDynamicAst)) {
       // eslint-disable-next-line no-restricted-syntax
       return staticAttributeValue(`${actualFileName}-${value.replaceAll(".", "")}-${role}`);
     }
 
-    if (attrDynamic.exp.ast?.type === "CallExpression") {
+    if (isCallExpression(attrDynamicAst) || isOptionalCallExpression(attrDynamicAst)) {
       value = getVueExpressionSource(attrDynamic.exp as VueExpressionNode, "compiled", "loc");
       return templateAttributeValue(`${actualFileName}-\${${value}}-${role}`);
     }
@@ -1710,9 +1755,9 @@ function getDataTestIdValueFromValueAttribute(
 }
 
 export function generateToDirectiveDataTestId(componentName: string, node: ElementNode, toDirective: DirectiveNode, context: TransformContext, hierarchyMap: HierarchyMap, nativeWrappers: NativeWrappersMap): AttributeValue | null {
-  const key = getKeyDirectiveValue(node, context) || getSelfClosingForDirectiveKeyAttrValue(node) || getContainedInVForDirectiveKeyValue(context, node, hierarchyMap);
-  if (key) {
-    return templateAttributeValue(`${componentName}-${key}-${formatTagName(node, nativeWrappers)}`);
+  const keyInfo = getKeyDirectiveInfo(node) || getContainedInVForDirectiveKeyInfo(context, node, hierarchyMap);
+  if (keyInfo) {
+    return templateAttributeValue(`${componentName}-${keyInfo.selectorFragment}-${formatTagName(node, nativeWrappers)}`);
   } else {
     let name = toDirectiveObjectFieldNameValue(toDirective);
     if (!name) {
@@ -1764,48 +1809,49 @@ export function toDirectiveObjectFieldNameValue(node: DirectiveNode): string | n
     return null;
   }
 
-  const source = (node.exp as CompoundExpressionNode).loc.source.trim();
-  try {
-    const expr = parseExpression(source, { plugins: ["typescript"] }) as object;
-
-    const isNodeType = (n: object | null, type: string): n is { type: string } => {
-      return n !== null && (n as { type?: string }).type === type;
-    };
-    const isStringLiteralNode = (n: object | null): n is { type: "StringLiteral"; value: string } => {
-      return isNodeType(n, "StringLiteral") && typeof (n as { value?: string }).value === "string";
-    };
-    const isIdentifierNode = (n: object | null): n is { type: "Identifier"; name: string } => {
-      return isNodeType(n, "Identifier") && typeof (n as { name?: string }).name === "string";
-    };
-    const isObjectPropertyNode = (n: object | null): n is { type: "ObjectProperty"; key: object; value: object } => {
-      if (!isNodeType(n, "ObjectProperty"))
-        return false;
-      const nn = n as { key?: object; value?: object };
-      return typeof nn.key === "object" && nn.key !== null && typeof nn.value === "object" && nn.value !== null;
-    };
-    const isObjectExpressionNode = (n: object | null): n is { type: "ObjectExpression"; properties: object[] } => {
-      if (!isNodeType(n, "ObjectExpression"))
-        return false;
-      const nn = n as { properties?: object[] };
-      return Array.isArray(nn.properties);
-    };
-
-    if (!isObjectExpressionNode(expr))
-      return null;
-
-    const nameProp = (expr as { properties: object[] }).properties.find((p) => {
-      if (!isObjectPropertyNode(p))
-        return false;
-      const key = p.key as object;
-      return (isIdentifierNode(key) && key.name === "name") || (isStringLiteralNode(key) && key.value === "name");
-    });
-    if (!nameProp || !isObjectPropertyNode(nameProp) || !isStringLiteralNode(nameProp.value as object))
-      return null;
-    return toPascalCase((nameProp.value as { value: string }).value);
-  }
-  catch {
+  const expr = tryGetDirectiveBabelAst(node, {
+    preferredViews: ["loc", "compiled"],
+    plugins: ["typescript"],
+    preferExistingAst: false,
+  }) as object | null;
+  if (!expr) {
     return null;
   }
+
+  const isNodeType = (n: object | null, type: string): n is { type: string } => {
+    return n !== null && (n as { type?: string }).type === type;
+  };
+  const isStringLiteralNode = (n: object | null): n is { type: "StringLiteral"; value: string } => {
+    return isNodeType(n, "StringLiteral") && typeof (n as { value?: string }).value === "string";
+  };
+  const isIdentifierNode = (n: object | null): n is { type: "Identifier"; name: string } => {
+    return isNodeType(n, "Identifier") && typeof (n as { name?: string }).name === "string";
+  };
+  const isObjectPropertyNode = (n: object | null): n is { type: "ObjectProperty"; key: object; value: object } => {
+    if (!isNodeType(n, "ObjectProperty"))
+      return false;
+    const nn = n as { key?: object; value?: object };
+    return typeof nn.key === "object" && nn.key !== null && typeof nn.value === "object" && nn.value !== null;
+  };
+  const isObjectExpressionNode = (n: object | null): n is { type: "ObjectExpression"; properties: object[] } => {
+    if (!isNodeType(n, "ObjectExpression"))
+      return false;
+    const nn = n as { properties?: object[] };
+    return Array.isArray(nn.properties);
+  };
+
+  if (!isObjectExpressionNode(expr))
+    return null;
+
+  const nameProp = (expr as { properties: object[] }).properties.find((p) => {
+    if (!isObjectPropertyNode(p))
+      return false;
+    const key = p.key as object;
+    return (isIdentifierNode(key) && key.name === "name") || (isStringLiteralNode(key) && key.value === "name");
+  });
+  if (!nameProp || !isObjectPropertyNode(nameProp) || !isStringLiteralNode(nameProp.value as object))
+    return null;
+  return toPascalCase((nameProp.value as { value: string }).value);
 }
 
 export function addComponentTestIds(componentName: string, componentTestIds: Map<string, Set<string>>, desiredTestId: string) {
@@ -1872,12 +1918,12 @@ function tryParseBabelAstFromHandlerSource(source: string): object | null {
     return null;
 
   // Most handlers are expression-shaped; parse that first.
-  try {
-    return parseExpression(trimmed, { plugins: ["typescript", "jsx"] }) as object;
+  const expressionAst = tryParseBabelExpressionFromSource(trimmed, ["typescript", "jsx"]);
+  if (expressionAst) {
+    return expressionAst as object;
   }
-  catch {
-    // Handlers can also be statement-shaped (e.g. `a(); b()` or `if (...) ...`). Parse as a file.
-  }
+
+  // Handlers can also be statement-shaped (e.g. `a(); b()` or `if (...) ...`). Parse as a file.
 
   try {
     return parse(trimmed, { sourceType: "module", plugins: ["typescript", "jsx"] }) as object;
@@ -2459,15 +2505,8 @@ export function tryGetExistingElementDataTestId(node: ElementNode, attributeName
     return null;
   }
 
-  let fallbackAst = ast as BabelNode | null | false | undefined;
-  if (!fallbackAst) {
-    try {
-      fallbackAst = parseExpression(raw, { plugins: ["typescript"] }) as BabelNode;
-    }
-    catch {
-      fallbackAst = null;
-    }
-  }
+  const fallbackAst = (ast as BabelNode | null | false | undefined)
+    ?? tryGetVueExpressionAst(simpleExp, { preferredViews: ["content", "loc", "compiled"], plugins: ["typescript"] });
 
   if (fallbackAst && typeof fallbackAst === "object" && "type" in fallbackAst && (fallbackAst as { type: string }).type === "StringLiteral") {
     const sl = fallbackAst as { value?: string };
@@ -3379,32 +3418,10 @@ export function applyResolvedDataTestId(args: {
   };
 
   const tryGetDirectiveExpressionAst = (dir: DirectiveNode): BabelNode | null => {
-    const exp = dir.exp;
-    if (!exp) {
-      return null;
-    }
-
-    // Prefer Vue-populated `exp.ast` when present.
-    if (exp.type === NodeTypes.SIMPLE_EXPRESSION) {
-      const simple = exp as SimpleExpressionNode;
-      const ast = simple.ast as object | null;
-      if (ast && "type" in ast) {
-        return ast as BabelNode;
-      }
-    }
-
-    // Fallback: parse the expression source.
-    try {
-      const raw = getVueExpressionSource(
-        exp as VueExpressionNode,
-        args.context ? "compiled" : "loc",
-        args.context ? "loc" : "compiled",
-      );
-      return parseExpression(raw, { plugins: ["typescript"] }) as BabelNode;
-    }
-    catch {
-      return null;
-    }
+    return tryGetDirectiveBabelAst(dir, {
+      preferredViews: args.context ? ["compiled", "loc"] : ["loc", "compiled"],
+      plugins: ["typescript"],
+    });
   };
 
   const tryGetStaticStringFromBabel = (node: BabelNode | null): string | null => {

--- a/utils.ts
+++ b/utils.ts
@@ -527,6 +527,48 @@ function getKeyDirective(node: ElementNode): DirectiveNode | null {
   return findDirectiveByName(node, "bind", "key") ?? null;
 }
 
+function tryUnwrapTemplateLiteralExpressionSource(source: string): { template: string; expressionCount: number } | null {
+  const trimmed = source.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const ast = parseExpression(trimmed, { plugins: ["typescript"] }) as BabelNode;
+    if (!isTemplateLiteral(ast)) {
+      return null;
+    }
+
+    const start = typeof ast.start === "number" ? ast.start + 1 : 1;
+    const end = typeof ast.end === "number" ? ast.end - 1 : trimmed.length - 1;
+    return {
+      template: trimmed.slice(start, end),
+      expressionCount: ast.expressions.length,
+    };
+  }
+  catch {
+    return null;
+  }
+}
+
+function tryParseTemplateFragment(fragment: string): TemplateLiteral | null {
+  if (!fragment) {
+    return null;
+  }
+
+  try {
+    const ast = parseExpression(`\`${fragment}\``, { plugins: ["typescript"] }) as BabelNode;
+    return isTemplateLiteral(ast) ? ast : null;
+  }
+  catch {
+    return null;
+  }
+}
+
+export function hasTemplateInterpolationExpressions(fragment: string): boolean {
+  return (tryParseTemplateFragment(fragment)?.expressions.length ?? 0) > 0;
+}
+
 /**
  * Gets the value placeholder for a :key directive
  *
@@ -543,8 +585,9 @@ export function getKeyDirectiveValue(node: ElementNode, _context: TransformConte
       // Inline template-literal keys directly into the generated data-testid template so the
       // resulting expression uses the compiler-prefixed component scope (`_ctx.*`) while still
       // preserving local v-for / slot bindings without nesting an extra template literal.
-      if (value.startsWith("`") && value.endsWith("`")) {
-        return value.slice(1, -1);
+      const templateLiteral = tryUnwrapTemplateLiteralExpressionSource(value);
+      if (templateLiteral) {
+        return templateLiteral.template;
       }
 
       return `\${${value}}`;
@@ -553,9 +596,8 @@ export function getKeyDirectiveValue(node: ElementNode, _context: TransformConte
 
   const rawSource = keyDirective?.exp?.loc.source?.trim();
   if (rawSource) {
-    return rawSource.startsWith("`") && rawSource.endsWith("`")
-      ? rawSource.slice(1, -1)
-      : `\${${rawSource}}`;
+    const templateLiteral = tryUnwrapTemplateLiteralExpressionSource(rawSource);
+    return templateLiteral ? templateLiteral.template : `\${${rawSource}}`;
   }
 
   return null;
@@ -565,17 +607,15 @@ export function getKeyDirectiveRuntimeValue(node: ElementNode): string | null {
   const keyDirective = getKeyDirective(node);
   const rawSource = keyDirective?.exp?.loc.source?.trim();
   if (rawSource) {
-    return rawSource.startsWith("`") && rawSource.endsWith("`")
-      ? rawSource.slice(1, -1)
-      : `\${${rawSource}}`;
+    const templateLiteral = tryUnwrapTemplateLiteralExpressionSource(rawSource);
+    return templateLiteral ? templateLiteral.template : `\${${rawSource}}`;
   }
 
   if (keyDirective?.exp) {
     const value = stringifyExpression(keyDirective.exp).trim();
     if (value) {
-      return value.startsWith("`") && value.endsWith("`")
-        ? value.slice(1, -1)
-        : `\${${value}}`;
+      const templateLiteral = tryUnwrapTemplateLiteralExpressionSource(value);
+      return templateLiteral ? templateLiteral.template : `\${${value}}`;
     }
   }
 
@@ -2127,9 +2167,7 @@ export function tryGetExistingElementDataTestId(node: ElementNode, attributeName
     // Prefer the raw template (so callers can validate placeholders / preserve interpolation),
     // but fall back to cooked content when we can't confidently unwrap.
     const raw = (simpleExp.content ?? "").trim();
-    const unwrappedTemplate = (raw.startsWith("`") && raw.endsWith("`") && raw.length >= 2)
-      ? raw.slice(1, -1)
-      : cooked;
+    const unwrappedTemplate = tryUnwrapTemplateLiteralExpressionSource(raw)?.template ?? cooked;
 
     if (isStatic) {
       return { value: unwrappedTemplate, isDynamic: false, isStaticLiteral: true };
@@ -2180,10 +2218,7 @@ export function tryGetExistingElementDataTestId(node: ElementNode, attributeName
       const cooked = (tl.quasis ?? []).map(q => q.value?.cooked ?? "").join("");
       const expressionCount = (tl.expressions ?? []).length;
       const isStatic = expressionCount === 0;
-
-      const unwrappedTemplate = (raw.startsWith("`") && raw.endsWith("`") && raw.length >= 2)
-        ? raw.slice(1, -1)
-        : cooked;
+      const unwrappedTemplate = tryUnwrapTemplateLiteralExpressionSource(raw)?.template ?? cooked;
 
       if (isStatic) {
         return { value: unwrappedTemplate, isDynamic: false, isStaticLiteral: true };
@@ -2222,8 +2257,12 @@ export function tryGetExistingElementDataTestId(node: ElementNode, attributeName
 }
 
 function isTemplatePlaceholder(part: string) {
-  // Avoid regex literals here; this only needs to detect the simple `${...}` wrapper.
-  return part.startsWith("${") && part.endsWith("}") && part.length >= 3;
+  const templateLiteral = tryParseTemplateFragment(part);
+  return !!templateLiteral
+    && templateLiteral.expressions.length === 1
+    && templateLiteral.quasis.length === 2
+    && (templateLiteral.quasis[0]?.value.raw ?? "") === ""
+    && (templateLiteral.quasis[1]?.value.raw ?? "") === "";
 }
 
 function isAllCapsOrDigits(value: string): boolean {

--- a/utils.ts
+++ b/utils.ts
@@ -2647,7 +2647,7 @@ export function applyResolvedDataTestId(args: {
   keyInfo: ResolvedKeyInfo | null;
   /** Optional enumerable key values (e.g. derived from v-for="item in ['One','Two']"). */
   keyValuesOverride?: string[] | null;
-  entryOverrides?: Partial<IDataTestId>;
+  entryOverrides?: DataTestIdEntryOverrides;
   /**
    * Semantic naming hint used for generating method/property names.
    *
@@ -3252,12 +3252,12 @@ export function applyResolvedDataTestId(args: {
 
   const childComponentName = args.element.tag;
   const dataTestIdEntry: IDataTestId = {
-    selectorValue: createPomStringPattern(
+    selectorValue: entryOverrides.selectorValue ?? createPomStringPattern(
       getAttributeValueText(dataTestId),
       dataTestId.kind === "template" ? "parameterized" : "static",
     ),
-    templateLiteral: undefined,
-    ...entryOverrides,
+    templateLiteral: entryOverrides.templateLiteral,
+    targetPageObjectModelClass: entryOverrides.targetPageObjectModelClass,
   };
 
   // Store the primary POM spec so emitters can generate POMs for multiple languages.
@@ -3695,6 +3695,12 @@ export interface IDataTestId {
    * ever needing to parse the `data-testid` string itself.
    */
   pom?: PomPrimarySpec;
+}
+
+export interface DataTestIdEntryOverrides {
+  selectorValue?: PomStringPattern;
+  templateLiteral?: TemplateLiteral;
+  targetPageObjectModelClass?: string;
 }
 
 /**

--- a/utils.ts
+++ b/utils.ts
@@ -115,16 +115,26 @@ export interface NativeWrappersMap {
   }
 }
 
+interface ParsedTemplateFragment {
+  source: string;
+  templateLiteral: TemplateLiteral;
+}
+
 export type AttributeValue =
   | { kind: "static"; value: string }
-  | { kind: "template"; template: string };
+  | { kind: "template"; template: string; parsedTemplate: ParsedTemplateFragment };
 
 export function staticAttributeValue(value: string): AttributeValue {
   return { kind: "static", value };
 }
 
 export function templateAttributeValue(template: string): AttributeValue {
-  return { kind: "template", template };
+  const parsedTemplate = tryParseTemplateFragment(template);
+  if (!parsedTemplate) {
+    throw new Error(`[vue-pom-generator] Failed to parse generated template fragment: ${template}`);
+  }
+
+  return { kind: "template", template, parsedTemplate };
 }
 
 export function getAttributeValueText(value: AttributeValue): string {
@@ -529,39 +539,31 @@ function getKeyDirective(node: ElementNode): DirectiveNode | null {
 }
 
 /**
- * Attempts to unwrap a template-literal expression into its body text.
- *
- * Accepts either the original Vue `SimpleExpressionNode` or a raw expression string.
+ * Attempts to unwrap a full template-literal expression source into its body text.
  *
  * @example
- * tryUnwrapTemplateLiteralExpressionSource("`row-${item.id}`")
+ * tryUnwrapTemplateLiteralSource("`row-${item.id}`")
  * // => { template: "row-${item.id}", expressionCount: 1 }
  *
  * @example
- * tryUnwrapTemplateLiteralExpressionSource("item.id")
+ * tryUnwrapTemplateLiteralSource("item.id")
  * // => null
  */
-function tryUnwrapTemplateLiteralExpressionSource(expression: SimpleExpressionNode | string | null | undefined): { template: string; expressionCount: number } | null {
-  const rawSource = typeof expression === "string"
-    ? expression.trim()
-    : (expression?.content ?? "").trim();
+function tryUnwrapTemplateLiteralSource(source: string): { template: string; expressionCount: number } | null {
+  const rawSource = source.trim();
   if (!rawSource) {
     return null;
   }
 
-  let ast = typeof expression === "string"
-    ? null
-    : (expression?.ast as BabelNode | null | false | undefined);
-  if (!ast || !isTemplateLiteral(ast)) {
-    try {
-      ast = parseExpression(rawSource, { plugins: ["typescript"] }) as BabelNode;
-    }
-    catch {
-      return null;
-    }
+  let ast: BabelNode | null | false | undefined = null;
+  try {
+    ast = parseExpression(rawSource, { plugins: ["typescript"] }) as BabelNode;
+  }
+  catch {
+    return null;
   }
 
-  if (!isTemplateLiteral(ast)) {
+  if (!ast || !isTemplateLiteral(ast)) {
     return null;
   }
 
@@ -583,20 +585,45 @@ function tryUnwrapTemplateLiteralExpressionSource(expression: SimpleExpressionNo
 }
 
 /**
+ * Attempts to unwrap a template-literal expression node into its body text.
+ *
+ * Accepts the original Vue template-expression node so callers stay on the AST-driven path.
+ * Vue commonly represents template-literal bindings as `CompoundExpressionNode`s even when the
+ * attached Babel AST is a single `TemplateLiteral`, so this helper intentionally accepts both
+ * simple and compound expression nodes.
+ *
+ * @example
+ * const exp = findDirectiveByName(node, "bind", "key")?.exp as SimpleExpressionNode | CompoundExpressionNode;
+ * tryUnwrapTemplateLiteralExpressionSource(exp)
+ * // => { template: "row-${item.id}", expressionCount: 1 }
+ *
+ * @example
+ * const exp = findDirectiveByName(node, "bind", "key")?.exp as SimpleExpressionNode | CompoundExpressionNode;
+ * tryUnwrapTemplateLiteralExpressionSource(exp)
+ * // => null
+ */
+function tryUnwrapTemplateLiteralExpressionSource(expression: SimpleExpressionNode | CompoundExpressionNode | null): { template: string; expressionCount: number } | null {
+  const rawSource = expression
+    ? (expression.loc?.source ?? stringifyExpression(expression)).trim()
+    : "";
+  return rawSource ? tryUnwrapTemplateLiteralSource(rawSource) : null;
+}
+
+/**
  * Parses the inside of a template literal as a `TemplateLiteral` AST node.
  *
  * `parseExpression()` only accepts complete JavaScript expressions, so fragments like
  * `line-${item.id}` need synthetic backticks before they can be parsed.
  *
  * @example
- * tryParseTemplateFragment("line-${item.id}")?.expressions.length
+ * tryParseTemplateFragment("line-${item.id}")?.templateLiteral.expressions.length
  * // => 1
  *
  * @example
- * tryParseTemplateFragment("plain-text")?.expressions.length
+ * tryParseTemplateFragment("plain-text")?.templateLiteral.expressions.length
  * // => 0
  */
-function tryParseTemplateFragment(fragment: string): TemplateLiteral | null {
+function tryParseTemplateFragment(fragment: string): ParsedTemplateFragment | null {
   if (!fragment) {
     return null;
   }
@@ -604,8 +631,9 @@ function tryParseTemplateFragment(fragment: string): TemplateLiteral | null {
   try {
     // A fragment like `line-${item.id}` is the inside of a template literal, not a standalone
     // JavaScript expression, so we synthesize the surrounding backticks before parsing.
-    const ast = parseExpression(`\`${fragment}\``, { plugins: ["typescript"] }) as BabelNode;
-    return isTemplateLiteral(ast) ? ast : null;
+    const source = `\`${fragment}\``;
+    const ast = parseExpression(source, { plugins: ["typescript"] }) as BabelNode;
+    return isTemplateLiteral(ast) ? { source, templateLiteral: ast } : null;
   }
   catch {
     return null;
@@ -624,7 +652,7 @@ function tryParseTemplateFragment(fragment: string): TemplateLiteral | null {
  * // => false
  */
 export function hasTemplateInterpolationExpressions(fragment: string): boolean {
-  return (tryParseTemplateFragment(fragment)?.expressions.length ?? 0) > 0;
+  return (tryParseTemplateFragment(fragment)?.templateLiteral.expressions.length ?? 0) > 0;
 }
 
 export interface InterpolatedTemplateFragment {
@@ -662,22 +690,25 @@ export function toInterpolatedTemplateFragment(fragment: string | null): Interpo
 }
 
 /**
- * Reconstructs a full template-literal expression from a fragment using the parsed quasis/expressions.
+ * Reconstructs a full template-literal expression from a template AttributeValue using its parsed quasis/expressions.
  *
  * @example
- * renderTemplateLiteralExpressionFromFragment("line-${item.id}")
+ * const templateValue = templateAttributeValue("line-${item.id}");
+ * if (templateValue.kind === "template") {
+ *   renderTemplateLiteralExpression(templateValue)
+ * }
  * // => "`line-${item.id}`"
  *
  * @example
- * renderTemplateLiteralExpressionFromFragment("plain-text")
+ * const templateValue = templateAttributeValue("plain-text");
+ * if (templateValue.kind === "template") {
+ *   renderTemplateLiteralExpression(templateValue)
+ * }
  * // => "`plain-text`"
  */
-export function renderTemplateLiteralExpressionFromFragment(fragment: string): string {
-  const templateLiteralSource = `\`${fragment}\``;
-  const templateLiteral = tryParseTemplateFragment(fragment);
-  if (!templateLiteral) {
-    return templateLiteralSource;
-  }
+export function renderTemplateLiteralExpression(templateValue: Extract<AttributeValue, { kind: "template" }>): string {
+  const templateLiteralSource = templateValue.parsedTemplate.source;
+  const templateLiteral = templateValue.parsedTemplate.templateLiteral;
 
   // Render through the shared TypeScript writer so this codegen path follows the same
   // quoting/newline conventions as the rest of the repo's generated TypeScript output.
@@ -716,13 +747,20 @@ export function renderTemplateLiteralExpressionFromFragment(fragment: string): s
  */
 export function getKeyDirectiveValue(node: ElementNode, _context: TransformContext | null = null): string | null {
   const keyDirective = getKeyDirective(node);
-  if (keyDirective?.exp) {
-    const value = stringifyExpression(keyDirective.exp).trim();
+  const keyExpression = keyDirective?.exp && (
+    keyDirective.exp.type === NodeTypes.SIMPLE_EXPRESSION
+    || keyDirective.exp.type === NodeTypes.COMPOUND_EXPRESSION
+  )
+    ? keyDirective.exp as SimpleExpressionNode | CompoundExpressionNode
+    : null;
+
+  if (keyExpression) {
+    const value = stringifyExpression(keyExpression).trim();
     if (value) {
       // Inline template-literal keys directly into the generated data-testid template so the
       // resulting expression uses the compiler-prefixed component scope (`_ctx.*`) while still
       // preserving local v-for / slot bindings without nesting an extra template literal.
-      const templateLiteral = tryUnwrapTemplateLiteralExpressionSource(value);
+      const templateLiteral = tryUnwrapTemplateLiteralSource(value);
       if (templateLiteral) {
         return templateLiteral.template;
       }
@@ -731,9 +769,9 @@ export function getKeyDirectiveValue(node: ElementNode, _context: TransformConte
     }
   }
 
-  const rawSource = keyDirective?.exp?.loc.source?.trim();
+  const rawSource = keyExpression?.loc.source?.trim();
   if (rawSource) {
-    const templateLiteral = tryUnwrapTemplateLiteralExpressionSource(rawSource);
+    const templateLiteral = tryUnwrapTemplateLiteralExpressionSource(keyExpression);
     return templateLiteral ? templateLiteral.template : `\${${rawSource}}`;
   }
 
@@ -742,16 +780,22 @@ export function getKeyDirectiveValue(node: ElementNode, _context: TransformConte
 
 export function getKeyDirectiveRuntimeValue(node: ElementNode): string | null {
   const keyDirective = getKeyDirective(node);
-  const rawSource = keyDirective?.exp?.loc.source?.trim();
+  const keyExpression = keyDirective?.exp && (
+    keyDirective.exp.type === NodeTypes.SIMPLE_EXPRESSION
+    || keyDirective.exp.type === NodeTypes.COMPOUND_EXPRESSION
+  )
+    ? keyDirective.exp as SimpleExpressionNode | CompoundExpressionNode
+    : null;
+  const rawSource = keyExpression?.loc.source?.trim();
   if (rawSource) {
-    const templateLiteral = tryUnwrapTemplateLiteralExpressionSource(rawSource);
+    const templateLiteral = tryUnwrapTemplateLiteralExpressionSource(keyExpression);
     return templateLiteral ? templateLiteral.template : `\${${rawSource}}`;
   }
 
-  if (keyDirective?.exp) {
-    const value = stringifyExpression(keyDirective.exp).trim();
+  if (keyExpression) {
+    const value = stringifyExpression(keyExpression).trim();
     if (value) {
-      const templateLiteral = tryUnwrapTemplateLiteralExpressionSource(value);
+      const templateLiteral = tryUnwrapTemplateLiteralExpressionSource(keyExpression);
       return templateLiteral ? templateLiteral.template : `\${${value}}`;
     }
   }
@@ -2364,7 +2408,8 @@ export function tryGetExistingElementDataTestId(node: ElementNode, attributeName
 }
 
 function isTemplatePlaceholder(part: string) {
-  const templateLiteral = tryParseTemplateFragment(part);
+  const parsedTemplate = tryParseTemplateFragment(part);
+  const templateLiteral = parsedTemplate?.templateLiteral;
   return !!templateLiteral
     && templateLiteral.expressions.length === 1
     && templateLiteral.quasis.length === 2

--- a/utils.ts
+++ b/utils.ts
@@ -2537,8 +2537,9 @@ function safeMethodNameFromParts(parts: string[]) {
 /**
  * Replaces any `${...}` interpolation in a template string with the stable placeholder `${key}`.
  *
- * IMPORTANT: This function does NOT attempt to parse the template expression(s). It is a
- * best-effort scanner that preserves literal text and normalizes interpolation slots.
+ * This is only for the generated POM selector shape. Runtime/test-id generation keeps the real
+ * interpolation expressions; the POM layer just needs to know that a keyed slot exists and where
+ * it sits relative to the surrounding literal text.
  */
 function replaceAllTemplateExpressionsWithKey(templateValue: Extract<AttributeValue, { kind: "template" }>): string {
   const { templateLiteral } = templateValue.parsedTemplate;

--- a/utils.ts
+++ b/utils.ts
@@ -53,6 +53,7 @@ import {
   isTemplateLiteral,
 } from "@babel/types";
 import { parse, parseExpression } from "@babel/parser";
+import type { PomPatternKind } from "./pom-patterns";
 import { createTypeScriptWriter } from "./typescript-codegen";
 
 export { isSimpleExpressionNode } from "./compiler/ast-guards";
@@ -2849,12 +2850,13 @@ export function applyResolvedDataTestId(args: {
   // It can be provided via entryOverrides (e.g. router-link :to resolution).
   const targetPageObjectModelClass = entryOverrides.targetPageObjectModelClass;
 
-  // Keyed-ness is represented in the selector pattern, not derived by parsing the test id.
+  // Parameterized selectors are represented explicitly in the POM spec instead of being re-inferred
+  // later from the formatted `${key}` placeholder convention.
   const formattedDataTestIdForPom = dataTestId.kind === "template"
     ? toPomKeyPattern(dataTestId)
     : dataTestId.value;
-
-  const isKeyed = formattedDataTestIdForPom.includes("${key}");
+  const selectorPatternKind: PomPatternKind = dataTestId.kind === "template" ? "parameterized" : "static";
+  const selectorIsParameterized = selectorPatternKind === "parameterized";
 
   const deriveBaseMethodNameFromHint = (hint: string | undefined) => {
     const hintRaw = (hint ?? "").trim();
@@ -2919,8 +2921,8 @@ export function applyResolvedDataTestId(args: {
     const roleSuffix = upperFirst(normalizedRole || "Element");
     const baseName = upperFirst(primaryMethodName);
     const propertyName = hasRoleSuffix(baseName, roleSuffix) ? baseName : `${baseName}${roleSuffix}`;
-    // Keep behavior aligned with TS emitter: keyed getters expose `Foo[key]` by removing `ByKey`.
-    return isKeyed ? removeByKeySegment(propertyName) : propertyName;
+    // Keep behavior aligned with TS emitter: parameterized getters expose `Foo[key]` by removing `ByKey`.
+    return selectorIsParameterized ? removeByKeySegment(propertyName) : propertyName;
   };
 
   const getPrimaryGetterNameCandidates = (primaryMethodName: string): { primary: string; alternate?: string } => {
@@ -2928,7 +2930,7 @@ export function applyResolvedDataTestId(args: {
     const baseName = upperFirst(primaryMethodName);
     const propertyName = hasRoleSuffix(baseName, roleSuffix) ? baseName : `${baseName}${roleSuffix}`;
 
-    if (!isKeyed) {
+    if (!selectorIsParameterized) {
       return { primary: propertyName };
     }
 
@@ -3014,10 +3016,10 @@ export function applyResolvedDataTestId(args: {
     ];
     const sharesSelectorIdentity = existingSelectors.includes(formattedDataTestIdForPom);
 
-    // Keyed selectors are only safe to merge when both entries already resolve to the exact
-    // same keyed selector pattern. Distinct keyed lists should still force authors to
+    // Parameterized selectors are only safe to merge when both entries already resolve to the exact
+    // same selector pattern. Distinct dynamic lists should still force authors to
     // disambiguate their semantic hints instead of collapsing to one API.
-    if (isKeyed && !sharesSelectorIdentity) {
+    if (selectorIsParameterized && !sharesSelectorIdentity) {
       return false;
     }
 
@@ -3046,6 +3048,13 @@ export function applyResolvedDataTestId(args: {
       }
     }
 
+    if (selectorIsParameterized) {
+      existingPom.selectorPatternKind = "parameterized";
+      if (!Object.prototype.hasOwnProperty.call(existingPom.params, "key")) {
+        existingPom.params.key = keyTypeFromValues;
+      }
+    }
+
     return true;
   };
 
@@ -3062,9 +3071,9 @@ export function applyResolvedDataTestId(args: {
 
     while (true) {
       const baseWithSuffix = suffix === 1 ? base : `${base}${suffix}`;
-      // Keep the ByKey segment at the end so downstream logic (and keyed getter naming)
+      // Keep the ByKey segment at the end so downstream logic (and parameterized getter naming)
       // can reliably strip it when needed.
-      const candidate = isKeyed ? `${baseWithSuffix}ByKey` : baseWithSuffix;
+      const candidate = selectorIsParameterized ? `${baseWithSuffix}ByKey` : baseWithSuffix;
 
       const actionName = getPrimaryActionMethodName(candidate);
 
@@ -3078,8 +3087,8 @@ export function applyResolvedDataTestId(args: {
 
       let conflicts = hasConflicts(chosenGetterName);
 
-      // Edge-case: keyed getter name (FooButton[key]) can collide with a non-keyed FooButton.
-      // When that happens, keep the ByKey segment on the keyed getter name.
+      // Edge-case: parameterized getter name (FooButton[key]) can collide with a non-parameterized
+      // FooButton. When that happens, keep the ByKey segment on the parameterized getter name.
       if (conflicts && getterCandidates.alternate) {
         const alt = getterCandidates.alternate;
         const altConflicts = hasConflicts(alt);
@@ -3112,7 +3121,7 @@ export function applyResolvedDataTestId(args: {
         // Only try role-suffixing when the base name isn't already role-suffixed.
         if (!hasRoleSuffix(baseNameUpper, roleSuffix)) {
           const baseWithRoleSuffix = `${baseWithSuffix}${roleSuffix}`;
-          const candidateWithRoleSuffix = isKeyed ? `${baseWithRoleSuffix}ByKey` : baseWithRoleSuffix;
+          const candidateWithRoleSuffix = selectorIsParameterized ? `${baseWithRoleSuffix}ByKey` : baseWithRoleSuffix;
           const actionNameWithRoleSuffix = getPrimaryActionMethodName(candidateWithRoleSuffix);
 
           const getterCandidatesWithRoleSuffix = getPrimaryGetterNameCandidates(candidateWithRoleSuffix);
@@ -3125,7 +3134,7 @@ export function applyResolvedDataTestId(args: {
 
           let conflictsWithRoleSuffix = hasConflictsWithRoleSuffix(chosenGetterNameWithRoleSuffix);
 
-          // Preserve keyed edge-case behavior: allow keeping ByKey segment on the getter.
+          // Preserve the parameterized edge-case behavior: allow keeping ByKey on the getter.
           if (conflictsWithRoleSuffix && getterCandidatesWithRoleSuffix.alternate) {
             const alt = getterCandidatesWithRoleSuffix.alternate;
             const altConflicts = hasConflictsWithRoleSuffix(alt);
@@ -3203,7 +3212,7 @@ export function applyResolvedDataTestId(args: {
   }
 
   const params: Record<string, string> = {};
-  if (isKeyed) {
+  if (selectorIsParameterized) {
     params.key = keyTypeFromValues;
   }
 
@@ -3211,21 +3220,21 @@ export function applyResolvedDataTestId(args: {
     case "input":
       params.text = "string";
       params.annotationText = "string = \"\"";
-      if (!isKeyed) delete params.key;
+      if (!selectorIsParameterized) delete params.key;
       break;
     case "select":
       params.value = "string";
       params.annotationText = "string = \"\"";
-      if (!isKeyed) delete params.key;
+      if (!selectorIsParameterized) delete params.key;
       break;
     case "vselect":
       params.value = "string";
       params.timeOut = "number = 500";
       params.annotationText = "string = \"\"";
-      if (!isKeyed) delete params.key;
+      if (!selectorIsParameterized) delete params.key;
       break;
     case "radio":
-      // radio can be keyed (e.g. `${key}` option ids) or not.
+      // radio selectors can be parameterized (for dynamic option ids) or static.
       params.annotationText = "string = \"\"";
       break;
     default:
@@ -3256,6 +3265,7 @@ export function applyResolvedDataTestId(args: {
     nativeRole: normalizedRole,
     methodName,
     getterNameOverride,
+    selectorPatternKind,
     formattedDataTestId: formattedDataTestIdForPom,
     alternateFormattedDataTestIds: undefined,
     mergeKey: args.pomMergeKey,
@@ -3347,6 +3357,7 @@ export function applyResolvedDataTestId(args: {
       role: pom.nativeRole,
       methodName: pom.methodName,
       getterNameOverride: pom.getterNameOverride ?? null,
+      selectorPatternKind: pom.selectorPatternKind,
       formattedDataTestId: pom.formattedDataTestId,
       alternateFormattedDataTestIds: alternates.length ? alternates : undefined,
       params: stableParams,
@@ -3551,7 +3562,9 @@ export function applyResolvedDataTestId(args: {
           selector: {
             kind: "withinTestIdByLabel",
             rootFormattedDataTestId: wrapperTestId,
+            rootPatternKind: selectorPatternKind,
             formattedLabel: label,
+            labelPatternKind: "static",
             exact: true,
           },
           params: { annotationText: `string = ""` },
@@ -3581,7 +3594,9 @@ export function applyResolvedDataTestId(args: {
       selector: {
         kind: "withinTestIdByLabel",
         rootFormattedDataTestId: wrapperTestId,
+        rootPatternKind: selectorPatternKind,
         formattedLabel: "${value}",
+        labelPatternKind: "parameterized",
         exact: true,
       },
       params: { value: "string", annotationText: `string = ""` },
@@ -3601,8 +3616,7 @@ export function applyResolvedDataTestId(args: {
   // This keeps the POM ergonomic and avoids pushing key plumbing into tests.
   const staticKeyValues = (args.keyValuesOverride ?? null);
   const needsKey = Object.prototype.hasOwnProperty.call(params, "key")
-    && typeof formattedDataTestIdForPom === "string"
-    && formattedDataTestIdForPom.includes("${key}");
+    && selectorIsParameterized;
   const isNavigation = !!dataTestIdEntry.targetPageObjectModelClass;
 
   if (
@@ -3636,6 +3650,7 @@ export function applyResolvedDataTestId(args: {
         selector: {
           kind: "testId",
           formattedDataTestId: formattedDataTestIdForPom,
+          patternKind: selectorPatternKind,
         },
         keyLiteral: rawValue,
         params: { wait: "boolean = true" },
@@ -3689,7 +3704,7 @@ export interface IDataTestId {
 /**
  * Structured representation of a generated element for POM emission.
  *
- * - `formattedDataTestId` may contain the placeholder `${key}` when keyed.
+ * - `selectorPatternKind` tells emitters whether this selector is static or parameterized.
  * - `params` is TypeScript-flavored today because TS is our reference emitter;
  *   C# emission maps these params to C# types.
  */
@@ -3699,7 +3714,9 @@ export interface PomPrimarySpec {
   methodName: string;
   /** Optional override for the generated locator getter name (used for edge-case collision avoidance). */
   getterNameOverride?: string;
-  /** Test id pattern used by generated POM methods (may include `${key}` placeholder). */
+  /** Whether the selector is a plain test id or a parameterized `${key}` template pattern. */
+  selectorPatternKind: PomPatternKind;
+  /** Test id pattern used by generated POM methods. Parameterized patterns still render with `${key}`. */
   formattedDataTestId: string;
   /** Additional test id patterns that should be treated as equivalent to formattedDataTestId (merge-by-action). */
   alternateFormattedDataTestIds?: string[];
@@ -3718,14 +3735,17 @@ export interface PomPrimarySpec {
 export type PomSelectorSpec =
   | {
     kind: "testId";
-    /** Static or keyed test id; keyed uses `${key}` placeholder. */
+    patternKind: PomPatternKind;
+    /** Static or parameterized test id; parameterized patterns render with `${key}`. */
     formattedDataTestId: string;
   }
   | {
     kind: "withinTestIdByLabel";
+    rootPatternKind: PomPatternKind;
     /** Wrapper/root test id to scope the label search under. */
     rootFormattedDataTestId: string;
-    /** Visible label text; may include `${value}` placeholder for dynamic methods. */
+    labelPatternKind: PomPatternKind;
+    /** Visible label text; parameterized labels may contain `${value}`. */
     formattedLabel: string;
     exact?: boolean;
   };

--- a/utils.ts
+++ b/utils.ts
@@ -115,7 +115,7 @@ export interface NativeWrappersMap {
   }
 }
 
-interface ParsedTemplateFragment {
+export interface ParsedTemplateFragment {
   source: string;
   templateLiteral: TemplateLiteral;
 }
@@ -128,7 +128,7 @@ export function staticAttributeValue(value: string): AttributeValue {
   return { kind: "static", value };
 }
 
-export function templateAttributeValue(template: string): AttributeValue {
+export function templateAttributeValue(template: string): Extract<AttributeValue, { kind: "template" }> {
   const parsedTemplate = tryParseTemplateFragment(template);
   if (!parsedTemplate) {
     throw new Error(`[vue-pom-generator] Failed to parse generated template fragment: ${template}`);
@@ -638,6 +638,55 @@ function tryParseTemplateFragment(fragment: string): ParsedTemplateFragment | nu
   catch {
     return null;
   }
+}
+
+function getTemplateExpressionSource(parsedTemplate: ParsedTemplateFragment, index: number): string | null {
+  const expression = parsedTemplate.templateLiteral.expressions[index];
+  if (!expression) {
+    return null;
+  }
+
+  const start = typeof expression.start === "number" ? expression.start : null;
+  const end = typeof expression.end === "number" ? expression.end : null;
+  if (start === null || end === null) {
+    return null;
+  }
+
+  return parsedTemplate.source.slice(start, end);
+}
+
+function getSingleExpressionTemplateFragment(parsedTemplate: ParsedTemplateFragment): {
+  prefix: string;
+  expressionSource: string;
+  suffix: string;
+} | null {
+  const { templateLiteral } = parsedTemplate;
+  if (templateLiteral.expressions.length !== 1 || templateLiteral.quasis.length !== 2) {
+    return null;
+  }
+
+  const expressionSource = getTemplateExpressionSource(parsedTemplate, 0);
+  if (expressionSource === null) {
+    return null;
+  }
+
+  return {
+    prefix: templateLiteral.quasis[0]?.value.raw ?? "",
+    expressionSource,
+    suffix: templateLiteral.quasis[1]?.value.raw ?? "",
+  };
+}
+
+function templateFragmentContainsSingleExpression(container: ParsedTemplateFragment, candidate: ParsedTemplateFragment): boolean {
+  const containerFragment = getSingleExpressionTemplateFragment(container);
+  const candidateFragment = getSingleExpressionTemplateFragment(candidate);
+  if (!containerFragment || !candidateFragment) {
+    return false;
+  }
+
+  return containerFragment.expressionSource === candidateFragment.expressionSource
+    && containerFragment.prefix.endsWith(candidateFragment.prefix)
+    && containerFragment.suffix.startsWith(candidateFragment.suffix);
 }
 
 /**
@@ -2285,6 +2334,8 @@ export interface ExistingElementDataTestIdInfo {
 
   /** When the binding can be preserved as a one-slot template, the unwrapped template text (without backticks). */
   template?: string;
+  /** Parsed template metadata for preserve-safe template ids. */
+  parsedTemplate?: ParsedTemplateFragment;
   /** Number of interpolations in the template literal, if known. */
   templateExpressionCount?: number;
   /** For non-template dynamic bindings, the raw expression string (identifier/call/etc). */
@@ -2341,11 +2392,13 @@ export function tryGetExistingElementDataTestId(node: ElementNode, attributeName
       return { value: unwrappedTemplateLiteral.template, isDynamic: false, isStaticLiteral: true };
     }
 
+    const templateValue = templateAttributeValue(unwrappedTemplateLiteral.template);
     return {
-      value: unwrappedTemplateLiteral.template,
+      value: templateValue.template,
       isDynamic: true,
       isStaticLiteral: false,
-      template: unwrappedTemplateLiteral.template,
+      template: templateValue.template,
+      parsedTemplate: templateValue.parsedTemplate,
       templateExpressionCount: unwrappedTemplateLiteral.expressionCount,
     };
   }
@@ -2362,11 +2415,13 @@ export function tryGetExistingElementDataTestId(node: ElementNode, attributeName
 
   const preservableReference = tryGetPreservableDynamicReferenceExpression(ast as BabelNode | null | false | undefined);
   if (preservableReference) {
+    const templateValue = templateAttributeValue(`\${${preservableReference}}`);
     return {
       value: preservableReference,
       isDynamic: true,
       isStaticLiteral: false,
-      template: `\${${preservableReference}}`,
+      template: templateValue.template,
+      parsedTemplate: templateValue.parsedTemplate,
       templateExpressionCount: 1,
       rawExpression: preservableReference,
     };
@@ -2394,11 +2449,13 @@ export function tryGetExistingElementDataTestId(node: ElementNode, attributeName
 
   const fallbackPreservableReference = tryGetPreservableDynamicReferenceExpression(fallbackAst);
   if (fallbackPreservableReference) {
+    const templateValue = templateAttributeValue(`\${${fallbackPreservableReference}}`);
     return {
       value: fallbackPreservableReference,
       isDynamic: true,
       isStaticLiteral: false,
-      template: `\${${fallbackPreservableReference}}`,
+      template: templateValue.template,
+      parsedTemplate: templateValue.parsedTemplate,
       templateExpressionCount: 1,
       rawExpression: fallbackPreservableReference,
     };
@@ -2409,12 +2466,8 @@ export function tryGetExistingElementDataTestId(node: ElementNode, attributeName
 
 function isTemplatePlaceholder(part: string) {
   const parsedTemplate = tryParseTemplateFragment(part);
-  const templateLiteral = parsedTemplate?.templateLiteral;
-  return !!templateLiteral
-    && templateLiteral.expressions.length === 1
-    && templateLiteral.quasis.length === 2
-    && (templateLiteral.quasis[0]?.value.raw ?? "") === ""
-    && (templateLiteral.quasis[1]?.value.raw ?? "") === "";
+  const templateFragment = parsedTemplate ? getSingleExpressionTemplateFragment(parsedTemplate) : null;
+  return !!templateFragment && templateFragment.prefix === "" && templateFragment.suffix === "";
 }
 
 function isAllCapsOrDigits(value: string): boolean {
@@ -2487,35 +2540,14 @@ function safeMethodNameFromParts(parts: string[]) {
  * IMPORTANT: This function does NOT attempt to parse the template expression(s). It is a
  * best-effort scanner that preserves literal text and normalizes interpolation slots.
  */
-function replaceAllTemplateExpressionsWithKey(template: string): string {
+function replaceAllTemplateExpressionsWithKey(templateValue: Extract<AttributeValue, { kind: "template" }>): string {
+  const { templateLiteral } = templateValue.parsedTemplate;
   let out = "";
-  let i = 0;
-  while (i < template.length) {
-    const start = template.indexOf("${", i);
-    if (start < 0) {
-      out += template.slice(i);
-      break;
+  for (let i = 0; i < templateLiteral.quasis.length; i += 1) {
+    out += templateLiteral.quasis[i]?.value.raw ?? "";
+    if (templateLiteral.expressions[i]) {
+      out += "${key}";
     }
-    out += template.slice(i, start);
-    // Find the closing brace, accounting for nested braces within the interpolation.
-    let depth = 1;
-    let j = start + 2;
-    while (j < template.length && depth > 0) {
-      if (template[j] === "{") {
-        depth++;
-      } else if (template[j] === "}") {
-        depth--;
-      }
-      j++;
-    }
-    const end = depth === 0 ? j - 1 : -1;
-    if (end < 0) {
-      // Malformed; append rest and stop.
-      out += template.slice(start);
-      break;
-    }
-    out += "${key}";
-    i = end + 1;
   }
   return out;
 }
@@ -2646,9 +2678,13 @@ export function applyResolvedDataTestId(args: {
 
       if (existing.isDynamic) {
         if (existing.template) {
-          const existingTemplate = existing.template;
+          const existingTemplateValue = existing.parsedTemplate
+            ? { kind: "template", template: existing.template, parsedTemplate: existing.parsedTemplate } as const
+            : templateAttributeValue(existing.template);
+          const existingTemplateFragment = getSingleExpressionTemplateFragment(existingTemplateValue.parsedTemplate);
+          const requiredKeyTemplateValue = bestKeyPreservePlaceholder ? templateAttributeValue(bestKeyPreservePlaceholder) : null;
 
-          if ((existing.templateExpressionCount ?? 0) !== 1) {
+          if ((existing.templateExpressionCount ?? 0) !== 1 || !existingTemplateFragment) {
             throw new Error(
               `[vue-pom-generator] Existing ${attrLabel} is a template literal with multiple interpolations and cannot be preserved safely.\n`
               + `Component: ${args.componentName}\n`
@@ -2658,9 +2694,11 @@ export function applyResolvedDataTestId(args: {
             );
           }
 
-          const hasExact = bestKeyPreservePlaceholder && existingTemplate.includes(bestKeyPreservePlaceholder);
+          const hasExact = requiredKeyTemplateValue
+            ? templateFragmentContainsSingleExpression(existingTemplateValue.parsedTemplate, requiredKeyTemplateValue.parsedTemplate)
+            : false;
           const hasVarAccess = getBestKeyAccessCandidates(args.bestKeyVariable)
-            .some(candidate => existingTemplate.includes(candidate));
+            .some(candidate => existingTemplateFragment.expressionSource === candidate);
 
           if (!hasExact && !hasVarAccess && bestKeyPreservePlaceholder) {
             throw new Error(
@@ -2673,8 +2711,8 @@ export function applyResolvedDataTestId(args: {
             );
           }
 
-          dataTestId = templateAttributeValue(existing.template);
-          runtimeDataTestId = templateAttributeValue(existing.template);
+          dataTestId = existingTemplateValue;
+          runtimeDataTestId = existingTemplateValue;
           fromExisting = true;
         }
         else {
@@ -2748,7 +2786,7 @@ export function applyResolvedDataTestId(args: {
 
   // Keyed-ness is represented in the selector pattern, not derived by parsing the test id.
   const formattedDataTestIdForPom = dataTestId.kind === "template"
-    ? replaceAllTemplateExpressionsWithKey(dataTestId.template)
+    ? replaceAllTemplateExpressionsWithKey(dataTestId)
     : dataTestId.value;
 
   const isKeyed = formattedDataTestIdForPom.includes("${key}");

--- a/utils.ts
+++ b/utils.ts
@@ -69,11 +69,13 @@ import { createTypeScriptWriter } from "./typescript-codegen";
 export { isSimpleExpressionNode } from "./compiler/ast-guards";
 export type { RouterIntrospectionResult } from "./router-introspection";
 export {
+  analyzeToDirectiveTarget,
   getRouteNameKeyFromToDirective,
   setResolveToComponentNameFn,
   setRouteNameToComponentNameMap,
   tryResolveToDirectiveTargetComponentName,
 } from "./routing/to-directive";
+export type { RouteDirectiveTargetAnalysis } from "./routing/to-directive";
 
 function getDataTestIdFromGroupOption(text: string) {
   // eslint-disable-next-line no-restricted-syntax
@@ -2467,7 +2469,10 @@ export function tryGetExistingElementDataTestId(node: ElementNode, attributeName
   }
 
   const simpleExp = exp as SimpleExpressionNode;
-  const ast = simpleExp.ast;
+  const ast = tryGetVueExpressionAst(simpleExp, {
+    preferredViews: ["content", "loc", "compiled"],
+    plugins: ["typescript"],
+  });
 
   const unwrappedTemplateLiteral = tryUnwrapTemplateLiteralExpressionSource(simpleExp);
   if (unwrappedTemplateLiteral) {
@@ -2514,28 +2519,6 @@ export function tryGetExistingElementDataTestId(node: ElementNode, attributeName
   const raw = (simpleExp.content ?? "").trim();
   if (!raw) {
     return null;
-  }
-
-  const fallbackAst = (ast as BabelNode | null | false | undefined)
-    ?? tryGetVueExpressionAst(simpleExp, { preferredViews: ["content", "loc", "compiled"], plugins: ["typescript"] });
-
-  if (fallbackAst && typeof fallbackAst === "object" && "type" in fallbackAst && (fallbackAst as { type: string }).type === "StringLiteral") {
-    const sl = fallbackAst as { value?: string };
-    return { value: sl.value ?? "", isDynamic: false, isStaticLiteral: true };
-  }
-
-  const fallbackPreservableReference = tryGetPreservableDynamicReferenceExpression(fallbackAst);
-  if (fallbackPreservableReference) {
-    const templateValue = templateAttributeValue(`\${${fallbackPreservableReference}}`);
-    return {
-      value: fallbackPreservableReference,
-      isDynamic: true,
-      isStaticLiteral: false,
-      template: templateValue.template,
-      parsedTemplate: templateValue.parsedTemplate,
-      templateExpressionCount: 1,
-      rawExpression: fallbackPreservableReference,
-    };
   }
 
   return { value: raw, isDynamic: true, isStaticLiteral: false, rawExpression: raw };
@@ -2688,17 +2671,17 @@ export function applyResolvedDataTestId(args: {
   /**
    * How to handle an author-provided existing test id attribute when we encounter one.
    *
-   * - "preserve": keep the existing value (default)
+   * - "error": throw to force cleanup/migration (default)
+   * - "preserve": keep the existing value
    * - "overwrite": replace it with the generated value
-   * - "error": throw to force cleanup/migration
    */
   existingIdBehavior?: "preserve" | "overwrite" | "error";
 
   /**
    * Controls what happens when the generator would emit duplicate POM member names within the same class.
-   * - "error": throw and fail compilation
+   * - "error": throw and fail compilation (default)
    * - "warn": warn and append a suffix
-   * - "suffix": append a suffix silently (default)
+   * - "suffix": append a suffix silently
    */
   nameCollisionBehavior?: "error" | "warn" | "suffix";
 
@@ -2708,8 +2691,8 @@ export function applyResolvedDataTestId(args: {
   const addHtmlAttribute = args.addHtmlAttribute ?? true;
   const entryOverrides = args.entryOverrides ?? {};
   const testIdAttribute = args.testIdAttribute ?? "data-testid";
-  const existingIdBehavior = args.existingIdBehavior ?? "preserve";
-  const nameCollisionBehavior = args.nameCollisionBehavior ?? "suffix";
+  const existingIdBehavior = args.existingIdBehavior ?? "error";
+  const nameCollisionBehavior = args.nameCollisionBehavior ?? "error";
   const warn = args.warn;
 
   const getBestKeyAccessCandidates = (expr: string | null | undefined) => {

--- a/utils.ts
+++ b/utils.ts
@@ -57,8 +57,10 @@ import { createPomStringPattern, pomStringPatternEquals, type PomPatternKind, ty
 import {
   createPomMethodSignature,
   createPomParameterSpec,
-  normalizePomParameters,
+  hasPomParameter,
   pomMethodSignatureEquals,
+  removePomParameter,
+  setPomParameter,
   type PomMethodSignature,
   type PomParameterSpec,
 } from "./pom-params";
@@ -3217,42 +3219,35 @@ export function applyResolvedDataTestId(args: {
     );
   }
 
-  const params: Record<string, string> = {};
-  if (selectorIsParameterized) {
-    params.key = keyTypeFromValues;
-  }
+  let parameters: PomParameterSpec[] = selectorIsParameterized
+    ? [createPomParameterSpec("key", keyTypeFromValues)]
+    : [];
 
   switch (normalizedRole) {
     case "input":
-      params.text = "string";
-      params.annotationText = "string = \"\"";
-      if (!selectorIsParameterized) delete params.key;
+      parameters = setPomParameter(parameters, "text", "string");
+      parameters = setPomParameter(parameters, "annotationText", "string = \"\"");
       break;
     case "select":
-      params.value = "string";
-      params.annotationText = "string = \"\"";
-      if (!selectorIsParameterized) delete params.key;
+      parameters = setPomParameter(parameters, "value", "string");
+      parameters = setPomParameter(parameters, "annotationText", "string = \"\"");
       break;
     case "vselect":
-      params.value = "string";
-      params.timeOut = "number = 500";
-      params.annotationText = "string = \"\"";
-      if (!selectorIsParameterized) delete params.key;
+      parameters = setPomParameter(parameters, "value", "string");
+      parameters = setPomParameter(parameters, "timeOut", "number = 500");
+      parameters = setPomParameter(parameters, "annotationText", "string = \"\"");
       break;
     case "radio":
       // radio selectors can be parameterized (for dynamic option ids) or static.
-      params.annotationText = "string = \"\"";
+      parameters = setPomParameter(parameters, "annotationText", "string = \"\"");
       break;
     default:
       break;
   }
 
-  // If the caller provided enumerable key values (e.g. derived from a static v-for list),
-  // propagate a literal-union type into the underlying keyed locator method signature.
-  if (keyTypeFromValues !== "string" && Object.prototype.hasOwnProperty.call(params, "key")) {
-    params.key = keyTypeFromValues;
-  }
-  const normalizedParameters = normalizePomParameters(params);
+  const normalizedParameters = selectorIsParameterized
+    ? setPomParameter(parameters, "key", keyTypeFromValues)
+    : removePomParameter(parameters, "key");
 
   // 3) Apply attribute (only when we generated it) and register for POM generation.
   if (addHtmlAttribute && !fromExisting) {
@@ -3316,41 +3311,7 @@ export function applyResolvedDataTestId(args: {
   };
 
   const getSignatureForGeneratedMethod = () => {
-    const role = normalizedRole;
-    const isNavigation = !!dataTestIdEntry.targetPageObjectModelClass;
-    const needsKey = Object.prototype.hasOwnProperty.call(params, "key");
-    const keyType = keyTypeFromValues;
-
-    if (isNavigation) {
-      if (needsKey) {
-        return createPomMethodSignature({ key: keyType });
-      }
-      return createPomMethodSignature([]);
-    }
-
-    switch (role) {
-      case "input":
-        return needsKey
-          ? createPomMethodSignature({ key: keyType, text: "string", annotationText: "string = \"\"" })
-          : createPomMethodSignature({ text: "string", annotationText: "string = \"\"" });
-      case "select":
-        return needsKey
-          ? createPomMethodSignature({ key: keyType, value: "string", annotationText: "string = \"\"" })
-          : createPomMethodSignature({ value: "string", annotationText: "string = \"\"" });
-      case "vselect":
-        return needsKey
-          ? createPomMethodSignature({ key: keyType, value: "string", timeOut: "number = 500" })
-          : createPomMethodSignature({ value: "string", timeOut: "number = 500" });
-      case "radio":
-        return needsKey
-          ? createPomMethodSignature({ key: keyType, annotationText: "string = \"\"" })
-          : createPomMethodSignature({ annotationText: "string = \"\"" });
-      default:
-        if (needsKey) {
-          return createPomMethodSignature({ key: keyType });
-        }
-        return createPomMethodSignature([]);
-    }
+    return createPomMethodSignature(normalizedParameters);
   };
 
   const registerPrimaryOnce = (pom: PomPrimarySpec) => {
@@ -3567,11 +3528,11 @@ export function applyResolvedDataTestId(args: {
             label: createPomStringPattern(label, "static"),
             exact: true,
           },
-          parameters: normalizePomParameters({ annotationText: `string = ""` }),
+          parameters: [createPomParameterSpec("annotationText", `string = ""`)],
         });
 
         if (added) {
-          registerGeneratedMethodSignature(generatedName, createPomMethodSignature({ annotationText: `string = ""` }));
+          registerGeneratedMethodSignature(generatedName, createPomMethodSignature([createPomParameterSpec("annotationText", `string = ""`)]));
         }
       }
 
@@ -3597,11 +3558,17 @@ export function applyResolvedDataTestId(args: {
         label: createPomStringPattern("${value}", "parameterized"),
         exact: true,
       },
-      parameters: normalizePomParameters({ value: "string", annotationText: `string = ""` }),
+      parameters: [
+        createPomParameterSpec("value", "string"),
+        createPomParameterSpec("annotationText", `string = ""`),
+      ],
     });
 
     if (added) {
-      registerGeneratedMethodSignature(generatedName, createPomMethodSignature({ value: "string", annotationText: `string = ""` }));
+      registerGeneratedMethodSignature(generatedName, createPomMethodSignature([
+        createPomParameterSpec("value", "string"),
+        createPomParameterSpec("annotationText", `string = ""`),
+      ]));
     }
     return { selectorValue: dataTestId, runtimeValue: runtimeDataTestId, fromExisting };
   }
@@ -3613,7 +3580,7 @@ export function applyResolvedDataTestId(args: {
   //
   // This keeps the POM ergonomic and avoids pushing key plumbing into tests.
   const staticKeyValues = (args.keyValuesOverride ?? null);
-  const needsKey = Object.prototype.hasOwnProperty.call(params, "key")
+  const needsKey = hasPomParameter(normalizedParameters, "key")
     && selectorIsParameterized;
   const isNavigation = !!dataTestIdEntry.targetPageObjectModelClass;
 
@@ -3650,11 +3617,11 @@ export function applyResolvedDataTestId(args: {
           testId: selectorPattern,
         },
         keyLiteral: rawValue,
-        parameters: normalizePomParameters({ wait: "boolean = true" }),
+        parameters: [createPomParameterSpec("wait", "boolean = true")],
       });
 
       if (added) {
-        registerGeneratedMethodSignature(generatedName, createPomMethodSignature({ wait: "boolean = true" }));
+        registerGeneratedMethodSignature(generatedName, createPomMethodSignature([createPomParameterSpec("wait", "boolean = true")]));
       }
     }
 

--- a/utils.ts
+++ b/utils.ts
@@ -537,19 +537,46 @@ function getKeyDirective(node: ElementNode): DirectiveNode | null {
  */
 export function getKeyDirectiveValue(node: ElementNode, _context: TransformContext | null = null): string | null {
   const keyDirective = getKeyDirective(node);
+  if (keyDirective?.exp) {
+    const value = stringifyExpression(keyDirective.exp).trim();
+    if (value) {
+      // Inline template-literal keys directly into the generated data-testid template so the
+      // resulting expression uses the compiler-prefixed component scope (`_ctx.*`) while still
+      // preserving local v-for / slot bindings without nesting an extra template literal.
+      if (value.startsWith("`") && value.endsWith("`")) {
+        return value.slice(1, -1);
+      }
+
+      return `\${${value}}`;
+    }
+  }
+
   const rawSource = keyDirective?.exp?.loc.source?.trim();
   if (rawSource) {
-    // Preserve author-facing key source instead of compiler-prefixed `_ctx.*` output.
-    // Generated keyed test ids are later embedded into other transformed expressions
-    // (for example, click instrumentation wrappers), and reusing a stringified `_ctx.*`
-    // expression there can produce invalid double-prefixing like `_ctx._ctx.item.id`.
-    return `\${${rawSource}}`;
+    return rawSource.startsWith("`") && rawSource.endsWith("`")
+      ? rawSource.slice(1, -1)
+      : `\${${rawSource}}`;
+  }
+
+  return null;
+}
+
+export function getKeyDirectiveRuntimeValue(node: ElementNode): string | null {
+  const keyDirective = getKeyDirective(node);
+  const rawSource = keyDirective?.exp?.loc.source?.trim();
+  if (rawSource) {
+    return rawSource.startsWith("`") && rawSource.endsWith("`")
+      ? rawSource.slice(1, -1)
+      : `\${${rawSource}}`;
   }
 
   if (keyDirective?.exp) {
-    const value = stringifyExpression(keyDirective.exp);
-    if (value)
-      return `\${${value}}`;
+    const value = stringifyExpression(keyDirective.exp).trim();
+    if (value) {
+      return value.startsWith("`") && value.endsWith("`")
+        ? value.slice(1, -1)
+        : `\${${value}}`;
+    }
   }
 
   return null;
@@ -707,6 +734,24 @@ export function getContainedInVForDirectiveKeyValue(context: TransformContext, n
         // Found the v-for element, now look for :key
         const keyValue = getKeyDirectiveValue(parent as ElementNode);
         return keyValue;
+      }
+    }
+    parent = getParent(hierarchyMap, parent);
+  }
+  return null;
+}
+
+export function getContainedInVForDirectiveKeyRuntimeValue(context: TransformContext, node: ElementNode, hierarchyMap: HierarchyMap): string | null {
+  if (!context.scopes.vFor || context.scopes.vFor === 0) {
+    return null;
+  }
+
+  let parent = getParent(hierarchyMap, node);
+  while (parent) {
+    if (parent.type === NodeTypes.ELEMENT) {
+      const forDirective = findDirectiveByName(parent as ElementNode, "for");
+      if (forDirective) {
+        return getKeyDirectiveRuntimeValue(parent as ElementNode);
       }
     }
     parent = getParent(hierarchyMap, parent);
@@ -2025,6 +2070,12 @@ export interface ExistingElementDataTestIdInfo {
   rawExpression?: string;
 }
 
+export interface ResolvedDataTestIdValues {
+  selectorValue: AttributeValue;
+  runtimeValue: AttributeValue;
+  fromExisting: boolean;
+}
+
 /**
  * Extracts existing data-testid info from an element.
  *
@@ -2301,7 +2352,9 @@ export function applyResolvedDataTestId(args: {
   generatedMethodContentByComponent: Map<string, Set<string>>;
   nativeRole: string;
   preferredGeneratedValue: AttributeValue;
+  preferredRuntimeValue?: AttributeValue;
   bestKeyPlaceholder: string | null;
+  bestKeyPreservePlaceholder?: string | null;
   /** Optional variable name that must be present in a placeholder (e.g. "data" from slot scope). */
   bestKeyVariable?: string | null;
   /** Optional enumerable key values (e.g. derived from v-for="item in ['One','Two']"). */
@@ -2353,7 +2406,7 @@ export function applyResolvedDataTestId(args: {
 
   /** Optional warning sink (typically the shared generator logger). */
   warn?: (message: string) => void;
-}): void {
+}): ResolvedDataTestIdValues {
   const addHtmlAttribute = args.addHtmlAttribute ?? true;
   const entryOverrides = args.entryOverrides ?? {};
   const testIdAttribute = args.testIdAttribute ?? "data-testid";
@@ -2371,7 +2424,9 @@ export function applyResolvedDataTestId(args: {
 
   // 1) Resolve effective data-testid (respecting any existing attribute).
   let dataTestId = args.preferredGeneratedValue;
+  let runtimeDataTestId = args.preferredRuntimeValue ?? args.preferredGeneratedValue;
   let fromExisting = false;
+  const bestKeyPreservePlaceholder = args.bestKeyPreservePlaceholder ?? args.bestKeyPlaceholder;
 
   const existing = tryGetExistingElementDataTestId(args.element, testIdAttribute);
   if (existing) {
@@ -2412,22 +2467,23 @@ export function applyResolvedDataTestId(args: {
             );
           }
 
-          const hasExact = args.bestKeyPlaceholder && existingTemplate.includes(args.bestKeyPlaceholder);
+          const hasExact = bestKeyPreservePlaceholder && existingTemplate.includes(bestKeyPreservePlaceholder);
           const hasVarAccess = getBestKeyAccessCandidates(args.bestKeyVariable)
             .some(candidate => existingTemplate.includes(candidate));
 
-          if (!hasExact && !hasVarAccess && args.bestKeyPlaceholder) {
+          if (!hasExact && !hasVarAccess && bestKeyPreservePlaceholder) {
             throw new Error(
               `[vue-pom-generator] Existing ${attrLabel} appears to be missing the key placeholder needed to keep it unique.\n`
               + `Component: ${args.componentName}\n`
               + `File: ${file}:${locationHint}\n`
               + `Existing ${attrLabel}: ${JSON.stringify(existing.value)}\n`
-              + `Required placeholder: ${JSON.stringify(args.bestKeyPlaceholder)}${args.bestKeyVariable ? ` or an access on "${args.bestKeyVariable}"` : ""}\n\n`
-              + `Fix: either (1) include ${args.bestKeyPlaceholder} in your :${attrLabel} template literal, or (2) remove the explicit ${attrLabel} so it can be auto-generated.`,
+              + `Required placeholder: ${JSON.stringify(bestKeyPreservePlaceholder)}${args.bestKeyVariable ? ` or an access on "${args.bestKeyVariable}"` : ""}\n\n`
+              + `Fix: either (1) include ${bestKeyPreservePlaceholder} in your :${attrLabel} template literal, or (2) remove the explicit ${attrLabel} so it can be auto-generated.`,
             );
           }
 
           dataTestId = templateAttributeValue(existing.template);
+          runtimeDataTestId = templateAttributeValue(existing.template);
           fromExisting = true;
         }
         else {
@@ -2442,18 +2498,19 @@ export function applyResolvedDataTestId(args: {
         }
       }
       else {
-        if (args.bestKeyPlaceholder && existing.isStaticLiteral) {
+        if (bestKeyPreservePlaceholder && existing.isStaticLiteral) {
           throw new Error(
             `[vue-pom-generator] Existing ${attrLabel} appears to be missing the key placeholder needed to keep it unique.\n`
             + `Component: ${args.componentName}\n`
             + `File: ${file}:${locationHint}\n`
             + `Existing ${attrLabel}: ${JSON.stringify(existing.value)}\n`
-            + `Required placeholder: ${JSON.stringify(args.bestKeyPlaceholder)}${args.bestKeyVariable ? ` or an access on "${args.bestKeyVariable}"` : ""}\n\n`
-            + `Fix: either (1) include ${args.bestKeyPlaceholder} in your :${attrLabel} template literal, or (2) remove the explicit ${attrLabel} so it can be auto-generated.`,
+            + `Required placeholder: ${JSON.stringify(bestKeyPreservePlaceholder)}${args.bestKeyVariable ? ` or an access on "${args.bestKeyVariable}"` : ""}\n\n`
+            + `Fix: either (1) include ${bestKeyPreservePlaceholder} in your :${attrLabel} template literal, or (2) remove the explicit ${attrLabel} so it can be auto-generated.`,
           );
         }
 
         dataTestId = staticAttributeValue(existing.value);
+        runtimeDataTestId = staticAttributeValue(existing.value);
         fromExisting = true;
       }
     }
@@ -3230,7 +3287,7 @@ export function applyResolvedDataTestId(args: {
       }
 
       // For statically-known options, we intentionally do NOT generate the generic parameterized method.
-      return;
+      return { selectorValue: dataTestId, runtimeValue: runtimeDataTestId, fromExisting };
     }
 
     // Dynamic options expression: generate a single method that accepts an option label string.
@@ -3257,7 +3314,7 @@ export function applyResolvedDataTestId(args: {
     if (added) {
       registerGeneratedMethodSignature(generatedName, { params: `value: string, annotationText: string = ""`, argNames: ["value", "annotationText"] });
     }
-    return;
+    return { selectorValue: dataTestId, runtimeValue: runtimeDataTestId, fromExisting };
   }
 
   // Special handling for v-for driven by a static literal list.
@@ -3314,7 +3371,7 @@ export function applyResolvedDataTestId(args: {
     }
 
     // For statically-known keys, we intentionally do NOT emit the generic keyed method.
-    return;
+    return { selectorValue: dataTestId, runtimeValue: runtimeDataTestId, fromExisting };
   }
 
   // Default/legacy behavior: emit the primary method+locator for this element.
@@ -3332,6 +3389,8 @@ export function applyResolvedDataTestId(args: {
     const generatedName = getGeneratedMethodName();
     registerGeneratedMethodSignature(generatedName, signature);
   }
+
+  return { selectorValue: dataTestId, runtimeValue: runtimeDataTestId, fromExisting };
 }
 
 export interface IDataTestId {

--- a/utils.ts
+++ b/utils.ts
@@ -53,6 +53,7 @@ import {
   isTemplateLiteral,
 } from "@babel/types";
 import { parse, parseExpression } from "@babel/parser";
+import { createTypeScriptWriter } from "./typescript-codegen";
 
 export { isSimpleExpressionNode } from "./compiler/ast-guards";
 export type { RouterIntrospectionResult } from "./router-introspection";
@@ -557,6 +558,8 @@ function tryParseTemplateFragment(fragment: string): TemplateLiteral | null {
   }
 
   try {
+    // A fragment like `line-${item.id}` is the inside of a template literal, not a standalone
+    // JavaScript expression, so we synthesize the surrounding backticks before parsing.
     const ast = parseExpression(`\`${fragment}\``, { plugins: ["typescript"] }) as BabelNode;
     return isTemplateLiteral(ast) ? ast : null;
   }
@@ -590,15 +593,16 @@ export function toInterpolatedTemplateFragment(fragment: string | null): Interpo
 }
 
 export function renderTemplateLiteralExpressionFromFragment(fragment: string): string {
-  const wrappedSource = `\`${fragment}\``;
+  const templateLiteralSource = `\`${fragment}\``;
   const templateLiteral = tryParseTemplateFragment(fragment);
   if (!templateLiteral) {
-    return wrappedSource;
+    return templateLiteralSource;
   }
 
-  let expression = "`";
+  const writer = createTypeScriptWriter();
+  writer.write("`");
   for (let i = 0; i < templateLiteral.quasis.length; i += 1) {
-    expression += templateLiteral.quasis[i]?.value.raw ?? "";
+    writer.write(templateLiteral.quasis[i]?.value.raw ?? "");
 
     const interpolation = templateLiteral.expressions[i];
     if (!interpolation) {
@@ -608,14 +612,16 @@ export function renderTemplateLiteralExpressionFromFragment(fragment: string): s
     const start = typeof interpolation.start === "number" ? interpolation.start : null;
     const end = typeof interpolation.end === "number" ? interpolation.end : null;
     if (start === null || end === null) {
-      return wrappedSource;
+      return templateLiteralSource;
     }
 
-    expression += `\${${wrappedSource.slice(start, end)}}`;
+    writer.write("${");
+    writer.write(templateLiteralSource.slice(start, end));
+    writer.write("}");
   }
 
-  expression += "`";
-  return expression;
+  writer.write("`");
+  return writer.toString();
 }
 
 /**

--- a/utils.ts
+++ b/utils.ts
@@ -569,6 +569,55 @@ export function hasTemplateInterpolationExpressions(fragment: string): boolean {
   return (tryParseTemplateFragment(fragment)?.expressions.length ?? 0) > 0;
 }
 
+export interface InterpolatedTemplateFragment {
+  template: string;
+  rawExpression: string | null;
+}
+
+export function toInterpolatedTemplateFragment(fragment: string | null): InterpolatedTemplateFragment | null {
+  if (!fragment) {
+    return null;
+  }
+
+  if (hasTemplateInterpolationExpressions(fragment)) {
+    return { template: fragment, rawExpression: null };
+  }
+
+  return {
+    template: `\${${fragment}}`,
+    rawExpression: fragment,
+  };
+}
+
+export function renderTemplateLiteralExpressionFromFragment(fragment: string): string {
+  const wrappedSource = `\`${fragment}\``;
+  const templateLiteral = tryParseTemplateFragment(fragment);
+  if (!templateLiteral) {
+    return wrappedSource;
+  }
+
+  let expression = "`";
+  for (let i = 0; i < templateLiteral.quasis.length; i += 1) {
+    expression += templateLiteral.quasis[i]?.value.raw ?? "";
+
+    const interpolation = templateLiteral.expressions[i];
+    if (!interpolation) {
+      continue;
+    }
+
+    const start = typeof interpolation.start === "number" ? interpolation.start : null;
+    const end = typeof interpolation.end === "number" ? interpolation.end : null;
+    if (start === null || end === null) {
+      return wrappedSource;
+    }
+
+    expression += `\${${wrappedSource.slice(start, end)}}`;
+  }
+
+  expression += "`";
+  return expression;
+}
+
 /**
  * Gets the value placeholder for a :key directive
  *

--- a/utils.ts
+++ b/utils.ts
@@ -592,6 +592,15 @@ function tryUnwrapTemplateLiteralSource(source: string): { template: string; exp
  * attached Babel AST is a single `TemplateLiteral`, so this helper intentionally accepts both
  * simple and compound expression nodes.
  *
+ * Vue also exposes two different string views of the same binding:
+ * - `loc.source` preserves the author-written local scope expression (e.g. `item.id`)
+ * - `stringifyExpression()` emits the compiler-rewritten form (often including `_ctx.*`)
+ *
+ * We still prefer carrying structured AST metadata through the pipeline, but this helper is the
+ * narrow bridge where we normalize those compiler-provided string forms before reparsing a template
+ * fragment later on. That keeps the rest of the codebase from having to care which compiler view
+ * produced the binding in the first place.
+ *
  * @example
  * const exp = findDirectiveByName(node, "bind", "key")?.exp as SimpleExpressionNode | CompoundExpressionNode;
  * tryUnwrapTemplateLiteralExpressionSource(exp)


### PR DESCRIPTION
## Summary
- carry resolved selector/runtime test-id metadata through the transform instead of reading generated `:data-testid` expressions back from the AST
- fix keyed click-wrapper and router-link handling so generated runtime expressions stay in the correct scope
- remove the `injection.clickInstrumentation` opt-out so runtime click instrumentation stays fail-fast and always-on
- add regression coverage for the keyed expression cases that were forcing the downstream workaround

## Validation
- npm test
- npm run typecheck
- npm run build