### PR TITLE
feat: add a generated WebMCP bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,7 +758,7 @@ registration.unregister();
 What it contains:
 
 - an object keyed by component/page object model class name
-- for each component with supported form-like controls or button actions: one or more suggested tools
+- for each component/page: source metadata, `usedComponents` relationship data for route-aware scoping, and zero or more suggested tools
 - for each tool: `toolName`, `toolDescription`, `toolAutoSubmit`, parameter metadata with `toolParamDescription`, and any generated action names that can drive submission or follow-up behavior
 - parameterized selectors also carry `selectorTemplateVariables` so a runtime bridge can resolve test ids such as `foo-${key}-button`
 
@@ -782,6 +782,9 @@ const registration = registerGeneratedWebMcpTools();
 // optional: scope to a subtree or a custom modelContext
 // const registration = registerGeneratedWebMcpTools({ root: document.querySelector("#app")! });
 
+// optional: route-scope the tool surface in a Vue SPA
+// const registration = registerGeneratedWebMcpTools({ router });
+
 // later
 registration.unregister();
 ```
@@ -791,13 +794,16 @@ What it does:
 - imports the browser-safe `@immense/vue-pom-generator/webmcp-runtime` helper for you
 - binds the current generated `webMcpManifest`
 - binds the current configured test-id attribute
+- when given `{ router }`, derives the active route view tree from Vue Router and only registers tools for the matched components plus their generated component dependencies
 - unregisters the generated tools on Vite HMR disposal so dev reloads do not leak duplicate registrations
 
 Current bridge behavior:
 
+- promotes generated POM actions to top-level tools (for example click/goTo/select/type methods become WebMCP tool names)
+- falls back to `set_<component>` tools only for component surfaces that expose writable params but no action
 - fills native text inputs / textareas, checkboxes, radios, and native selects generically
 - attempts a best-effort combobox/select interaction path for `vselect`-style controls
-- auto-clicks a tool's sole action only when the tool has no parameters; otherwise use the generated `submitAction` input to choose an action explicitly
+- resolves DOM targets at call time so SPA rerenders do not leave stale element handles behind
 
 ## ESLint rules that actually ship
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you already use Playwright with `getByTestId`, the point is simple: this pack
 - **Can generate Playwright fixtures** so tests can request `userListPage` instead of constructing `new UserListPage(page)` manually.
 - **Can fail fast on unnameable wrapper-button actions** so complex inline handlers do not silently degrade into low-signal generated APIs.
 - **Can emit a single C# POM file** for Playwright .NET consumers.
-- **Exposes `virtual:testids` and `virtual:pom-manifest`** so your app can inspect collected ids and generated POM metadata at runtime.
+- **Exposes `virtual:testids`, `virtual:pom-manifest`, and `virtual:webmcp-manifest`** so your app can inspect collected ids, generated POM metadata, and WebMCP-oriented tool metadata at runtime.
 - **Ships ESLint rules** to remove legacy manually-authored test ids, ban raw `page` fixture usage in spec callbacks, and discourage raw locator actions on generated getters.
 
 ## What this does not do
@@ -348,7 +348,7 @@ This is important if you are deciding whether the tool will fit into a real code
 
 - **Dev server:** on startup, it scans the configured Vue page/component/layout directories (or the directories resolved from Nuxt config in Nuxt mode), compiles each `.vue` file into a snapshot, writes the configured TypeScript outputs once, then batches add/change/delete events and regenerates incrementally.
 - **Build:** it generates from the richest build pass it sees, which matters because Vite can run multiple passes (for example SSR plus client). The generator avoids letting a thinner pass clobber a richer one.
-- **Always-on virtual modules:** `virtual:testids` and `virtual:pom-manifest` are registered whether generation is enabled or disabled.
+- **Always-on virtual modules:** `virtual:testids`, `virtual:pom-manifest`, and `virtual:webmcp-manifest` are registered whether generation is enabled or disabled.
 - **Generation can be disabled:** `generation: false` still keeps compile-time test-id injection and the virtual modules, but skips emitted POM files.
 
 ## Router-aware navigation: the real semantics
@@ -681,10 +681,11 @@ This package registers a Vite virtual module named `virtual:testids`.
 Usage:
 
 ```ts
-import { pomManifest, testIdManifest } from "virtual:testids";
+import { pomManifest, testIdManifest, webMcpManifest } from "virtual:testids";
 
 console.log(testIdManifest.UserEditorPage);
 console.log(pomManifest.UserEditorPage.entries);
+console.log(webMcpManifest.UserEditorPage.tools);
 ```
 
 What it contains:
@@ -692,6 +693,7 @@ What it contains:
 - an object keyed by component name
 - `testIdManifest`: each value is a sorted array of collected test ids for that component
 - `pomManifest`: richer per-component metadata including source file, generated locator/property names, and generated action names
+- `webMcpManifest`: WebMCP-oriented tool metadata derived from the same semantic graph, including suggested tool names, parameter descriptions, and action names
 - each manifest entry also carries `locatorDescription`, which matches the human-readable label used by generated Playwright locators
 - each manifest entry may also carry `accessibility`, a compile-time review signal with static metadata, accessible-name hints, and `needsReview`
 
@@ -701,6 +703,7 @@ What it is good for:
 - analytics / logging helpers that need the current generated ids
 - debugging what the generator has collected and generated
 - keeping manifest-driven tools aligned with the same locator descriptions shown in Playwright traces
+- bootstrapping WebMCP integration without scraping emitted POM files or walking the DOM at runtime
 
 What it is not:
 
@@ -724,6 +727,30 @@ What it contains:
 - an object keyed by component/page object model class name
 - for each component: source file, whether it is a view or component, sorted test ids, and rich entry metadata
 - for each entry: test id, semantic name, inferred role, generated property name, generated action names, collected compiler metadata when available, and accessibility review metadata when available
+
+## `virtual:webmcp-manifest`
+
+This package also registers `virtual:webmcp-manifest` for consumers that want a tool-oriented manifest aligned with WebMCP's declarative model.
+
+Usage:
+
+```ts
+import { webMcpManifest } from "virtual:webmcp-manifest";
+
+console.log(webMcpManifest.UserEditorPage.tools[0].toolName);
+console.log(webMcpManifest.UserEditorPage.tools[0].params);
+```
+
+What it contains:
+
+- an object keyed by component/page object model class name
+- for each component with form-like controls: one or more suggested tools
+- for each tool: `toolName`, `toolDescription`, parameter metadata with `toolParamDescription`, and any generated action names that can drive submission or follow-up behavior
+
+What it is not:
+
+- automatic DOM annotation with `toolname`, `tooldescription`, or `toolparamdescription`
+- a runtime crawler or a replacement for explicit WebMCP authoring when your UI semantics need manual curation
 
 ## ESLint rules that actually ship
 

--- a/README.md
+++ b/README.md
@@ -741,6 +741,37 @@ console.log(webMcpManifest.UserEditorPage.tools[0].toolName);
 console.log(webMcpManifest.UserEditorPage.tools[0].params);
 ```
 
+Example: bridge the manifest into a WebMCP runtime with `@mcp-b/global`:
+
+```ts
+import "@mcp-b/global";
+import { webMcpManifest } from "virtual:webmcp-manifest";
+
+for (const component of Object.values(webMcpManifest)) {
+  for (const tool of component.tools) {
+    navigator.modelContext.registerTool({
+      name: tool.toolName,
+      description: tool.toolDescription,
+      inputSchema: {
+        type: "object",
+        properties: Object.fromEntries(tool.params.map(param => [
+          param.name,
+          {
+            type: param.role === "checkbox" ? "boolean" : "string",
+            description: param.toolParamDescription,
+          },
+        ])),
+      },
+      async execute(args) {
+        return {
+          content: [{ type: "text", text: JSON.stringify(args) }],
+        };
+      },
+    });
+  }
+}
+```
+
 What it contains:
 
 - an object keyed by component/page object model class name

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you already use Playwright with `getByTestId`, the point is simple: this pack
 - **Can generate Playwright fixtures** so tests can request `userListPage` instead of constructing `new UserListPage(page)` manually.
 - **Can fail fast on unnameable wrapper-button actions** so complex inline handlers do not silently degrade into low-signal generated APIs.
 - **Can emit a single C# POM file** for Playwright .NET consumers.
-- **Exposes `virtual:testids`, `virtual:pom-manifest`, and `virtual:webmcp-manifest`** so your app can inspect collected ids, generated POM metadata, and WebMCP-oriented tool metadata at runtime.
+- **Exposes `virtual:testids`, `virtual:pom-manifest`, `virtual:webmcp-manifest`, and `virtual:webmcp-bridge`** so your app can inspect collected ids, generated POM metadata, consume WebMCP-oriented tool metadata, or opt into a generated WebMCP runtime bridge.
 - **Ships ESLint rules** to remove legacy manually-authored test ids, ban raw `page` fixture usage in spec callbacks, and discourage raw locator actions on generated getters.
 
 ## What this does not do
@@ -26,6 +26,7 @@ If you already use Playwright with `getByTestId`, the point is simple: this pack
 - **It does not fully fill route params for you.** Generated `goTo()` / `goToSelf()` methods use the discovered route template literally. A route like `/users/:id` still needs a real `/users/123` when you actually navigate.
 - **It does not auto-attach every file in `pom/custom`.** Custom helpers are imported, but they only affect generated classes when you explicitly configure attachments, or when they match the built-in `Toggle` / `Checkbox` widget conventions.
 - **It does not make override classes globally replace generated classes.** `pom/overrides` only changes generated fixture instantiation. Direct imports from the generated barrel still give you the generated class unless you import your override yourself.
+- **It does not magically make your app WebMCP-controllable unless you opt into a runtime.** The manifest is metadata; actual tool registration still requires either `virtual:webmcp-bridge` or the browser-safe `@immense/vue-pom-generator/webmcp-runtime` helper plus a `navigator.modelContext` implementation.
 - **The C# emitter is not feature-parity with the TypeScript emitter.** It emits locator/action classes, but not Playwright fixtures, not helper attachments, and not the same route helper surface.
 
 ## A minimal Vue example
@@ -348,7 +349,7 @@ This is important if you are deciding whether the tool will fit into a real code
 
 - **Dev server:** on startup, it scans the configured Vue page/component/layout directories (or the directories resolved from Nuxt config in Nuxt mode), compiles each `.vue` file into a snapshot, writes the configured TypeScript outputs once, then batches add/change/delete events and regenerates incrementally.
 - **Build:** it generates from the richest build pass it sees, which matters because Vite can run multiple passes (for example SSR plus client). The generator avoids letting a thinner pass clobber a richer one.
-- **Always-on virtual modules:** `virtual:testids`, `virtual:pom-manifest`, and `virtual:webmcp-manifest` are registered whether generation is enabled or disabled.
+- **Always-on virtual modules:** `virtual:testids`, `virtual:pom-manifest`, `virtual:webmcp-manifest`, and `virtual:webmcp-bridge` are registered whether generation is enabled or disabled.
 - **Generation can be disabled:** `generation: false` still keeps compile-time test-id injection and the virtual modules, but skips emitted POM files.
 
 ## Router-aware navigation: the real semantics
@@ -741,47 +742,62 @@ console.log(webMcpManifest.UserEditorPage.tools[0].toolName);
 console.log(webMcpManifest.UserEditorPage.tools[0].params);
 ```
 
-Example: bridge the manifest into a WebMCP runtime with `@mcp-b/global`:
+Example: bridge the manifest into a WebMCP runtime yourself with the browser-safe helper export:
 
 ```ts
 import "@mcp-b/global";
+import { registerWebMcpManifestTools } from "@immense/vue-pom-generator/webmcp-runtime";
 import { webMcpManifest } from "virtual:webmcp-manifest";
 
-for (const component of Object.values(webMcpManifest)) {
-  for (const tool of component.tools) {
-    navigator.modelContext.registerTool({
-      name: tool.toolName,
-      description: tool.toolDescription,
-      inputSchema: {
-        type: "object",
-        properties: Object.fromEntries(tool.params.map(param => [
-          param.name,
-          {
-            type: param.role === "checkbox" ? "boolean" : "string",
-            description: param.toolParamDescription,
-          },
-        ])),
-      },
-      async execute(args) {
-        return {
-          content: [{ type: "text", text: JSON.stringify(args) }],
-        };
-      },
-    });
-  }
-}
+const registration = registerWebMcpManifestTools({ manifest: webMcpManifest });
+
+// later
+registration.unregister();
 ```
 
 What it contains:
 
 - an object keyed by component/page object model class name
-- for each component with form-like controls: one or more suggested tools
-- for each tool: `toolName`, `toolDescription`, parameter metadata with `toolParamDescription`, and any generated action names that can drive submission or follow-up behavior
+- for each component with supported form-like controls or button actions: one or more suggested tools
+- for each tool: `toolName`, `toolDescription`, `toolAutoSubmit`, parameter metadata with `toolParamDescription`, and any generated action names that can drive submission or follow-up behavior
+- parameterized selectors also carry `selectorTemplateVariables` so a runtime bridge can resolve test ids such as `foo-${key}-button`
 
 What it is not:
 
 - automatic DOM annotation with `toolname`, `tooldescription`, or `toolparamdescription`
 - a runtime crawler or a replacement for explicit WebMCP authoring when your UI semantics need manual curation
+
+## `virtual:webmcp-bridge`
+
+This package also registers `virtual:webmcp-bridge` for consumers that want the generated manifest pre-bound to the current test-id attribute and ready to register as live tools.
+
+Usage:
+
+```ts
+import "@mcp-b/global";
+import { registerGeneratedWebMcpTools } from "virtual:webmcp-bridge";
+
+const registration = registerGeneratedWebMcpTools();
+
+// optional: scope to a subtree or a custom modelContext
+// const registration = registerGeneratedWebMcpTools({ root: document.querySelector("#app")! });
+
+// later
+registration.unregister();
+```
+
+What it does:
+
+- imports the browser-safe `@immense/vue-pom-generator/webmcp-runtime` helper for you
+- binds the current generated `webMcpManifest`
+- binds the current configured test-id attribute
+- unregisters the generated tools on Vite HMR disposal so dev reloads do not leak duplicate registrations
+
+Current bridge behavior:
+
+- fills native text inputs / textareas, checkboxes, radios, and native selects generically
+- attempts a best-effort combobox/select interaction path for `vselect`-style controls
+- auto-clicks a tool's sole action only when the tool has no parameters; otherwise use the generated `submitAction` input to choose an action explicitly
 
 ## ESLint rules that actually ship
 

--- a/README.md
+++ b/README.md
@@ -800,7 +800,7 @@ What it does:
 Current bridge behavior:
 
 - promotes generated POM actions to top-level tools (for example click/goTo/select/type methods become WebMCP tool names)
-- falls back to `set_<component>` tools only for component surfaces that expose writable params but no action
+- falls back to component-scoped param tools (for example `dynamic_form_field`) only when a surface exposes writable params but no action
 - fills native text inputs / textareas, checkboxes, radios, and native selects generically
 - attempts a best-effort combobox/select interaction path for `vselect`-style controls
 - resolves DOM targets at call time so SPA rerenders do not leave stale element handles behind

--- a/manifest-generator.ts
+++ b/manifest-generator.ts
@@ -12,7 +12,6 @@ import {
   humanizePomMethodName,
   normalizePomRoleLabel,
   splitPomDiscoverabilityWords,
-  stripPomActionPrefix,
 } from "./pom-discoverability";
 import type {
   WebMcpManifest,
@@ -58,6 +57,12 @@ type PomManifestComponent = {
 };
 
 type PomManifest = Record<string, PomManifestComponent>;
+
+type PendingWebMcpTool = Omit<WebMcpManifestTool, "toolName"> & {
+  componentName: string;
+  preferredToolName: string;
+  fallbackToolNames: string[];
+};
 
 const WEB_MCP_PARAM_ROLES = new Set(["input", "select", "vselect", "checkbox", "radio"]);
 const WEB_MCP_ACTION_ROLES = new Set(["button", "toggle"]);
@@ -146,9 +151,34 @@ function toCamelCase(words: readonly string[]): string {
   return words[0] + words.slice(1).map(word => upperFirst(word)).join("");
 }
 
+function splitWebMcpToolWords(value: string): string[] {
+  const normalized = value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .replace(/[._-]+/g, " ")
+    .trim();
+
+  if (!normalized) {
+    return [];
+  }
+
+  return normalized
+    .split(/\s+/)
+    .map(word => word.toLowerCase())
+    .filter(Boolean);
+}
+
+function humanizeWebMcpToolName(value: string): string {
+  return splitWebMcpToolWords(value).join(" ").replace(/\s+/g, " ").trim();
+}
+
 function getComponentWords(componentName: string): string[] {
   const words = splitPomDiscoverabilityWords(humanizePomComponentName(componentName));
   return words.length ? words : splitPomDiscoverabilityWords(componentName);
+}
+
+function getRawComponentWords(componentName: string): string[] {
+  return splitPomDiscoverabilityWords(componentName);
 }
 
 function getWebMcpParamName(entry: PomManifestEntry, componentWords: readonly string[]): string {
@@ -164,6 +194,92 @@ function getWebMcpParamName(entry: PomManifestEntry, componentWords: readonly st
       : [entry.inferredRole === "checkbox" ? "checked" : "value"];
 
   return toCamelCase(words);
+}
+
+function dedupeAndDisambiguateWebMcpParams(params: readonly WebMcpManifestParameter[]): WebMcpManifestParameter[] {
+  const uniqueParams = Array.from(new Map(
+    params.map(param => [
+      JSON.stringify([
+        param.name,
+        param.role,
+        param.testId,
+        param.selectorPatternKind,
+        param.selectorTemplateVariables,
+        param.toolParamDescription,
+        param.generatedPropertyName,
+      ]),
+      param,
+    ]),
+  ).values());
+
+  const groups = uniqueParams.reduce((acc, param) => {
+    const existing = acc.get(param.name);
+    if (existing) {
+      existing.push(param);
+    } else {
+      acc.set(param.name, [param]);
+    }
+    return acc;
+  }, new Map<string, WebMcpManifestParameter[]>());
+
+  const resolved: WebMcpManifestParameter[] = [];
+  const usedNames = new Set<string>();
+
+  const getGeneratedPropertyParamName = (param: WebMcpManifestParameter): string | null => {
+    if (!param.generatedPropertyName) {
+      return null;
+    }
+
+    const words = splitPomDiscoverabilityWords(param.generatedPropertyName);
+    return words.length ? toCamelCase(words) : null;
+  };
+
+  const getRoleQualifiedParamName = (param: WebMcpManifestParameter): string | null => {
+    const roleWords = splitPomDiscoverabilityWords(normalizePomRoleLabel(param.role));
+    return roleWords.length ? toCamelCase([...splitPomDiscoverabilityWords(param.name), ...roleWords]) : null;
+  };
+
+  const getTestIdQualifiedParamName = (param: WebMcpManifestParameter): string | null => {
+    const words = splitPomDiscoverabilityWords(param.testId);
+    return words.length ? toCamelCase(words) : null;
+  };
+
+  for (const [baseName, groupEntries] of Array.from(groups.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
+    const group = [...groupEntries].sort((a, b) => a.testId.localeCompare(b.testId) || a.role.localeCompare(b.role));
+    if (group.length === 1 && !usedNames.has(baseName)) {
+      resolved.push(group[0]);
+      usedNames.add(baseName);
+      continue;
+    }
+
+    const candidateSets = [
+      group.map(getGeneratedPropertyParamName),
+      group.map(getRoleQualifiedParamName),
+      group.map(getTestIdQualifiedParamName),
+      group.map((param, index) => `${param.name}${index + 1}`),
+    ];
+
+    const chosenNames = candidateSets.find((candidateSet): candidateSet is string[] => {
+      return candidateSet.every((name): name is string => typeof name === "string" && name.length > 0)
+        && new Set(candidateSet).size === candidateSet.length
+        && candidateSet.every(name => !usedNames.has(name));
+    });
+
+    if (!chosenNames) {
+      throw new Error(`[vue-pom-generator] Could not assign unique WebMCP parameter names for ${JSON.stringify(baseName)}.`);
+    }
+
+    for (let index = 0; index < group.length; index += 1) {
+      const name = chosenNames[index];
+      usedNames.add(name);
+      resolved.push({
+        ...group[index],
+        name,
+      });
+    }
+  }
+
+  return resolved.sort((a, b) => a.name.localeCompare(b.name) || a.testId.localeCompare(b.testId));
 }
 
 function buildWebMcpActions(entries: readonly PomManifestEntry[]): WebMcpManifestAction[] {
@@ -188,7 +304,7 @@ function buildWebMcpActions(entries: readonly PomManifestEntry[]): WebMcpManifes
       actions.set(actionName, {
         name: actionName,
         testId: entry.testId,
-        description: upperFirst(humanizePomMethodName(stripPomActionPrefix(actionName))),
+        description: upperFirst(humanizeWebMcpToolName(actionName)),
         selectorPatternKind: entry.selectorPatternKind,
         selectorTemplateVariables: entry.selectorTemplateVariables,
         ...(entry.targetPageObjectModelClass ? { targetPageObjectModelClass: entry.targetPageObjectModelClass } : {}),
@@ -199,12 +315,66 @@ function buildWebMcpActions(entries: readonly PomManifestEntry[]): WebMcpManifes
   return Array.from(actions.values()).sort((a, b) => a.name.localeCompare(b.name) || a.testId.localeCompare(b.testId));
 }
 
+function resolvePendingWebMcpTools(pendingTools: readonly PendingWebMcpTool[]): Array<{ componentName: string; tool: WebMcpManifestTool }> {
+  const preferredNameCounts = pendingTools.reduce((counts, tool) => {
+    counts.set(tool.preferredToolName, (counts.get(tool.preferredToolName) ?? 0) + 1);
+    return counts;
+  }, new Map<string, number>());
+  const usedNames = new Set<string>();
+
+  return pendingTools.map(tool => {
+    const candidateNames = [
+      ...(preferredNameCounts.get(tool.preferredToolName) === 1 ? [tool.preferredToolName] : []),
+      ...tool.fallbackToolNames,
+    ];
+
+    let resolvedToolName = candidateNames.find(candidate => candidate && !usedNames.has(candidate));
+    if (!resolvedToolName) {
+      const suffixBase = tool.fallbackToolNames[tool.fallbackToolNames.length - 1] || tool.preferredToolName;
+      resolvedToolName = suffixBase;
+      let suffix = 2;
+      while (usedNames.has(resolvedToolName)) {
+        resolvedToolName = `${suffixBase}_${suffix}`;
+        suffix += 1;
+      }
+    }
+
+    usedNames.add(resolvedToolName);
+    return {
+      componentName: tool.componentName,
+      tool: {
+        toolName: resolvedToolName,
+        toolDescription: tool.toolDescription,
+        toolAutoSubmit: tool.toolAutoSubmit,
+        params: tool.params,
+        actions: tool.actions,
+      },
+    };
+  });
+}
+
 export function buildWebMcpManifestFromPomManifest(pomManifest: PomManifest): WebMcpManifest {
-  const webMcpEntries = Object.entries(pomManifest)
+  const componentEntries = Object.entries(pomManifest)
     .map(([componentName, component]) => {
       const componentWords = getComponentWords(componentName);
+      const preferredToolName = toSnakeCase(componentWords);
+      const rawComponentWords = getRawComponentWords(componentName);
+      return [componentName, component, componentWords, preferredToolName, rawComponentWords] as const;
+    });
+
+  const duplicatePreferredToolNames = new Set(
+    Array.from(componentEntries.reduce((counts, [, , , preferredToolName]) => {
+      counts.set(preferredToolName, (counts.get(preferredToolName) ?? 0) + 1);
+      return counts;
+    }, new Map<string, number>()).entries())
+      .filter(([, count]) => count > 1)
+      .map(([toolName]) => toolName),
+  );
+
+  const pendingTools: PendingWebMcpTool[] = componentEntries
+    .flatMap<PendingWebMcpTool>(([componentName, component, componentWords, preferredToolName, rawComponentWords]) => {
       const actions = buildWebMcpActions(component.entries);
-      const params = component.entries
+      const params = dedupeAndDisambiguateWebMcpParams(component.entries
         .filter(entry => entry.inferredRole && WEB_MCP_PARAM_ROLES.has(entry.inferredRole))
         .map(entry => ({
           name: getWebMcpParamName(entry, componentWords),
@@ -215,26 +385,67 @@ export function buildWebMcpManifestFromPomManifest(pomManifest: PomManifest): We
           toolParamDescription: entry.semanticName,
           generatedPropertyName: entry.generatedPropertyName,
         } satisfies WebMcpManifestParameter))
-        .sort((a, b) => a.name.localeCompare(b.name) || a.testId.localeCompare(b.testId));
+      );
 
       if (!params.length && !actions.length) {
-        return null;
+        return [];
       }
 
       const componentLabel = upperFirst(humanizePomComponentName(componentName) || componentName);
-      const tools: WebMcpManifestTool[] = [{
-        toolName: toSnakeCase(componentWords),
-        toolDescription: `Interact with ${componentLabel}.`,
-        toolAutoSubmit: actions.length === 1 && params.length === 0,
+      const resolvedComponentToolName = duplicatePreferredToolNames.has(preferredToolName) && rawComponentWords.length
+        ? toSnakeCase(rawComponentWords)
+        : preferredToolName;
+
+      if (actions.length) {
+        return actions.map(action => {
+          const preferredActionToolName = toSnakeCase(splitWebMcpToolWords(action.name));
+          return {
+            componentName,
+            preferredToolName: preferredActionToolName,
+            fallbackToolNames: [`${preferredActionToolName}_${resolvedComponentToolName}`],
+            toolDescription: `${upperFirst(humanizeWebMcpToolName(action.name))} on ${componentLabel}.`,
+            toolAutoSubmit: true,
+            params,
+            actions: [action],
+          } satisfies PendingWebMcpTool;
+        });
+      }
+
+      return [{
+        componentName,
+        preferredToolName: `set_${resolvedComponentToolName}`,
+        fallbackToolNames: [`update_${resolvedComponentToolName}`, `set_${resolvedComponentToolName}_tool`],
+        toolDescription: `Set values on ${componentLabel}.`,
+        toolAutoSubmit: false,
         params,
-        actions,
-      }];
+        actions: [],
+      } satisfies PendingWebMcpTool];
+    });
+
+  const toolsByComponent = resolvePendingWebMcpTools(pendingTools)
+    .reduce((acc, { componentName, tool }) => {
+      const existing = acc.get(componentName);
+      if (existing) {
+        existing.push(tool);
+      } else {
+        acc.set(componentName, [tool]);
+      }
+      return acc;
+    }, new Map<string, WebMcpManifestTool[]>());
+
+  const webMcpEntries: Array<readonly [string, WebMcpManifestComponent]> = componentEntries
+    .map(([componentName, component]) => {
+      const tools = toolsByComponent.get(componentName);
+      if (!tools?.length) {
+        return null;
+      }
 
       return [componentName, {
         componentName,
         className: component.className,
         sourceFile: component.sourceFile,
         kind: component.kind,
+        usedComponents: [] as string[],
         tools,
       } satisfies WebMcpManifestComponent] as const;
     })
@@ -247,7 +458,27 @@ export function buildWebMcpManifest(
   componentHierarchyMap: Map<string, IComponentDependencies>,
   elementMetadata: Map<string, Map<string, ElementMetadata>>,
 ): WebMcpManifest {
-  return buildWebMcpManifestFromPomManifest(buildPomManifest(componentHierarchyMap, elementMetadata));
+  const manifest = buildWebMcpManifestFromPomManifest(buildPomManifest(componentHierarchyMap, elementMetadata));
+
+  for (const [componentName, dependencies] of Array.from(componentHierarchyMap.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
+    const usedComponents = Array.from(dependencies.usedComponentSet).sort((a, b) => a.localeCompare(b));
+    const existing = manifest[componentName];
+    if (existing) {
+      existing.usedComponents = usedComponents;
+      continue;
+    }
+
+    manifest[componentName] = {
+      componentName,
+      className: componentName,
+      sourceFile: dependencies.filePath,
+      kind: dependencies.isView ? "view" : "component",
+      usedComponents,
+      tools: [],
+    };
+  }
+
+  return manifest;
 }
 
 function matchesPrimarySelector(extraMethod: PomExtraClickMethodSpec, pom: PomPrimarySpec): boolean {
@@ -363,7 +594,7 @@ export function generateTestIdsModule(
 ): string {
   const pomManifest = buildPomManifest(componentHierarchyMap, elementMetadata);
   const testIdManifest = buildTestIdManifest(pomManifest);
-  const webMcpManifest = buildWebMcpManifestFromPomManifest(pomManifest);
+  const webMcpManifest = buildWebMcpManifest(componentHierarchyMap, elementMetadata);
 
   return renderSourceFile("virtual-testids.ts", (sourceFile) => {
     sourceFile.addStatements("// Virtual module: test id manifest");
@@ -488,73 +719,46 @@ export function generateWebMcpBridgeModule(
   testIdAttribute: string,
 ): string {
   const webMcpManifest = buildWebMcpManifest(componentHierarchyMap, elementMetadata);
+  const manifestSource = JSON.stringify(webMcpManifest, null, 2);
+  const testIdAttributeSource = JSON.stringify(testIdAttribute);
 
-  return renderSourceFile("virtual-webmcp-bridge.ts", (sourceFile) => {
-    sourceFile.addStatements("// Virtual module: WebMCP runtime bridge");
-    addNamedImport(sourceFile, {
-      moduleSpecifier: "@immense/vue-pom-generator/webmcp-runtime",
-      namedImports: ["registerWebMcpManifestTools"],
-    });
-    addNamedImport(sourceFile, {
-      moduleSpecifier: "@immense/vue-pom-generator/webmcp-runtime",
-      isTypeOnly: true,
-      namedImports: ["RegisterWebMcpManifestToolsOptions", "RegisteredWebMcpToolsHandle"],
-    });
-    sourceFile.addVariableStatement({
-      declarationKind: VariableDeclarationKind.Const,
-      isExported: true,
-      declarations: [{
-        name: "webMcpManifest",
-        initializer: writeConstJson(webMcpManifest),
-      }],
-    });
-    sourceFile.addVariableStatement({
-      declarationKind: VariableDeclarationKind.Const,
-      isExported: true,
-      declarations: [{
-        name: "webMcpTestIdAttribute",
-        initializer: JSON.stringify(testIdAttribute),
-      }],
-    });
-    sourceFile.addTypeAlias({
-      isExported: true,
-      name: "WebMcpManifest",
-      type: "typeof webMcpManifest",
-    });
-    sourceFile.addTypeAlias({
-      isExported: true,
-      name: "WebMcpManifestComponentName",
-      type: "keyof WebMcpManifest",
-    });
-    sourceFile.addStatements(`
-let activeWebMcpRegistration: RegisteredWebMcpToolsHandle | null = null;
-
-export type GeneratedWebMcpToolRegistrationOptions = Omit<RegisterWebMcpManifestToolsOptions, "manifest" | "testIdAttribute">;
-
-export function registerGeneratedWebMcpTools(
-  options: GeneratedWebMcpToolRegistrationOptions = {},
-): RegisteredWebMcpToolsHandle {
-  if (activeWebMcpRegistration) {
-    activeWebMcpRegistration.unregister();
-  }
-
-  activeWebMcpRegistration = registerWebMcpManifestTools({
-    manifest: webMcpManifest,
-    testIdAttribute: webMcpTestIdAttribute,
-    ...options,
-  });
-
-  return activeWebMcpRegistration;
-}
-
-if (import.meta.hot) {
-  import.meta.hot.dispose(() => {
-    if (activeWebMcpRegistration) {
-      activeWebMcpRegistration.unregister();
-      activeWebMcpRegistration = null;
-    }
-  });
-}
-`);
-  });
+  return [
+    "// Virtual module: WebMCP runtime bridge",
+    "import { registerRouteScopedWebMcpManifestTools, registerWebMcpManifestTools } from \"@immense/vue-pom-generator/webmcp-runtime\";",
+    "",
+    `export const webMcpManifest = ${manifestSource};`,
+    `export const webMcpTestIdAttribute = ${testIdAttributeSource};`,
+    "",
+    "let activeWebMcpRegistration = null;",
+    "",
+    "export function registerGeneratedWebMcpTools(options = {}) {",
+    "  if (activeWebMcpRegistration) {",
+    "    activeWebMcpRegistration.unregister();",
+    "  }",
+    "",
+    "  activeWebMcpRegistration = options.router",
+    "    ? registerRouteScopedWebMcpManifestTools({",
+    "      manifest: webMcpManifest,",
+    "      testIdAttribute: webMcpTestIdAttribute,",
+    "      ...options,",
+    "    })",
+    "    : registerWebMcpManifestTools({",
+    "      manifest: webMcpManifest,",
+    "      testIdAttribute: webMcpTestIdAttribute,",
+    "      ...options,",
+    "    });",
+    "",
+    "  return activeWebMcpRegistration;",
+    "}",
+    "",
+    "if (import.meta.hot) {",
+    "  import.meta.hot.dispose(() => {",
+    "    if (activeWebMcpRegistration) {",
+    "      activeWebMcpRegistration.unregister();",
+    "      activeWebMcpRegistration = null;",
+    "    }",
+    "  });",
+    "}",
+    "",
+  ].join("\n");
 }

--- a/manifest-generator.ts
+++ b/manifest-generator.ts
@@ -66,6 +66,13 @@ type PendingWebMcpTool = Omit<WebMcpManifestTool, "toolName"> & {
 
 const WEB_MCP_PARAM_ROLES = new Set(["input", "select", "vselect", "checkbox", "radio"]);
 const WEB_MCP_ACTION_ROLES = new Set(["button", "toggle"]);
+const WEB_MCP_TOOL_TRANSPORT_PREFIXES = [
+  ["click"],
+  ["go", "to"],
+  ["type"],
+  ["select"],
+  ["set"],
+] as const;
 
 function removeByKeySegment(value: string): string {
   const idx = value.indexOf("ByKey");
@@ -170,6 +177,34 @@ function splitWebMcpToolWords(value: string): string[] {
 
 function humanizeWebMcpToolName(value: string): string {
   return splitWebMcpToolWords(value).join(" ").replace(/\s+/g, " ").trim();
+}
+
+function stripLeadingWebMcpToolTransportWords(words: readonly string[]): string[] {
+  let remainingWords = [...words];
+
+  while (remainingWords.length) {
+    const matchingPrefix = WEB_MCP_TOOL_TRANSPORT_PREFIXES.find(prefixWords =>
+      remainingWords.length >= prefixWords.length
+      && prefixWords.every((word, index) => remainingWords[index] === word),
+    );
+    if (!matchingPrefix) {
+      break;
+    }
+
+    remainingWords = remainingWords.slice(matchingPrefix.length);
+  }
+
+  return remainingWords;
+}
+
+function getWebMcpToolWordsFromActionName(actionName: string, fallbackWords: readonly string[] = []): string[] {
+  const actionWords = splitWebMcpToolWords(actionName);
+  const strippedWords = stripLeadingWebMcpToolTransportWords(actionWords);
+  if (strippedWords.length) {
+    return strippedWords;
+  }
+
+  return fallbackWords.length ? [...fallbackWords] : actionWords;
 }
 
 function getComponentWords(componentName: string): string[] {
@@ -398,7 +433,10 @@ export function buildWebMcpManifestFromPomManifest(pomManifest: PomManifest): We
 
       if (actions.length) {
         return actions.map(action => {
-          const preferredActionToolName = toSnakeCase(splitWebMcpToolWords(action.name));
+          const preferredActionToolName = toSnakeCase(getWebMcpToolWordsFromActionName(
+            action.name,
+            rawComponentWords.length ? rawComponentWords : componentWords,
+          ));
           return {
             componentName,
             preferredToolName: preferredActionToolName,
@@ -413,8 +451,8 @@ export function buildWebMcpManifestFromPomManifest(pomManifest: PomManifest): We
 
       return [{
         componentName,
-        preferredToolName: `set_${resolvedComponentToolName}`,
-        fallbackToolNames: [`update_${resolvedComponentToolName}`, `set_${resolvedComponentToolName}_tool`],
+        preferredToolName: resolvedComponentToolName,
+        fallbackToolNames: [`${resolvedComponentToolName}_fields`, `${resolvedComponentToolName}_tool`],
         toolDescription: `Set values on ${componentLabel}.`,
         toolAutoSubmit: false,
         params,

--- a/manifest-generator.ts
+++ b/manifest-generator.ts
@@ -14,13 +14,21 @@ import {
   splitPomDiscoverabilityWords,
   stripPomActionPrefix,
 } from "./pom-discoverability";
+import type {
+  WebMcpManifest,
+  WebMcpManifestAction,
+  WebMcpManifestComponent,
+  WebMcpManifestParameter,
+  WebMcpManifestTool,
+} from "./webmcp-runtime";
 import type { IComponentDependencies, IDataTestId, PomExtraClickMethodSpec, PomPrimarySpec } from "./utils";
-import { renderSourceFile, VariableDeclarationKind, type WriterFunction } from "./typescript-codegen";
+import { addNamedImport, renderSourceFile, VariableDeclarationKind, type WriterFunction } from "./typescript-codegen";
 import { upperFirst } from "./utils";
 
 type PomManifestEntry = {
   testId: string;
   selectorPatternKind: "static" | "parameterized";
+  selectorTemplateVariables: string[];
   semanticName: string;
   locatorDescription: string;
   inferredRole: string | null;
@@ -50,39 +58,6 @@ type PomManifestComponent = {
 };
 
 type PomManifest = Record<string, PomManifestComponent>;
-
-type WebMcpManifestParameter = {
-  name: string;
-  role: string;
-  testId: string;
-  selectorPatternKind: "static" | "parameterized";
-  toolParamDescription: string;
-  generatedPropertyName: string | null;
-};
-
-type WebMcpManifestAction = {
-  name: string;
-  testId: string;
-  description: string;
-  targetPageObjectModelClass?: string;
-};
-
-type WebMcpManifestTool = {
-  toolName: string;
-  toolDescription: string;
-  params: WebMcpManifestParameter[];
-  actions: WebMcpManifestAction[];
-};
-
-type WebMcpManifestComponent = {
-  componentName: string;
-  className: string;
-  sourceFile: string;
-  kind: "component" | "view";
-  tools: WebMcpManifestTool[];
-};
-
-type WebMcpManifest = Record<string, WebMcpManifestComponent>;
 
 const WEB_MCP_PARAM_ROLES = new Set(["input", "select", "vselect", "checkbox", "radio"]);
 const WEB_MCP_ACTION_ROLES = new Set(["button", "toggle"]);
@@ -214,6 +189,8 @@ function buildWebMcpActions(entries: readonly PomManifestEntry[]): WebMcpManifes
         name: actionName,
         testId: entry.testId,
         description: upperFirst(humanizePomMethodName(stripPomActionPrefix(actionName))),
+        selectorPatternKind: entry.selectorPatternKind,
+        selectorTemplateVariables: entry.selectorTemplateVariables,
         ...(entry.targetPageObjectModelClass ? { targetPageObjectModelClass: entry.targetPageObjectModelClass } : {}),
       });
     }
@@ -226,6 +203,7 @@ export function buildWebMcpManifestFromPomManifest(pomManifest: PomManifest): We
   const webMcpEntries = Object.entries(pomManifest)
     .map(([componentName, component]) => {
       const componentWords = getComponentWords(componentName);
+      const actions = buildWebMcpActions(component.entries);
       const params = component.entries
         .filter(entry => entry.inferredRole && WEB_MCP_PARAM_ROLES.has(entry.inferredRole))
         .map(entry => ({
@@ -233,12 +211,13 @@ export function buildWebMcpManifestFromPomManifest(pomManifest: PomManifest): We
           role: entry.inferredRole!,
           testId: entry.testId,
           selectorPatternKind: entry.selectorPatternKind,
+          selectorTemplateVariables: entry.selectorTemplateVariables,
           toolParamDescription: entry.semanticName,
           generatedPropertyName: entry.generatedPropertyName,
         } satisfies WebMcpManifestParameter))
         .sort((a, b) => a.name.localeCompare(b.name) || a.testId.localeCompare(b.testId));
 
-      if (!params.length) {
+      if (!params.length && !actions.length) {
         return null;
       }
 
@@ -246,8 +225,9 @@ export function buildWebMcpManifestFromPomManifest(pomManifest: PomManifest): We
       const tools: WebMcpManifestTool[] = [{
         toolName: toSnakeCase(componentWords),
         toolDescription: `Interact with ${componentLabel}.`,
+        toolAutoSubmit: actions.length === 1 && params.length === 0,
         params,
-        actions: buildWebMcpActions(component.entries),
+        actions,
       }];
 
       return [componentName, {
@@ -305,6 +285,7 @@ function getManifestEntry(
   return {
     testId,
     selectorPatternKind: entry.selectorValue.patternKind,
+    selectorTemplateVariables: [...entry.selectorValue.templateVariables],
     semanticName: metadata?.semanticName ?? (pom ? humanizePomMethodName(pom.methodName) : testId),
     locatorDescription: pom
       ? buildPomLocatorDescription({
@@ -498,5 +479,82 @@ export function generateWebMcpManifestModule(
       name: "WebMcpManifestComponentName",
       type: "keyof WebMcpManifest",
     });
+  });
+}
+
+export function generateWebMcpBridgeModule(
+  componentHierarchyMap: Map<string, IComponentDependencies>,
+  elementMetadata: Map<string, Map<string, ElementMetadata>>,
+  testIdAttribute: string,
+): string {
+  const webMcpManifest = buildWebMcpManifest(componentHierarchyMap, elementMetadata);
+
+  return renderSourceFile("virtual-webmcp-bridge.ts", (sourceFile) => {
+    sourceFile.addStatements("// Virtual module: WebMCP runtime bridge");
+    addNamedImport(sourceFile, {
+      moduleSpecifier: "@immense/vue-pom-generator/webmcp-runtime",
+      namedImports: ["registerWebMcpManifestTools"],
+    });
+    addNamedImport(sourceFile, {
+      moduleSpecifier: "@immense/vue-pom-generator/webmcp-runtime",
+      isTypeOnly: true,
+      namedImports: ["RegisterWebMcpManifestToolsOptions", "RegisteredWebMcpToolsHandle"],
+    });
+    sourceFile.addVariableStatement({
+      declarationKind: VariableDeclarationKind.Const,
+      isExported: true,
+      declarations: [{
+        name: "webMcpManifest",
+        initializer: writeConstJson(webMcpManifest),
+      }],
+    });
+    sourceFile.addVariableStatement({
+      declarationKind: VariableDeclarationKind.Const,
+      isExported: true,
+      declarations: [{
+        name: "webMcpTestIdAttribute",
+        initializer: JSON.stringify(testIdAttribute),
+      }],
+    });
+    sourceFile.addTypeAlias({
+      isExported: true,
+      name: "WebMcpManifest",
+      type: "typeof webMcpManifest",
+    });
+    sourceFile.addTypeAlias({
+      isExported: true,
+      name: "WebMcpManifestComponentName",
+      type: "keyof WebMcpManifest",
+    });
+    sourceFile.addStatements(`
+let activeWebMcpRegistration: RegisteredWebMcpToolsHandle | null = null;
+
+export type GeneratedWebMcpToolRegistrationOptions = Omit<RegisterWebMcpManifestToolsOptions, "manifest" | "testIdAttribute">;
+
+export function registerGeneratedWebMcpTools(
+  options: GeneratedWebMcpToolRegistrationOptions = {},
+): RegisteredWebMcpToolsHandle {
+  if (activeWebMcpRegistration) {
+    activeWebMcpRegistration.unregister();
+  }
+
+  activeWebMcpRegistration = registerWebMcpManifestTools({
+    manifest: webMcpManifest,
+    testIdAttribute: webMcpTestIdAttribute,
+    ...options,
+  });
+
+  return activeWebMcpRegistration;
+}
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    if (activeWebMcpRegistration) {
+      activeWebMcpRegistration.unregister();
+      activeWebMcpRegistration = null;
+    }
+  });
+}
+`);
   });
 }

--- a/manifest-generator.ts
+++ b/manifest-generator.ts
@@ -6,7 +6,14 @@
 import type { AccessibilityAuditResult } from "./accessibility-audit";
 import { buildAccessibilityAudit } from "./accessibility-audit";
 import type { ElementMetadata } from "./metadata-collector";
-import { buildPomLocatorDescription, humanizePomMethodName } from "./pom-discoverability";
+import {
+  buildPomLocatorDescription,
+  humanizePomComponentName,
+  humanizePomMethodName,
+  normalizePomRoleLabel,
+  splitPomDiscoverabilityWords,
+  stripPomActionPrefix,
+} from "./pom-discoverability";
 import type { IComponentDependencies, IDataTestId, PomExtraClickMethodSpec, PomPrimarySpec } from "./utils";
 import { renderSourceFile, VariableDeclarationKind, type WriterFunction } from "./typescript-codegen";
 import { upperFirst } from "./utils";
@@ -43,6 +50,42 @@ type PomManifestComponent = {
 };
 
 type PomManifest = Record<string, PomManifestComponent>;
+
+type WebMcpManifestParameter = {
+  name: string;
+  role: string;
+  testId: string;
+  selectorPatternKind: "static" | "parameterized";
+  toolParamDescription: string;
+  generatedPropertyName: string | null;
+};
+
+type WebMcpManifestAction = {
+  name: string;
+  testId: string;
+  description: string;
+  targetPageObjectModelClass?: string;
+};
+
+type WebMcpManifestTool = {
+  toolName: string;
+  toolDescription: string;
+  params: WebMcpManifestParameter[];
+  actions: WebMcpManifestAction[];
+};
+
+type WebMcpManifestComponent = {
+  componentName: string;
+  className: string;
+  sourceFile: string;
+  kind: "component" | "view";
+  tools: WebMcpManifestTool[];
+};
+
+type WebMcpManifest = Record<string, WebMcpManifestComponent>;
+
+const WEB_MCP_PARAM_ROLES = new Set(["input", "select", "vselect", "checkbox", "radio"]);
+const WEB_MCP_ACTION_ROLES = new Set(["button", "toggle"]);
 
 function removeByKeySegment(value: string): string {
   const idx = value.indexOf("ByKey");
@@ -92,6 +135,139 @@ function getGeneratedActionName(entry: IDataTestId, pom: PomPrimarySpec): string
     default:
       return `click${methodNameUpper}`;
   }
+}
+
+function removeLeadingWords(words: readonly string[], prefixWords: readonly string[]): string[] {
+  if (!prefixWords.length || words.length < prefixWords.length) {
+    return [...words];
+  }
+
+  for (let i = 0; i < prefixWords.length; i += 1) {
+    if (words[i] !== prefixWords[i]) {
+      return [...words];
+    }
+  }
+
+  return words.slice(prefixWords.length);
+}
+
+function removeTrailingWord(words: readonly string[], trailingWord: string | null): string[] {
+  if (!trailingWord || !words.length || words[words.length - 1] !== trailingWord) {
+    return [...words];
+  }
+
+  return words.slice(0, -1);
+}
+
+function toSnakeCase(words: readonly string[]): string {
+  return words.join("_");
+}
+
+function toCamelCase(words: readonly string[]): string {
+  if (!words.length) {
+    return "";
+  }
+
+  return words[0] + words.slice(1).map(word => upperFirst(word)).join("");
+}
+
+function getComponentWords(componentName: string): string[] {
+  const words = splitPomDiscoverabilityWords(humanizePomComponentName(componentName));
+  return words.length ? words : splitPomDiscoverabilityWords(componentName);
+}
+
+function getWebMcpParamName(entry: PomManifestEntry, componentWords: readonly string[]): string {
+  const baseWords = splitPomDiscoverabilityWords(entry.generatedPropertyName || entry.semanticName || entry.testId);
+  const roleWord = entry.inferredRole ? normalizePomRoleLabel(entry.inferredRole).toLowerCase() : null;
+  const withoutComponentWords = removeLeadingWords(baseWords, componentWords);
+  const preferredWords = removeTrailingWord(withoutComponentWords, roleWord);
+  const fallbackWords = removeTrailingWord(baseWords, roleWord);
+  const words = preferredWords.length
+    ? preferredWords
+    : fallbackWords.length
+      ? fallbackWords
+      : [entry.inferredRole === "checkbox" ? "checked" : "value"];
+
+  return toCamelCase(words);
+}
+
+function buildWebMcpActions(entries: readonly PomManifestEntry[]): WebMcpManifestAction[] {
+  const actions = new Map<string, WebMcpManifestAction>();
+
+  for (const entry of entries) {
+    if (!entry.generatedActionNames.length) {
+      continue;
+    }
+
+    const canDriveAction = (entry.inferredRole && WEB_MCP_ACTION_ROLES.has(entry.inferredRole))
+      || !!entry.targetPageObjectModelClass;
+    if (!canDriveAction) {
+      continue;
+    }
+
+    for (const actionName of entry.generatedActionNames) {
+      if (actions.has(actionName)) {
+        continue;
+      }
+
+      actions.set(actionName, {
+        name: actionName,
+        testId: entry.testId,
+        description: upperFirst(humanizePomMethodName(stripPomActionPrefix(actionName))),
+        ...(entry.targetPageObjectModelClass ? { targetPageObjectModelClass: entry.targetPageObjectModelClass } : {}),
+      });
+    }
+  }
+
+  return Array.from(actions.values()).sort((a, b) => a.name.localeCompare(b.name) || a.testId.localeCompare(b.testId));
+}
+
+export function buildWebMcpManifestFromPomManifest(pomManifest: PomManifest): WebMcpManifest {
+  const webMcpEntries = Object.entries(pomManifest)
+    .map(([componentName, component]) => {
+      const componentWords = getComponentWords(componentName);
+      const params = component.entries
+        .filter(entry => entry.inferredRole && WEB_MCP_PARAM_ROLES.has(entry.inferredRole))
+        .map(entry => ({
+          name: getWebMcpParamName(entry, componentWords),
+          role: entry.inferredRole!,
+          testId: entry.testId,
+          selectorPatternKind: entry.selectorPatternKind,
+          toolParamDescription: entry.semanticName,
+          generatedPropertyName: entry.generatedPropertyName,
+        } satisfies WebMcpManifestParameter))
+        .sort((a, b) => a.name.localeCompare(b.name) || a.testId.localeCompare(b.testId));
+
+      if (!params.length) {
+        return null;
+      }
+
+      const componentLabel = upperFirst(humanizePomComponentName(componentName) || componentName);
+      const tools: WebMcpManifestTool[] = [{
+        toolName: toSnakeCase(componentWords),
+        toolDescription: `Interact with ${componentLabel}.`,
+        params,
+        actions: buildWebMcpActions(component.entries),
+      }];
+
+      return [componentName, {
+        componentName,
+        className: component.className,
+        sourceFile: component.sourceFile,
+        kind: component.kind,
+        tools,
+      } satisfies WebMcpManifestComponent] as const;
+    })
+    .filter((entry): entry is readonly [string, WebMcpManifestComponent] => entry !== null);
+
+  return Object.fromEntries(webMcpEntries);
+}
+
+export function buildWebMcpManifest(
+  componentHierarchyMap: Map<string, IComponentDependencies>,
+  elementMetadata: Map<string, Map<string, ElementMetadata>>,
+): WebMcpManifest {
+  return buildWebMcpManifestFromPomManifest(buildPomManifest(componentHierarchyMap, elementMetadata));
 }
 
 function matchesPrimarySelector(extraMethod: PomExtraClickMethodSpec, pom: PomPrimarySpec): boolean {
@@ -206,6 +382,7 @@ export function generateTestIdsModule(
 ): string {
   const pomManifest = buildPomManifest(componentHierarchyMap, elementMetadata);
   const testIdManifest = buildTestIdManifest(pomManifest);
+  const webMcpManifest = buildWebMcpManifestFromPomManifest(pomManifest);
 
   return renderSourceFile("virtual-testids.ts", (sourceFile) => {
     sourceFile.addStatements("// Virtual module: test id manifest");
@@ -223,6 +400,14 @@ export function generateTestIdsModule(
       declarations: [{
         name: "pomManifest",
         initializer: writeConstJson(pomManifest),
+      }],
+    });
+    sourceFile.addVariableStatement({
+      declarationKind: VariableDeclarationKind.Const,
+      isExported: true,
+      declarations: [{
+        name: "webMcpManifest",
+        initializer: writeConstJson(webMcpManifest),
       }],
     });
     sourceFile.addTypeAlias({
@@ -244,6 +429,16 @@ export function generateTestIdsModule(
       isExported: true,
       name: "PomManifestComponentName",
       type: "keyof PomManifest",
+    });
+    sourceFile.addTypeAlias({
+      isExported: true,
+      name: "WebMcpManifest",
+      type: "typeof webMcpManifest",
+    });
+    sourceFile.addTypeAlias({
+      isExported: true,
+      name: "WebMcpManifestComponentName",
+      type: "keyof WebMcpManifest",
     });
   });
 }
@@ -273,6 +468,35 @@ export function generatePomManifestModule(
       isExported: true,
       name: "PomManifestComponentName",
       type: "keyof PomManifest",
+    });
+  });
+}
+
+export function generateWebMcpManifestModule(
+  componentHierarchyMap: Map<string, IComponentDependencies>,
+  elementMetadata: Map<string, Map<string, ElementMetadata>>,
+): string {
+  const webMcpManifest = buildWebMcpManifest(componentHierarchyMap, elementMetadata);
+
+  return renderSourceFile("virtual-webmcp-manifest.ts", (sourceFile) => {
+    sourceFile.addStatements("// Virtual module: WebMCP tool manifest");
+    sourceFile.addVariableStatement({
+      declarationKind: VariableDeclarationKind.Const,
+      isExported: true,
+      declarations: [{
+        name: "webMcpManifest",
+        initializer: writeConstJson(webMcpManifest),
+      }],
+    });
+    sourceFile.addTypeAlias({
+      isExported: true,
+      name: "WebMcpManifest",
+      type: "typeof webMcpManifest",
+    });
+    sourceFile.addTypeAlias({
+      isExported: true,
+      name: "WebMcpManifestComponentName",
+      type: "keyof WebMcpManifest",
     });
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@babel/types": "^7.28.5",
         "@floating-ui/core": "^1.7.5",
         "@github/copilot-sdk": "^0.1.8",
+        "@mcp-b/global": "^2.2.0",
         "@playwright/test": "1.59.1",
         "@types/jsdom": "^27.0.0",
         "@types/node": "^24.1.0",
@@ -30,7 +31,9 @@
         "vite": "^7.3.1",
         "vitest": "^4.0.16",
         "vue-eslint-parser": "^10.2.0",
-        "vue-router": "^4.2.5"
+        "vue-router": "^4.2.5",
+        "zod": "^3.25.76",
+        "zod-to-json-schema": "^3.25.2"
       },
       "peerDependencies": {
         "@babel/parser": ">=7",
@@ -39,6 +42,7 @@
         "@vue/compiler-dom": ">=3.5",
         "@vue/compiler-sfc": ">=3.5",
         "eslint": ">=9",
+        "playwright": "1.59.1",
         "vite": "^5 || ^6 || ^7"
       },
       "peerDependenciesMeta": {
@@ -278,6 +282,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@clack/core": {
       "version": "0.5.0",
@@ -1343,6 +1354,16 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@github/copilot-sdk/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@github/copilot-win32-arm64": {
       "version": "0.0.399",
       "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-0.0.399.tgz",
@@ -1455,6 +1476,81 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mcp-b/global": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/global/-/global-2.2.0.tgz",
+      "integrity": "sha512-3+FNuVXPGyhzYsVPL5UItMkTF+GD6E3iHEmuJY0yydjjpWtlqrUw7b7PLhyuymKcc1+jTMunyrr3Zps0uPEfiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mcp-b/transports": "2.2.0",
+        "@mcp-b/webmcp-polyfill": "2.2.0",
+        "@mcp-b/webmcp-ts-sdk": "2.2.0",
+        "@mcp-b/webmcp-types": "2.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mcp-b/transports": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/transports/-/transports-2.2.0.tgz",
+      "integrity": "sha512-zSqYekrmou72z67GF5jXaDnQdhT84Hlmi4meshm0zMn71GlaYmHhXfb3UsgW3xQ7Y5CexQ4U9L9IrdG6/+MTfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mcp-b/webmcp-ts-sdk": "2.2.0",
+        "zod": "3.25.76"
+      }
+    },
+    "node_modules/@mcp-b/webmcp-polyfill": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-polyfill/-/webmcp-polyfill-2.2.0.tgz",
+      "integrity": "sha512-as49JP4MHXVMMVNzD8938EsiU2tEzWNk7Un6c6C/xK5rstkIrQZQsVLbH7NFtmgMb6bbryzSqg9JWSFIxkU27Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "@mcp-b/webmcp-types": "2.2.0",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mcp-b/webmcp-ts-sdk": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-ts-sdk/-/webmcp-ts-sdk-2.2.0.tgz",
+      "integrity": "sha512-IzjwqrpbbASbAJxpr5k5m1ryiELGdnohDXzpLuB7UK2VI1rsAwQ04j59uRkMvaqZ4iwvxHTzKk+AajRB57OcPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mcp-b/webmcp-polyfill": "2.2.0",
+        "@mcp-b/webmcp-types": "2.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        },
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mcp-b/webmcp-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-types/-/webmcp-types-2.2.0.tgz",
+      "integrity": "sha512-1/UYAwQKBkqRgK18GkbGR4m6Cn9vz6Qy6pTL5LIIinUOhR5dMLaNl/blH/tJT+nJleMmgDoFZWGAmmr+fAz2PQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
@@ -5215,6 +5311,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/knip/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -8463,13 +8569,23 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
+    "./webmcp-runtime": {
+      "types": "./dist/webmcp-runtime.d.ts",
+      "import": "./dist/webmcp-runtime.mjs",
+      "require": "./dist/webmcp-runtime.cjs"
+    },
     "./eslint": {
       "types": "./dist/eslint/index.d.ts",
       "import": "./dist/eslint/index.mjs",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@babel/types": "^7.28.5",
     "@floating-ui/core": "^1.7.5",
     "@github/copilot-sdk": "^0.1.8",
+    "@mcp-b/global": "^2.2.0",
     "@playwright/test": "1.59.1",
     "@types/jsdom": "^27.0.0",
     "@types/node": "^24.1.0",
@@ -91,7 +92,9 @@
     "vite": "^7.3.1",
     "vitest": "^4.0.16",
     "vue-eslint-parser": "^10.2.0",
-    "vue-router": "^4.2.5"
+    "vue-router": "^4.2.5",
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.25.2"
   },
   "license": "MIT"
 }

--- a/plugin/create-vue-pom-generator-plugins.ts
+++ b/plugin/create-vue-pom-generator-plugins.ts
@@ -472,6 +472,7 @@ export function createVuePomGeneratorPlugins(options: PomGeneratorPluginOptions 
   const supportPlugins = createSupportPlugins({
     componentHierarchyMap,
     elementMetadata,
+    semanticNameMap,
     vueFilesPathMap,
     nativeWrappers,
     excludedComponents,

--- a/plugin/create-vue-pom-generator-plugins.ts
+++ b/plugin/create-vue-pom-generator-plugins.ts
@@ -502,7 +502,7 @@ export function createVuePomGeneratorPlugins(options: PomGeneratorPluginOptions 
   ];
 
   if (!generationEnabled) {
-    const virtualModules = createTestIdsVirtualModulesPlugin(componentHierarchyMap, elementMetadata);
+    const virtualModules = createTestIdsVirtualModulesPlugin(componentHierarchyMap, elementMetadata, testIdAttribute);
     return [
       configPlugin,
       metadataCollectorPlugin,

--- a/plugin/support-plugins.ts
+++ b/plugin/support-plugins.ts
@@ -13,6 +13,7 @@ import { createTestIdsVirtualModulesPlugin } from "./support/virtual-modules";
 interface SupportFactoryOptions {
   componentHierarchyMap: Map<string, IComponentDependencies>;
   elementMetadata: Map<string, Map<string, ElementMetadata>>;
+  semanticNameMap: Map<string, string>;
   vueFilesPathMap: Map<string, string>;
   nativeWrappers: NativeWrappersMap;
   excludedComponents: string[];
@@ -32,6 +33,7 @@ export function createSupportPlugins(options: SupportFactoryOptions): PluginOpti
   const {
     componentHierarchyMap,
     elementMetadata,
+    semanticNameMap,
     vueFilesPathMap,
     nativeWrappers,
     excludedComponents,
@@ -113,6 +115,10 @@ export function createSupportPlugins(options: SupportFactoryOptions): PluginOpti
   });
 
   const devProcessor = createDevProcessorPlugin({
+    elementMetadata,
+    semanticNameMap,
+    componentHierarchyMap,
+    vueFilesPathMap,
     nativeWrappers,
     excludedComponents,
     getPageDirs,

--- a/plugin/support-plugins.ts
+++ b/plugin/support-plugins.ts
@@ -129,7 +129,7 @@ export function createSupportPlugins(options: SupportFactoryOptions): PluginOpti
     loggerRef,
   });
 
-  const virtualModules = createTestIdsVirtualModulesPlugin(componentHierarchyMap, elementMetadata);
+  const virtualModules = createTestIdsVirtualModulesPlugin(componentHierarchyMap, elementMetadata, testIdAttribute);
 
   return [tsProcessor, devProcessor, virtualModules];
 }

--- a/plugin/support/dev-plugin.ts
+++ b/plugin/support/dev-plugin.ts
@@ -4,11 +4,12 @@ import { performance } from "node:perf_hooks";
 import process from "node:process";
 
 import type { BindingMetadata } from "@vue/compiler-core";
-import * as compilerDom from "@vue/compiler-dom";
 import { compileScript, parse as parseSfc } from "@vue/compiler-sfc";
 import type { PluginOption, ViteDevServer } from "vite";
 
 import { generateFiles } from "../../class-generation";
+import { compileWithMetadataExtractionManual } from "../../compiler-wrapper";
+import type { ElementMetadata } from "../../metadata-collector";
 import { introspectNuxtPages, parseRouterFileFromCwd } from "../../router-introspection";
 import { createTestIdTransform } from "../../transform";
 import type { IComponentDependencies, NativeWrappersMap, RouterIntrospectionResult } from "../../utils";
@@ -18,6 +19,10 @@ import { isPathWithinDir, resolveComponentNameFromPath } from "../path-utils";
 import type { ResolvedGenerationSupportOptions } from "../resolved-generation-options";
 
 interface DevProcessorOptions {
+  elementMetadata: Map<string, Map<string, ElementMetadata>>;
+  semanticNameMap: Map<string, string>;
+  componentHierarchyMap: Map<string, IComponentDependencies>;
+  vueFilesPathMap: Map<string, string>;
   nativeWrappers: NativeWrappersMap;
   excludedComponents: string[];
   getPageDirs: () => string[];
@@ -36,8 +41,35 @@ interface DevProcessorOptions {
   loggerRef: { current: VuePomGeneratorLogger };
 }
 
+function replaceMapContents<K, V>(target: Map<K, V>, source: ReadonlyMap<K, V>) {
+  target.clear();
+  for (const [key, value] of source) {
+    target.set(key, value);
+  }
+}
+
+function removeComponentMetadata(
+  metadataMap: Map<string, Map<string, ElementMetadata>>,
+  semanticNameMap: Map<string, string>,
+  componentName: string,
+) {
+  const existingMetadata = metadataMap.get(componentName);
+  if (!existingMetadata) {
+    return;
+  }
+
+  for (const testId of existingMetadata.keys()) {
+    semanticNameMap.delete(testId);
+  }
+  metadataMap.delete(componentName);
+}
+
 export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOption {
   const {
+    elementMetadata: sharedElementMetadata,
+    semanticNameMap: sharedSemanticNameMap,
+    componentHierarchyMap: sharedComponentHierarchyMap,
+    vueFilesPathMap: sharedVueFilesPathMap,
     nativeWrappers,
     excludedComponents,
     getPageDirs,
@@ -221,7 +253,16 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
       // Build a complete snapshot once, then incrementally update on each changed .vue.
       let snapshotHierarchy = new Map<string, IComponentDependencies>();
       let snapshotVuePathMap = new Map<string, string>();
+      let snapshotElementMetadata = new Map<string, Map<string, ElementMetadata>>();
+      let snapshotSemanticNameMap = new Map<string, string>();
       const filePathToComponentName = new Map<string, string>();
+
+      const syncSharedStateFromSnapshot = () => {
+        replaceMapContents(sharedComponentHierarchyMap, snapshotHierarchy);
+        replaceMapContents(sharedVueFilesPathMap, snapshotVuePathMap);
+        replaceMapContents(sharedElementMetadata, snapshotElementMetadata);
+        replaceMapContents(sharedSemanticNameMap, snapshotSemanticNameMap);
+      };
 
       const createEmptyComponentDependencies = (absolutePath: string): IComponentDependencies => {
         const viewsDirAbs = path.resolve(getViewsDirAbs());
@@ -258,6 +299,8 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
         filePath: string,
         targetHierarchy: Map<string, IComponentDependencies> = snapshotHierarchy,
         targetVuePathMap: Map<string, string> = snapshotVuePathMap,
+        targetElementMetadata: Map<string, Map<string, ElementMetadata>> = snapshotElementMetadata,
+        targetSemanticNameMap: Map<string, string> = snapshotSemanticNameMap,
       ) => {
         const started = performance.now();
         const absolutePath = path.resolve(filePath);
@@ -272,6 +315,7 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
         }
 
         const template = extractTemplateFromSfc(sfc, absolutePath);
+        removeComponentMetadata(targetElementMetadata, targetSemanticNameMap, componentName);
         if (!template.trim()) {
           targetVuePathMap.set(componentName, absolutePath);
           targetHierarchy.set(componentName, createEmptyComponentDependencies(absolutePath));
@@ -290,7 +334,9 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
         const provisionalVuePathMap = new Map(targetVuePathMap);
         provisionalVuePathMap.set(componentName, absolutePath);
 
-        compilerDom.compile(template, {
+        compileWithMetadataExtractionManual(
+          template,
+          {
           filename: absolutePath,
           prefixIdentifiers: true,
           inline: isScriptSetup,
@@ -312,7 +358,12 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
               },
             ),
           ],
-        });
+          },
+          componentName,
+          targetElementMetadata,
+          targetSemanticNameMap,
+          testIdAttribute,
+        );
 
         targetVuePathMap.set(componentName, absolutePath);
         targetHierarchy.set(
@@ -327,6 +378,8 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
         const t0 = performance.now();
         const nextHierarchy = new Map<string, IComponentDependencies>();
         const nextVuePathMap = new Map<string, string>();
+        const nextElementMetadata = new Map<string, Map<string, ElementMetadata>>();
+        const nextSemanticNameMap = new Map<string, string>();
         filePathToComponentName.clear();
 
         let totalVueFiles = 0;
@@ -340,7 +393,13 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
           totalVueFiles += vueFiles.length;
 
           for (const file of vueFiles) {
-            const res = compileVueFileIntoSnapshot(file, nextHierarchy, nextVuePathMap);
+            const res = compileVueFileIntoSnapshot(
+              file,
+              nextHierarchy,
+              nextVuePathMap,
+              nextElementMetadata,
+              nextSemanticNameMap,
+            );
             if (res.compiled)
               compiledCount++;
           }
@@ -348,6 +407,9 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
 
         snapshotHierarchy = nextHierarchy;
         snapshotVuePathMap = nextVuePathMap;
+        snapshotElementMetadata = nextElementMetadata;
+        snapshotSemanticNameMap = nextSemanticNameMap;
+        syncSharedStateFromSnapshot();
 
         const t1 = performance.now();
         logInfo(`scan(${logLabel}): found ${totalVueFiles} .vue files in ${getSourceDirs().join(", ")}`);
@@ -405,10 +467,13 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
 
         const nextHierarchy = new Map(snapshotHierarchy);
         const nextVuePathMap = new Map(snapshotVuePathMap);
+        const nextElementMetadata = new Map(snapshotElementMetadata);
+        const nextSemanticNameMap = new Map(snapshotSemanticNameMap);
 
         for (const componentName of pendingDeletedComponents) {
           nextHierarchy.delete(componentName);
           nextVuePathMap.delete(componentName);
+          removeComponentMetadata(nextElementMetadata, nextSemanticNameMap, componentName);
         }
 
         const files = Array.from(pendingChangedVueFiles);
@@ -418,12 +483,21 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
 
         let compileMs = 0;
         for (const f of files) {
-          const res = compileVueFileIntoSnapshot(f, nextHierarchy, nextVuePathMap);
+          const res = compileVueFileIntoSnapshot(
+            f,
+            nextHierarchy,
+            nextVuePathMap,
+            nextElementMetadata,
+            nextSemanticNameMap,
+          );
           compileMs += res.ms;
         }
 
         snapshotHierarchy = nextHierarchy;
         snapshotVuePathMap = nextVuePathMap;
+        snapshotElementMetadata = nextElementMetadata;
+        snapshotSemanticNameMap = nextSemanticNameMap;
+        syncSharedStateFromSnapshot();
 
         const t1 = performance.now();
         await generateAggregatedFromSnapshot(reason);

--- a/plugin/support/virtual-modules.ts
+++ b/plugin/support/virtual-modules.ts
@@ -2,12 +2,18 @@ import type { Plugin } from "vite";
 
 import type { ElementMetadata } from "../../metadata-collector";
 import type { IComponentDependencies } from "../../utils";
-import { generatePomManifestModule, generateTestIdsModule } from "../../manifest-generator";
+import {
+  generatePomManifestModule,
+  generateTestIdsModule,
+  generateWebMcpManifestModule,
+} from "../../manifest-generator";
 
 const TEST_IDS_VIRTUAL_ID = "virtual:testids";
 const TEST_IDS_RESOLVED_ID = `\0${TEST_IDS_VIRTUAL_ID}`;
 const POM_MANIFEST_VIRTUAL_ID = "virtual:pom-manifest";
 const POM_MANIFEST_RESOLVED_ID = `\0${POM_MANIFEST_VIRTUAL_ID}`;
+const WEB_MCP_MANIFEST_VIRTUAL_ID = "virtual:webmcp-manifest";
+const WEB_MCP_MANIFEST_RESOLVED_ID = `\0${WEB_MCP_MANIFEST_VIRTUAL_ID}`;
 
 export function createTestIdsVirtualModulesPlugin(
   componentHierarchyMap: Map<string, IComponentDependencies>,
@@ -20,12 +26,16 @@ export function createTestIdsVirtualModulesPlugin(
         return TEST_IDS_RESOLVED_ID;
       if (id === POM_MANIFEST_VIRTUAL_ID)
         return POM_MANIFEST_RESOLVED_ID;
+      if (id === WEB_MCP_MANIFEST_VIRTUAL_ID)
+        return WEB_MCP_MANIFEST_RESOLVED_ID;
     },
     load(id) {
       if (id === TEST_IDS_RESOLVED_ID)
         return generateTestIdsModule(componentHierarchyMap, elementMetadata);
       if (id === POM_MANIFEST_RESOLVED_ID)
         return generatePomManifestModule(componentHierarchyMap, elementMetadata);
+      if (id === WEB_MCP_MANIFEST_RESOLVED_ID)
+        return generateWebMcpManifestModule(componentHierarchyMap, elementMetadata);
     },
   };
 }

--- a/plugin/support/virtual-modules.ts
+++ b/plugin/support/virtual-modules.ts
@@ -3,6 +3,7 @@ import type { Plugin } from "vite";
 import type { ElementMetadata } from "../../metadata-collector";
 import type { IComponentDependencies } from "../../utils";
 import {
+  generateWebMcpBridgeModule,
   generatePomManifestModule,
   generateTestIdsModule,
   generateWebMcpManifestModule,
@@ -14,10 +15,13 @@ const POM_MANIFEST_VIRTUAL_ID = "virtual:pom-manifest";
 const POM_MANIFEST_RESOLVED_ID = `\0${POM_MANIFEST_VIRTUAL_ID}`;
 const WEB_MCP_MANIFEST_VIRTUAL_ID = "virtual:webmcp-manifest";
 const WEB_MCP_MANIFEST_RESOLVED_ID = `\0${WEB_MCP_MANIFEST_VIRTUAL_ID}`;
+const WEB_MCP_BRIDGE_VIRTUAL_ID = "virtual:webmcp-bridge";
+const WEB_MCP_BRIDGE_RESOLVED_ID = `\0${WEB_MCP_BRIDGE_VIRTUAL_ID}`;
 
 export function createTestIdsVirtualModulesPlugin(
   componentHierarchyMap: Map<string, IComponentDependencies>,
   elementMetadata: Map<string, Map<string, ElementMetadata>>,
+  testIdAttribute: string = "data-testid",
 ): Plugin {
   return {
     name: "vue-pom-generator:virtual-testids",
@@ -28,6 +32,8 @@ export function createTestIdsVirtualModulesPlugin(
         return POM_MANIFEST_RESOLVED_ID;
       if (id === WEB_MCP_MANIFEST_VIRTUAL_ID)
         return WEB_MCP_MANIFEST_RESOLVED_ID;
+      if (id === WEB_MCP_BRIDGE_VIRTUAL_ID)
+        return WEB_MCP_BRIDGE_RESOLVED_ID;
     },
     load(id) {
       if (id === TEST_IDS_RESOLVED_ID)
@@ -36,6 +42,8 @@ export function createTestIdsVirtualModulesPlugin(
         return generatePomManifestModule(componentHierarchyMap, elementMetadata);
       if (id === WEB_MCP_MANIFEST_RESOLVED_ID)
         return generateWebMcpManifestModule(componentHierarchyMap, elementMetadata);
+      if (id === WEB_MCP_BRIDGE_RESOLVED_ID)
+        return generateWebMcpBridgeModule(componentHierarchyMap, elementMetadata, testIdAttribute);
     },
   };
 }

--- a/pom-discoverability.ts
+++ b/pom-discoverability.ts
@@ -16,6 +16,10 @@ function splitDiscoverabilityWords(value: string): string[] {
     .filter(Boolean);
 }
 
+export function splitPomDiscoverabilityWords(value: string): string[] {
+  return splitDiscoverabilityWords(value);
+}
+
 function joinDiscoverabilityWords(words: readonly string[]): string {
   return words.join(" ").replace(/\s+/g, " ").trim();
 }

--- a/tests/build-serve-parity.test.ts
+++ b/tests/build-serve-parity.test.ts
@@ -94,6 +94,10 @@ function makeDevPlugin(
   const existingIdBehaviorOverride = overrideEntries.existingIdBehavior as ResolvedGenerationSupportOptions["existingIdBehavior"] | undefined;
   delete overrideEntries.existingIdBehavior;
   return createDevProcessorPlugin({
+    elementMetadata: new Map(),
+    semanticNameMap: new Map(),
+    componentHierarchyMap: new Map(),
+    vueFilesPathMap: new Map(),
     nativeWrappers: {},
     excludedComponents: [],
     getPageDirs: () => ["src/views"],

--- a/tests/dev-plugin-options.test.ts
+++ b/tests/dev-plugin-options.test.ts
@@ -101,6 +101,10 @@ describe("dev processor option plumbing", () => {
       const basePageClassPath = path.join(projectRoot, "base-page.ts");
 
       const plugin = createDevProcessorPlugin({
+        elementMetadata: new Map(),
+        semanticNameMap: new Map(),
+        componentHierarchyMap: new Map(),
+        vueFilesPathMap: new Map(),
         nativeWrappers: {},
         excludedComponents: [],
         getPageDirs: () => ["src/views"],
@@ -188,6 +192,10 @@ describe("dev processor option plumbing", () => {
       );
 
       const plugin = createDevProcessorPlugin({
+        elementMetadata: new Map(),
+        semanticNameMap: new Map(),
+        componentHierarchyMap: new Map(),
+        vueFilesPathMap: new Map(),
         nativeWrappers: {},
         excludedComponents: [],
         getPageDirs: () => ["src/views"],
@@ -254,6 +262,10 @@ describe("dev processor option plumbing", () => {
       });
 
       const plugin = createDevProcessorPlugin({
+        elementMetadata: new Map(),
+        semanticNameMap: new Map(),
+        componentHierarchyMap: new Map(),
+        vueFilesPathMap: new Map(),
         nativeWrappers: {},
         excludedComponents: [],
         getPageDirs: () => ["src/views"],

--- a/tests/dev-plugin-state.test.ts
+++ b/tests/dev-plugin-state.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment node
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createDevProcessorPlugin } from "../plugin/support/dev-plugin";
+import { resolveGenerationSupportOptions } from "../plugin/resolved-generation-options";
+import { createTestIdsVirtualModulesPlugin } from "../plugin/support/virtual-modules";
+import type { ElementMetadata } from "../metadata-collector";
+import type { IComponentDependencies } from "../utils";
+
+vi.mock("../class-generation", () => ({
+  generateFiles: vi.fn(async () => undefined),
+}));
+
+function extractCode(loaded: unknown): string {
+  return typeof loaded === "string"
+    ? loaded
+    : (loaded && typeof loaded === "object" && "code" in loaded)
+      ? (loaded as { code: string }).code
+      : "";
+}
+
+function createDevServerStub() {
+  return {
+    watcher: {
+      add: vi.fn(),
+      on: vi.fn(),
+    },
+    config: {
+      logger: {
+        error: vi.fn(),
+      },
+    },
+    restart: vi.fn(),
+  };
+}
+
+describe("dev plugin shared state", () => {
+  it("populates virtual WebMCP modules from the full dev snapshot", async () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vue-pom-generator-dev-state-"));
+
+    try {
+      fs.mkdirSync(path.join(projectRoot, "src", "views"), { recursive: true });
+      fs.writeFileSync(
+        path.join(projectRoot, "src", "views", "LandingPage.vue"),
+        "<template><button>Request Access</button></template>",
+        "utf8",
+      );
+
+      const componentHierarchyMap = new Map<string, IComponentDependencies>();
+      const elementMetadata = new Map<string, Map<string, ElementMetadata>>();
+      const semanticNameMap = new Map<string, string>();
+      const vueFilesPathMap = new Map<string, string>();
+
+      const plugin = createDevProcessorPlugin({
+        elementMetadata,
+        semanticNameMap,
+        componentHierarchyMap,
+        vueFilesPathMap,
+        nativeWrappers: {},
+        excludedComponents: [],
+        getPageDirs: () => ["src/views"],
+        getComponentDirs: () => ["src/components"],
+        getLayoutDirs: () => ["src/layouts"],
+        getViewsDir: () => "src/views",
+        getSourceDirs: () => ["src/views", "src/components", "src/layouts"],
+        getWrapperSearchRoots: () => [],
+        projectRootRef: { current: projectRoot },
+        normalizedBasePagePath: path.posix.normalize(path.join(projectRoot, "base-page.ts")),
+        basePageClassPath: path.join(projectRoot, "base-page.ts"),
+        generation: resolveGenerationSupportOptions({
+          customPomAttachments: [],
+          nameCollisionBehavior: "error",
+          existingIdBehavior: "error",
+          testIdAttribute: "data-testid",
+          routerAwarePoms: false,
+        }),
+        getResolvedRouterEntry: () => undefined,
+        loggerRef: {
+          current: {
+            info() {},
+            debug() {},
+            warn() {},
+          },
+        },
+      });
+
+      const configureServer = (plugin as { configureServer?: (server: ReturnType<typeof createDevServerStub>) => Promise<void> | void }).configureServer;
+      if (!configureServer) {
+        throw new Error("Expected configureServer to exist");
+      }
+
+      await configureServer(createDevServerStub());
+
+      expect(componentHierarchyMap.has("LandingPage")).toBe(true);
+      expect(vueFilesPathMap.get("LandingPage")).toBe(path.join(projectRoot, "src", "views", "LandingPage.vue"));
+
+      const virtualModules = createTestIdsVirtualModulesPlugin(componentHierarchyMap, elementMetadata, "data-testid");
+      const resolvedBridge = await (virtualModules as { resolveId?: (id: string) => Promise<string | { id: string }> | string | { id: string } }).resolveId?.("virtual:webmcp-bridge");
+      const resolvedBridgeId = typeof resolvedBridge === "string" ? resolvedBridge : resolvedBridge?.id;
+      const loadedBridge = await (virtualModules as { load?: (id: string | undefined) => Promise<unknown> | unknown }).load?.(resolvedBridgeId);
+      const bridgeCode = extractCode(loadedBridge);
+
+      expect(bridgeCode).toContain("\"componentName\": \"LandingPage\"");
+      expect(bridgeCode).not.toContain("export const webMcpManifest = {};");
+    }
+    finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -890,6 +890,97 @@ describe('createTestIdTransform', () => {
     expect(deps?.generatedMethods?.has('clickImpersonateUser')).toBe(true)
   })
 
+  it('drops redundant click prefixes from direct wrapper handler names', () => {
+    const componentHierarchyMap = new Map<string, IComponentDependencies>()
+    const nativeWrappers: NativeWrappersMap = {
+      LoadButton: { role: 'button' },
+    }
+
+    expect(() => {
+      compileAndCaptureAst(
+        `
+          <LoadButton :handler="clickSave">
+            Save
+          </LoadButton>
+        `,
+        {
+          filename: '/src/views/SavePage.vue',
+          nodeTransforms: [createTestIdTransform('SavePage', componentHierarchyMap, nativeWrappers, [], '/src/views')],
+        },
+      )
+    }).not.toThrow()
+
+    const deps = componentHierarchyMap.get('SavePage') as IComponentDependencies | undefined
+    expect(deps).toBeTruthy()
+    expect(deps?.generatedMethods?.has('clickSave')).toBe(true)
+    expect(deps?.generatedMethods?.has('clickClickSave')).toBe(false)
+
+    const methodNames = Array.from(deps?.dataTestIdSet ?? [])
+      .map(e => e.pom?.methodName)
+      .filter((name): name is string => !!name)
+    expect(methodNames).toContain('Save')
+    expect(methodNames).not.toContain('ClickSave')
+  })
+
+  it('prefers author-facing alternates when a wrapper handler hint collapses to click', () => {
+    const componentHierarchyMap = new Map<string, IComponentDependencies>()
+    const nativeWrappers: NativeWrappersMap = {
+      LoadButton: { role: 'button' },
+    }
+
+    expect(() => {
+      compileAndCaptureAst(
+        `
+          <LoadButton :handler="clickClick">
+            Load
+          </LoadButton>
+        `,
+        {
+          filename: '/src/views/LoadPage.vue',
+          nodeTransforms: [createTestIdTransform('LoadPage', componentHierarchyMap, nativeWrappers, [], '/src/views')],
+        },
+      )
+    }).not.toThrow()
+
+    const deps = componentHierarchyMap.get('LoadPage') as IComponentDependencies | undefined
+    expect(deps).toBeTruthy()
+    expect(deps?.generatedMethods?.has('clickLoad')).toBe(true)
+    expect(deps?.generatedMethods?.has('clickClick')).toBe(false)
+
+    const methodNames = Array.from(deps?.dataTestIdSet ?? [])
+      .map(e => e.pom?.methodName)
+      .filter((name): name is string => !!name)
+    expect(methodNames).toContain('Load')
+    expect(methodNames).not.toContain('Click')
+  })
+
+  it('falls back to the component name for non-view click-only buttons', () => {
+    const componentHierarchyMap = new Map<string, IComponentDependencies>()
+
+    expect(() => {
+      compileAndCaptureAst(
+        `
+          <button @click="clickClick" />
+        `,
+        {
+          filename: '/src/components/LoadButton.vue',
+          nodeTransforms: [createTestIdTransform('LoadButton', componentHierarchyMap, {}, [], '/src/views')],
+        },
+      )
+    }).not.toThrow()
+
+    const deps = componentHierarchyMap.get('LoadButton') as IComponentDependencies | undefined
+    expect(deps).toBeTruthy()
+    expect(deps?.generatedMethods?.has('clickLoadButton')).toBe(true)
+    expect(deps?.generatedMethods?.has('clickButton')).toBe(false)
+    expect(deps?.generatedMethods?.has('clickClick')).toBe(false)
+
+    const methodNames = Array.from(deps?.dataTestIdSet ?? [])
+      .map(e => e.pom?.methodName)
+      .filter((name): name is string => !!name)
+    expect(methodNames).toContain('LoadButton')
+  })
+
   it('emits per-key click methods when v-for iterates a static literal list', () => {
     const componentHierarchyMap = new Map()
 

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -865,7 +865,7 @@ describe('createTestIdTransform', () => {
     expect(deps?.generatedMethods?.has('clickRefreshOauthAccessToken')).toBe(true)
   })
 
-  it('fails fast for button-like wrapper handlers that cannot produce a semantic name by default', () => {
+  it('accepts guarded button-like wrapper handlers in strict mode', () => {
     const componentHierarchyMap = new Map<string, IComponentDependencies>()
     const nativeWrappers: NativeWrappersMap = {
       LoadButton: { role: 'button' },
@@ -883,7 +883,11 @@ describe('createTestIdTransform', () => {
           nodeTransforms: [createTestIdTransform('RbacUserDetailsPage', componentHierarchyMap, nativeWrappers, [], '/src/views')],
         },
       )
-    }).toThrow(/move complex inline logic into a named function/i)
+    }).not.toThrow()
+
+    const deps = componentHierarchyMap.get('RbacUserDetailsPage') as IComponentDependencies | undefined
+    expect(deps).toBeTruthy()
+    expect(deps?.generatedMethods?.has('clickImpersonateUser')).toBe(true)
   })
 
   it('emits per-key click methods when v-for iterates a static literal list', () => {

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -6,6 +6,7 @@ import type {
   ElementNode,
   ForNode,
   RootNode,
+  SimpleExpressionNode,
   TemplateChildNode,
   TransformContext,
 } from "@vue/compiler-core";
@@ -429,13 +430,13 @@ describe("utils.ts coverage", () => {
     expect(info?.semanticNameHint).toBe("SetShowModalTrue");
   });
 
-  it("does not derive a :handler semanticNameHint from logical-expression arrow bodies", () => {
+  it("derives :handler semanticNameHint from logical-expression arrow bodies", () => {
     const root = parseTemplate(`
       <LoadButton :handler="() => person && impersonateUser(person.userId!)">Impersonate</LoadButton>
     `);
     const el = firstElement(root);
 
-    expect(nodeHandlerAttributeInfo(el)).toBeNull();
+    expect(nodeHandlerAttributeInfo(el)?.semanticNameHint).toBe("ImpersonateUser");
   });
 
   it("handles :key extraction paths", () => {
@@ -495,6 +496,18 @@ describe("utils.ts coverage", () => {
     const direct = firstElement(parseTemplate("<LoadButton :handler=\"approveChangeRequest\" />"));
     expect(nodeHandlerAttributeValue(direct)).toBe("ApproveChangeRequest");
     expect(nodeHandlerAttributeInfo(direct)?.mergeKey).toBe("handler:expr:approveChangeRequest");
+
+    const rewritten = firstElement(parseTemplate("<LoadButton :handler=\"saveNotes\" />"));
+    const rewrittenDirective = rewritten.props.find((prop): prop is DirectiveNode => {
+      return prop.type === NodeTypes.DIRECTIVE
+        && prop.name === "bind"
+        && prop.arg?.type === NodeTypes.SIMPLE_EXPRESSION
+        && prop.arg.content === "handler";
+    });
+    expect(rewrittenDirective?.exp?.type).toBe(NodeTypes.SIMPLE_EXPRESSION);
+    (rewrittenDirective?.exp as SimpleExpressionNode).content = "_unref(saveNotes)";
+    expect(nodeHandlerAttributeValue(rewritten)).toBe("SaveNotes");
+    expect(nodeHandlerAttributeInfo(rewritten)?.mergeKey).toBe("handler:expr:saveNotes");
 
     const goBackFalse = firstElement(parseTemplate("<LoadButton :handler=\"() => onSubmit({goBack:false})\" />"));
     const goBackTrue = firstElement(parseTemplate("<LoadButton :handler=\"() => onSubmit({goBack:true})\" />"));

--- a/tests/virtual-testids.test.ts
+++ b/tests/virtual-testids.test.ts
@@ -68,15 +68,26 @@ describe("virtual:testids", () => {
       ]), {
         filePath: "/repo/src/views/Foo.vue",
         isView: true,
-        pomExtraMethods: [{
-          kind: "click",
-          name: "clickFirstFoo",
-          selector: {
-            kind: "testId",
-            testId: createPomStringPattern("foo-${key}-button", "parameterized"),
+        pomExtraMethods: [
+          {
+            kind: "click",
+            name: "clickFirstFoo",
+            selector: {
+              kind: "testId",
+              testId: createPomStringPattern("foo-${key}-button", "parameterized"),
+            },
+            parameters: [createPomParameterSpec("key", "string")],
           },
-          parameters: [createPomParameterSpec("key", "string")],
-        }],
+          {
+            kind: "click",
+            name: "clickSetShowStickyActions",
+            selector: {
+              kind: "testId",
+              testId: createPomStringPattern("foo-save-button", "static"),
+            },
+            parameters: [],
+          },
+        ],
       })],
       ["Bar", createDependencies(new Set([
         {
@@ -104,6 +115,19 @@ describe("virtual:testids", () => {
       ]), {
         filePath: "/repo/src/views/BarPage.vue",
         isView: true,
+      })],
+      ["LoadButton", createDependencies(new Set([
+        {
+          selectorValue: createPomStringPattern("LoadButton-Click-button", "static"),
+          pom: {
+            nativeRole: "button",
+            methodName: "Click",
+            selector: createPomStringPattern("LoadButton-Click-button", "static"),
+            parameters: [],
+          },
+        },
+      ]), {
+        filePath: "/repo/src/components/LoadButton.vue",
       })],
       ["DynamicFormField", createDependencies(new Set([
         {
@@ -177,6 +201,16 @@ describe("virtual:testids", () => {
           staticTextContent: "Save",
         }],
       ])],
+      ["LoadButton", new Map([
+        ["LoadButton-Click-button", {
+          testId: "LoadButton-Click-button",
+          semanticName: "click",
+          tag: "button",
+          tagType: 0,
+          hasClickHandler: true,
+          staticTextContent: "Load",
+        }],
+      ])],
     ]);
 
     const plugin = createTestIdsVirtualModulesPlugin(componentHierarchyMap, elementMetadata, "data-qa");
@@ -211,7 +245,7 @@ describe("virtual:testids", () => {
     expect(code).toContain("\"sourceFile\": \"/repo/src/views/Foo.vue\"");
     expect(code).toContain("\"kind\": \"view\"");
     expect(code).toContain("\"semanticName\": \"foo item\"");
-    expect(code).toContain("\"toolName\": \"click_save_foo\"");
+    expect(code).toContain("\"toolName\": \"save_foo\"");
     expect(code).toContain("\"toolDescription\": \"Click save foo on Foo.\"");
     expect(code).toContain("\"toolAutoSubmit\": true");
     expect(code).toContain("\"toolParamDescription\": \"foo name\"");
@@ -243,12 +277,14 @@ describe("virtual:testids", () => {
     expect(webMcpManifestCode).not.toContain("export const pomManifest");
     expect(webMcpManifestCode).toContain("\"Bar\"");
     expect(webMcpManifestCode).toContain("\"BarPage\"");
-    expect(webMcpManifestCode).toContain("\"toolName\": \"click_foo_by_key\"");
-    expect(webMcpManifestCode).toContain("\"toolName\": \"click_first_foo\"");
-    expect(webMcpManifestCode).toContain("\"toolName\": \"click_save_foo\"");
-    expect(webMcpManifestCode).toContain("\"toolName\": \"click_bar\"");
-    expect(webMcpManifestCode).toContain("\"toolName\": \"click_refresh_bar_page\"");
-    expect(webMcpManifestCode).toContain("\"toolName\": \"set_dynamic_form_field\"");
+    expect(webMcpManifestCode).toContain("\"toolName\": \"foo_by_key\"");
+    expect(webMcpManifestCode).toContain("\"toolName\": \"first_foo\"");
+    expect(webMcpManifestCode).toContain("\"toolName\": \"save_foo\"");
+    expect(webMcpManifestCode).toContain("\"toolName\": \"load_button\"");
+    expect(webMcpManifestCode).toContain("\"toolName\": \"show_sticky_actions\"");
+    expect(webMcpManifestCode).toContain("\"toolName\": \"bar\"");
+    expect(webMcpManifestCode).toContain("\"toolName\": \"refresh_bar_page\"");
+    expect(webMcpManifestCode).toContain("\"toolName\": \"dynamic_form_field\"");
     expect(webMcpManifestCode).toContain("\"name\": \"fieldValueCheckbox\"");
     expect(webMcpManifestCode).toContain("\"name\": \"fieldValueInput\"");
     expect(webMcpManifestCode).toContain("\"name\": \"fieldValueRadio\"");

--- a/tests/virtual-testids.test.ts
+++ b/tests/virtual-testids.test.ts
@@ -91,6 +91,60 @@ describe("virtual:testids", () => {
       ]), {
         filePath: "/repo/src/components/Bar.vue",
       })],
+      ["BarPage", createDependencies(new Set([
+        {
+          selectorValue: createPomStringPattern("bar-page-refresh-button", "static"),
+          pom: {
+            nativeRole: "button",
+            methodName: "RefreshBarPage",
+            selector: createPomStringPattern("bar-page-refresh-button", "static"),
+            parameters: [],
+          },
+        },
+      ]), {
+        filePath: "/repo/src/views/BarPage.vue",
+        isView: true,
+      })],
+      ["DynamicFormField", createDependencies(new Set([
+        {
+          selectorValue: createPomStringPattern("DynamicFormField-FieldValue-checkbox", "static"),
+          pom: {
+            nativeRole: "checkbox",
+            methodName: "FieldValueCheckbox",
+            selector: createPomStringPattern("DynamicFormField-FieldValue-checkbox", "static"),
+            parameters: [],
+          },
+        },
+        {
+          selectorValue: createPomStringPattern("DynamicFormField-FieldValue-input", "static"),
+          pom: {
+            nativeRole: "input",
+            methodName: "FieldValue",
+            selector: createPomStringPattern("DynamicFormField-FieldValue-input", "static"),
+            parameters: [],
+          },
+        },
+        {
+          selectorValue: createPomStringPattern("DynamicFormField-FieldValue-input", "static"),
+          pom: {
+            nativeRole: "input",
+            methodName: "FieldValue",
+            selector: createPomStringPattern("DynamicFormField-FieldValue-input", "static"),
+            parameters: [],
+          },
+        },
+        {
+          selectorValue: createPomStringPattern("DynamicFormField-FieldValue-radio", "static"),
+          pom: {
+            nativeRole: "radio",
+            methodName: "FieldValueRadio",
+            selector: createPomStringPattern("DynamicFormField-FieldValue-radio", "static"),
+            parameters: [],
+          },
+        },
+      ]), {
+        filePath: "/repo/src/components/DynamicFormField.vue",
+      })],
     ]);
     const elementMetadata = new Map([
       ["Foo", new Map([
@@ -157,9 +211,9 @@ describe("virtual:testids", () => {
     expect(code).toContain("\"sourceFile\": \"/repo/src/views/Foo.vue\"");
     expect(code).toContain("\"kind\": \"view\"");
     expect(code).toContain("\"semanticName\": \"foo item\"");
-    expect(code).toContain("\"toolName\": \"foo\"");
-    expect(code).toContain("\"toolDescription\": \"Interact with Foo.\"");
-    expect(code).toContain("\"toolAutoSubmit\": false");
+    expect(code).toContain("\"toolName\": \"click_save_foo\"");
+    expect(code).toContain("\"toolDescription\": \"Click save foo on Foo.\"");
+    expect(code).toContain("\"toolAutoSubmit\": true");
     expect(code).toContain("\"toolParamDescription\": \"foo name\"");
     expect(code).toContain("\"toolParamDescription\": \"enabled\"");
     expect(code).toContain("\"name\": \"name\"");
@@ -188,8 +242,16 @@ describe("virtual:testids", () => {
     expect(webMcpManifestCode).not.toContain("export const testIdManifest");
     expect(webMcpManifestCode).not.toContain("export const pomManifest");
     expect(webMcpManifestCode).toContain("\"Bar\"");
-    expect(webMcpManifestCode).toContain("\"toolName\": \"foo\"");
-    expect(webMcpManifestCode).toContain("\"toolName\": \"bar\"");
+    expect(webMcpManifestCode).toContain("\"BarPage\"");
+    expect(webMcpManifestCode).toContain("\"toolName\": \"click_foo_by_key\"");
+    expect(webMcpManifestCode).toContain("\"toolName\": \"click_first_foo\"");
+    expect(webMcpManifestCode).toContain("\"toolName\": \"click_save_foo\"");
+    expect(webMcpManifestCode).toContain("\"toolName\": \"click_bar\"");
+    expect(webMcpManifestCode).toContain("\"toolName\": \"click_refresh_bar_page\"");
+    expect(webMcpManifestCode).toContain("\"toolName\": \"set_dynamic_form_field\"");
+    expect(webMcpManifestCode).toContain("\"name\": \"fieldValueCheckbox\"");
+    expect(webMcpManifestCode).toContain("\"name\": \"fieldValueInput\"");
+    expect(webMcpManifestCode).toContain("\"name\": \"fieldValueRadio\"");
     expect(webMcpManifestCode).toContain("\"toolAutoSubmit\": true");
     expect(webMcpManifestCode).toContain("\"toolParamDescription\": \"foo name\"");
     expect(webMcpManifestCode).toContain("\"name\": \"clickSaveFoo\"");
@@ -200,11 +262,15 @@ describe("virtual:testids", () => {
     const webMcpBridgeCode = extractCode(loadedWebMcpBridge);
 
     expect(webMcpBridgeCode).toContain("registerWebMcpManifestTools");
+    expect(webMcpBridgeCode).toContain("registerRouteScopedWebMcpManifestTools");
     expect(webMcpBridgeCode).toContain("registerGeneratedWebMcpTools");
+    expect(webMcpBridgeCode).toContain("options.router");
     expect(webMcpBridgeCode).toContain("webMcpTestIdAttribute");
     expect(webMcpBridgeCode).toContain("\"data-qa\"");
     expect(webMcpBridgeCode).toContain("@immense/vue-pom-generator/webmcp-runtime");
     expect(webMcpBridgeCode).toContain("import.meta.hot");
+    expect(webMcpBridgeCode).not.toContain("import type");
+    expect(webMcpBridgeCode).not.toContain("export type");
 
     componentHierarchyMap.set("Baz", createDependencies(new Set([
       {

--- a/tests/virtual-testids.test.ts
+++ b/tests/virtual-testids.test.ts
@@ -125,7 +125,7 @@ describe("virtual:testids", () => {
       ])],
     ]);
 
-    const plugin = createTestIdsVirtualModulesPlugin(componentHierarchyMap, elementMetadata);
+    const plugin = createTestIdsVirtualModulesPlugin(componentHierarchyMap, elementMetadata, "data-qa");
     expect(typeof plugin).toBe("object");
 
     const resolved = await (plugin as any).resolveId?.("virtual:testids");
@@ -159,11 +159,14 @@ describe("virtual:testids", () => {
     expect(code).toContain("\"semanticName\": \"foo item\"");
     expect(code).toContain("\"toolName\": \"foo\"");
     expect(code).toContain("\"toolDescription\": \"Interact with Foo.\"");
+    expect(code).toContain("\"toolAutoSubmit\": false");
     expect(code).toContain("\"toolParamDescription\": \"foo name\"");
     expect(code).toContain("\"toolParamDescription\": \"enabled\"");
     expect(code).toContain("\"name\": \"name\"");
     expect(code).toContain("\"name\": \"enabled\"");
     expect(code).toContain("\"name\": \"clickSaveFoo\"");
+    expect(code).toContain("\"selectorTemplateVariables\": [");
+    expect(code).toContain("\"key\"");
 
     const resolvedPomManifest = await (plugin as any).resolveId?.("virtual:pom-manifest");
     const resolvedPomManifestId = typeof resolvedPomManifest === "string" ? resolvedPomManifest : resolvedPomManifest?.id;
@@ -184,10 +187,24 @@ describe("virtual:testids", () => {
     expect(webMcpManifestCode).toContain("export const webMcpManifest");
     expect(webMcpManifestCode).not.toContain("export const testIdManifest");
     expect(webMcpManifestCode).not.toContain("export const pomManifest");
+    expect(webMcpManifestCode).toContain("\"Bar\"");
     expect(webMcpManifestCode).toContain("\"toolName\": \"foo\"");
+    expect(webMcpManifestCode).toContain("\"toolName\": \"bar\"");
+    expect(webMcpManifestCode).toContain("\"toolAutoSubmit\": true");
     expect(webMcpManifestCode).toContain("\"toolParamDescription\": \"foo name\"");
     expect(webMcpManifestCode).toContain("\"name\": \"clickSaveFoo\"");
-    expect(webMcpManifestCode).not.toContain("\"Bar\"");
+
+    const resolvedWebMcpBridge = await (plugin as any).resolveId?.("virtual:webmcp-bridge");
+    const resolvedWebMcpBridgeId = typeof resolvedWebMcpBridge === "string" ? resolvedWebMcpBridge : resolvedWebMcpBridge?.id;
+    const loadedWebMcpBridge = await (plugin as any).load?.(resolvedWebMcpBridgeId);
+    const webMcpBridgeCode = extractCode(loadedWebMcpBridge);
+
+    expect(webMcpBridgeCode).toContain("registerWebMcpManifestTools");
+    expect(webMcpBridgeCode).toContain("registerGeneratedWebMcpTools");
+    expect(webMcpBridgeCode).toContain("webMcpTestIdAttribute");
+    expect(webMcpBridgeCode).toContain("\"data-qa\"");
+    expect(webMcpBridgeCode).toContain("@immense/vue-pom-generator/webmcp-runtime");
+    expect(webMcpBridgeCode).toContain("import.meta.hot");
 
     componentHierarchyMap.set("Baz", createDependencies(new Set([
       {

--- a/tests/virtual-testids.test.ts
+++ b/tests/virtual-testids.test.ts
@@ -39,12 +39,29 @@ describe("virtual:testids", () => {
           },
         },
         {
-          selectorValue: createPomStringPattern("foo-root", "static"),
+          selectorValue: createPomStringPattern("foo-name-input", "static"),
+          pom: {
+            nativeRole: "input",
+            methodName: "FooName",
+            selector: createPomStringPattern("foo-name-input", "static"),
+            parameters: [],
+          },
+        },
+        {
+          selectorValue: createPomStringPattern("foo-enabled-checkbox", "static"),
+          pom: {
+            nativeRole: "checkbox",
+            methodName: "FooEnabled",
+            selector: createPomStringPattern("foo-enabled-checkbox", "static"),
+            parameters: [],
+          },
+        },
+        {
+          selectorValue: createPomStringPattern("foo-save-button", "static"),
           pom: {
             nativeRole: "button",
-            methodName: "FooRoot",
-            getterNameOverride: "FooRootButton",
-            selector: createPomStringPattern("foo-root", "static"),
+            methodName: "SaveFoo",
+            selector: createPomStringPattern("foo-save-button", "static"),
             parameters: [],
           },
         },
@@ -85,6 +102,26 @@ describe("virtual:testids", () => {
           hasClickHandler: true,
           staticTextContent: "Save",
         }],
+        ["foo-name-input", {
+          testId: "foo-name-input",
+          semanticName: "foo name",
+          tag: "input",
+          tagType: 0,
+        }],
+        ["foo-enabled-checkbox", {
+          testId: "foo-enabled-checkbox",
+          semanticName: "enabled",
+          tag: "input",
+          tagType: 0,
+        }],
+        ["foo-save-button", {
+          testId: "foo-save-button",
+          semanticName: "save foo",
+          tag: "button",
+          tagType: 0,
+          hasClickHandler: true,
+          staticTextContent: "Save",
+        }],
       ])],
     ]);
 
@@ -101,12 +138,15 @@ describe("virtual:testids", () => {
 
     expect(code).toContain("export const testIdManifest");
     expect(code).toContain("export const pomManifest");
+    expect(code).toContain("export const webMcpManifest");
 
     expect(code).toContain("\"Bar\"");
     expect(code).toContain("\"bar\"");
     expect(code).toContain("\"Foo\"");
     expect(code).toContain("\"foo-${key}-button\"");
-    expect(code).toContain("\"foo-root\"");
+    expect(code).toContain("\"foo-name-input\"");
+    expect(code).toContain("\"foo-enabled-checkbox\"");
+    expect(code).toContain("\"foo-save-button\"");
     expect(code).toContain("\"generatedPropertyName\": \"FooButton\"");
     expect(code).toContain("\"generatedActionNames\": [");
     expect(code).toContain("\"clickFooByKey\"");
@@ -117,6 +157,13 @@ describe("virtual:testids", () => {
     expect(code).toContain("\"sourceFile\": \"/repo/src/views/Foo.vue\"");
     expect(code).toContain("\"kind\": \"view\"");
     expect(code).toContain("\"semanticName\": \"foo item\"");
+    expect(code).toContain("\"toolName\": \"foo\"");
+    expect(code).toContain("\"toolDescription\": \"Interact with Foo.\"");
+    expect(code).toContain("\"toolParamDescription\": \"foo name\"");
+    expect(code).toContain("\"toolParamDescription\": \"enabled\"");
+    expect(code).toContain("\"name\": \"name\"");
+    expect(code).toContain("\"name\": \"enabled\"");
+    expect(code).toContain("\"name\": \"clickSaveFoo\"");
 
     const resolvedPomManifest = await (plugin as any).resolveId?.("virtual:pom-manifest");
     const resolvedPomManifestId = typeof resolvedPomManifest === "string" ? resolvedPomManifest : resolvedPomManifest?.id;
@@ -128,6 +175,19 @@ describe("virtual:testids", () => {
     expect(pomManifestCode).toContain("\"generatedPropertyName\": \"FooButton\"");
     expect(pomManifestCode).toContain("\"locatorDescription\": \"Foo button\"");
     expect(pomManifestCode).toContain("\"accessibleNameSource\": \"text\"");
+
+    const resolvedWebMcpManifest = await (plugin as any).resolveId?.("virtual:webmcp-manifest");
+    const resolvedWebMcpManifestId = typeof resolvedWebMcpManifest === "string" ? resolvedWebMcpManifest : resolvedWebMcpManifest?.id;
+    const loadedWebMcpManifest = await (plugin as any).load?.(resolvedWebMcpManifestId);
+    const webMcpManifestCode = extractCode(loadedWebMcpManifest);
+
+    expect(webMcpManifestCode).toContain("export const webMcpManifest");
+    expect(webMcpManifestCode).not.toContain("export const testIdManifest");
+    expect(webMcpManifestCode).not.toContain("export const pomManifest");
+    expect(webMcpManifestCode).toContain("\"toolName\": \"foo\"");
+    expect(webMcpManifestCode).toContain("\"toolParamDescription\": \"foo name\"");
+    expect(webMcpManifestCode).toContain("\"name\": \"clickSaveFoo\"");
+    expect(webMcpManifestCode).not.toContain("\"Bar\"");
 
     componentHierarchyMap.set("Baz", createDependencies(new Set([
       {

--- a/tests/webmcp-client.test.ts
+++ b/tests/webmcp-client.test.ts
@@ -6,6 +6,8 @@ import { buildWebMcpManifest } from "../manifest-generator";
 import { createPomParameterSpec } from "../pom-params";
 import { createPomStringPattern } from "../pom-patterns";
 import type { IComponentDependencies } from "../utils";
+import type { WebMcpModelContextLike } from "../webmcp-runtime";
+import { registerWebMcpManifestTools } from "../webmcp-runtime";
 
 const TEST_INIT_OPTIONS = {
   transport: {
@@ -17,33 +19,19 @@ const TEST_INIT_OPTIONS = {
   installTestingShim: true,
 } as const;
 
-type ModelContextToolSchema = {
-  type: string;
-  properties?: Record<string, {
-    type: string;
-    description?: string;
-  }>;
-};
-
-type ModelContextTool = {
-  name: string;
-  description: string;
-  inputSchema?: ModelContextToolSchema;
-};
-
-type ModelContextLike = {
-  registerTool(tool: {
+type TestingModelContext = WebMcpModelContextLike & {
+  listTools(): Array<{
     name: string;
     description: string;
-    inputSchema?: ModelContextToolSchema;
-    execute(args: Record<string, unknown>): Promise<{
-      content: Array<{
+    inputSchema?: {
+      type: string;
+      properties?: Record<string, {
         type: string;
-        text: string;
+        description?: string;
+        enum?: string[];
       }>;
-    }>;
-  }): unknown;
-  listTools(): ModelContextTool[];
+    };
+  }>;
   callTool(params: {
     name: string;
     arguments: Record<string, unknown>;
@@ -56,6 +44,7 @@ type ModelContextLike = {
 };
 
 afterEach(() => {
+  document.body.innerHTML = "";
   try {
     cleanupWebModelContext();
   }
@@ -75,8 +64,8 @@ function createDependencies(testIds: IComponentDependencies["dataTestIdSet"], op
   };
 }
 
-function requireModelContext(): ModelContextLike {
-  const modelContext = (navigator as Navigator & { modelContext?: ModelContextLike }).modelContext;
+function requireModelContext(): TestingModelContext {
+  const modelContext = (navigator as Navigator & { modelContext?: TestingModelContext }).modelContext;
   if (!modelContext) {
     throw new Error("Expected navigator.modelContext to be available");
   }
@@ -86,6 +75,20 @@ function requireModelContext(): ModelContextLike {
 
 function buildFixtureManifest() {
   const componentHierarchyMap = new Map<string, IComponentDependencies>([
+    ["Bar", createDependencies(new Set([
+      {
+        selectorValue: createPomStringPattern("bar", "static"),
+        pom: {
+          nativeRole: "button",
+          methodName: "Bar",
+          selector: createPomStringPattern("bar", "static"),
+          parameters: [],
+        },
+      },
+    ]), {
+      filePath: "/repo/src/components/Bar.vue",
+      isView: false,
+    })],
     ["Foo", createDependencies(new Set([
       {
         selectorValue: createPomStringPattern("foo-name-input", "static"),
@@ -106,6 +109,15 @@ function buildFixtureManifest() {
         },
       },
       {
+        selectorValue: createPomStringPattern("foo-${key}-notes-input", "parameterized"),
+        pom: {
+          nativeRole: "input",
+          methodName: "FooNotesByKey",
+          selector: createPomStringPattern("foo-${key}-notes-input", "parameterized"),
+          parameters: [createPomParameterSpec("key", "string")],
+        },
+      },
+      {
         selectorValue: createPomStringPattern("foo-save-button", "static"),
         pom: {
           nativeRole: "button",
@@ -123,9 +135,21 @@ function buildFixtureManifest() {
           parameters: [createPomParameterSpec("key", "string")],
         },
       },
-    ]))],
+    ]), {
+      filePath: "/repo/src/views/Foo.vue",
+      isView: true,
+    })],
   ]);
   const elementMetadata = new Map([
+    ["Bar", new Map([
+      ["bar", {
+        testId: "bar",
+        semanticName: "bar",
+        tag: "button",
+        tagType: 0,
+        hasClickHandler: true,
+      }],
+    ])],
     ["Foo", new Map([
       ["foo-name-input", {
         testId: "foo-name-input",
@@ -136,6 +160,12 @@ function buildFixtureManifest() {
       ["foo-enabled-checkbox", {
         testId: "foo-enabled-checkbox",
         semanticName: "enabled",
+        tag: "input",
+        tagType: 0,
+      }],
+      ["foo-${key}-notes-input", {
+        testId: "foo-${key}-notes-input",
+        semanticName: "foo notes",
         tag: "input",
         tagType: 0,
       }],
@@ -159,64 +189,72 @@ function buildFixtureManifest() {
   return buildWebMcpManifest(componentHierarchyMap, elementMetadata);
 }
 
-function buildInputSchema(tool: {
-  params: Array<{ name: string; role: string; toolParamDescription: string }>;
-}) {
-  return {
-    type: "object",
-    properties: Object.fromEntries(tool.params.map(param => [
-      param.name,
-      {
-        type: param.role === "checkbox" ? "boolean" : "string",
-        description: param.toolParamDescription,
-      },
-    ])),
-    required: [],
-    additionalProperties: false,
-  } as const;
-}
-
-function registerManifestTools(modelContext: ModelContextLike, manifest: ReturnType<typeof buildFixtureManifest>): void {
-  for (const component of Object.values(manifest)) {
-    for (const tool of component.tools) {
-      modelContext.registerTool({
-        name: tool.toolName,
-        description: tool.toolDescription,
-        inputSchema: buildInputSchema(tool),
-        async execute(args: Record<string, unknown>) {
-          return {
-            content: [{
-              type: "text",
-              text: JSON.stringify({
-                component: component.componentName,
-                tool: tool.toolName,
-                args,
-                actions: tool.actions.map(action => action.name),
-              }),
-            }],
-          };
-        },
-      });
-    }
-  }
-}
-
-describe("webMcpManifest with a WebMCP runtime", () => {
-  it("registers manifest-derived tools and executes them through navigator.modelContext", async () => {
+describe("webMcp runtime bridge", () => {
+  it("registers manifest-derived tools and drives DOM controls through navigator.modelContext", async () => {
     const webMcpManifest = buildFixtureManifest();
+
+    document.body.innerHTML = `
+      <div>
+        <button type="button" data-qa="bar">Bar</button>
+        <form>
+          <input data-qa="foo-name-input" />
+          <input type="checkbox" data-qa="foo-enabled-checkbox" />
+          <input data-qa="foo-alpha-notes-input" />
+          <button type="button" data-qa="foo-save-button">Save</button>
+          <button type="button" data-qa="foo-alpha-button">Row</button>
+        </form>
+      </div>
+    `;
+
+    const barButton = document.querySelector("[data-qa='bar']") as HTMLButtonElement;
+    const nameInput = document.querySelector("[data-qa='foo-name-input']") as HTMLInputElement;
+    const enabledCheckbox = document.querySelector("[data-qa='foo-enabled-checkbox']") as HTMLInputElement;
+    const notesInput = document.querySelector("[data-qa='foo-alpha-notes-input']") as HTMLInputElement;
+    const saveButton = document.querySelector("[data-qa='foo-save-button']") as HTMLButtonElement;
+    const rowButton = document.querySelector("[data-qa='foo-alpha-button']") as HTMLButtonElement;
+
+    let barClicks = 0;
+    let saveClicks = 0;
+    let rowClicks = 0;
+    barButton.addEventListener("click", () => {
+      barClicks += 1;
+    });
+    saveButton.addEventListener("click", () => {
+      saveClicks += 1;
+    });
+    rowButton.addEventListener("click", () => {
+      rowClicks += 1;
+    });
 
     cleanupWebModelContext();
     initializeWebModelContext(TEST_INIT_OPTIONS);
 
     const modelContext = requireModelContext();
-    registerManifestTools(modelContext, webMcpManifest);
+    const registration = registerWebMcpManifestTools({
+      manifest: webMcpManifest,
+      modelContext,
+      root: document.body,
+      testIdAttribute: "data-qa",
+    });
+
+    expect([...registration.toolNames].sort()).toEqual(["bar", "foo"]);
 
     const tools = modelContext.listTools();
+    const barTool = tools.find(tool => tool.name === "bar");
+    const fooTool = tools.find(tool => tool.name === "foo");
 
-    expect(tools).toHaveLength(1);
-    expect(tools[0]).toMatchObject({
+    expect(tools).toHaveLength(2);
+    expect(barTool).toMatchObject({
+      name: "bar",
+      description: "Interact with Bar. Calling this tool clicks clickBar.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+      },
+    });
+    expect(fooTool).toMatchObject({
       name: "foo",
-      description: "Interact with Foo.",
+      description: "Interact with Foo. Use submitAction to choose one of: clickFooByKey, clickSaveFoo.",
       inputSchema: {
         type: "object",
         properties: {
@@ -224,35 +262,67 @@ describe("webMcpManifest with a WebMCP runtime", () => {
             type: "boolean",
             description: "enabled",
           },
+          key: {
+            type: "string",
+            description: "Variable used to resolve parameterized generated selectors.",
+          },
           name: {
             type: "string",
             description: "foo name",
+          },
+          notes: {
+            type: "string",
+            description: "foo notes",
+          },
+          submitAction: {
+            type: "string",
+            description: "Optional generated action to click after applying parameters.",
+            enum: ["clickFooByKey", "clickSaveFoo"],
           },
         },
       },
     });
 
-    const result = await modelContext.callTool({
+    const barResult = await modelContext.callTool({
+      name: "bar",
+      arguments: {},
+    });
+    expect(barClicks).toBe(1);
+    expect(barResult.content[0]?.type).toBe("text");
+    expect(JSON.parse(barResult.content[0]?.text ?? "null")).toEqual({
+      component: "Bar",
+      tool: "bar",
+      appliedParameters: [],
+      selectorVariablesUsed: [],
+      action: "clickBar",
+    });
+
+    const fooResult = await modelContext.callTool({
       name: "foo",
       arguments: {
         name: "Ayla",
         enabled: true,
+        key: "alpha",
+        notes: "hello",
+        submitAction: "clickFooByKey",
       },
     });
 
-    expect(result).toMatchObject({
-      content: [{
-        type: "text",
-        text: JSON.stringify({
-          component: "Foo",
-          tool: "foo",
-          args: {
-            name: "Ayla",
-            enabled: true,
-          },
-          actions: ["clickFooByKey", "clickSaveFoo"],
-        }),
-      }],
+    expect(nameInput.value).toBe("Ayla");
+    expect(enabledCheckbox.checked).toBe(true);
+    expect(notesInput.value).toBe("hello");
+    expect(saveClicks).toBe(0);
+    expect(rowClicks).toBe(1);
+    expect(fooResult.content[0]?.type).toBe("text");
+    expect(JSON.parse(fooResult.content[0]?.text ?? "null")).toEqual({
+      component: "Foo",
+      tool: "foo",
+      appliedParameters: ["enabled", "name", "notes"],
+      selectorVariablesUsed: ["key"],
+      action: "clickFooByKey",
     });
+
+    registration.unregister();
+    expect(modelContext.listTools()).toHaveLength(0);
   });
 });

--- a/tests/webmcp-client.test.ts
+++ b/tests/webmcp-client.test.ts
@@ -6,8 +6,8 @@ import { buildWebMcpManifest } from "../manifest-generator";
 import { createPomParameterSpec } from "../pom-params";
 import { createPomStringPattern } from "../pom-patterns";
 import type { IComponentDependencies } from "../utils";
-import type { WebMcpModelContextLike } from "../webmcp-runtime";
-import { registerWebMcpManifestTools } from "../webmcp-runtime";
+import type { WebMcpModelContextLike, WebMcpRouteLike, WebMcpRouterLike } from "../webmcp-runtime";
+import { registerRouteScopedWebMcpManifestTools, registerWebMcpManifestTools } from "../webmcp-runtime";
 
 const TEST_INIT_OPTIONS = {
   transport: {
@@ -73,8 +73,65 @@ function requireModelContext(): TestingModelContext {
   return modelContext;
 }
 
+function createTestingRouter(initialRoute: WebMcpRouteLike, options: { withReady?: boolean } = {}) {
+  let afterEachHandler: ((to: WebMcpRouteLike) => void) | null = null;
+  const currentRoute = { value: initialRoute };
+  let resolveReady: (() => void) | null = null;
+  const readyPromise = new Promise<void>((resolve) => {
+    resolveReady = resolve;
+  });
+  const router: WebMcpRouterLike = {
+    currentRoute,
+    afterEach(guard) {
+      afterEachHandler = guard;
+      return () => {
+        if (afterEachHandler === guard) {
+          afterEachHandler = null;
+        }
+      };
+    },
+    ...(options.withReady
+      ? {
+          isReady() {
+            return readyPromise;
+          },
+        }
+      : {}),
+  };
+
+  return {
+    router,
+    navigate(nextRoute: WebMcpRouteLike, notify = true) {
+      currentRoute.value = nextRoute;
+      if (notify) {
+        afterEachHandler?.(nextRoute);
+      }
+    },
+    resolveReady() {
+      resolveReady?.();
+    },
+  };
+}
+
+function createMatchedRoute(componentName: string): WebMcpRouteLike {
+  return {
+    matched: [{
+      components: {
+        default: {
+          name: componentName,
+        },
+      },
+    }],
+  };
+}
+
 function buildFixtureManifest() {
   const componentHierarchyMap = new Map<string, IComponentDependencies>([
+    ["FooRoute", createDependencies(new Set(), {
+      filePath: "/repo/src/views/FooRoute.vue",
+      isView: true,
+      usedComponentSet: new Set(["Foo"]),
+    })],
     ["Bar", createDependencies(new Set([
       {
         selectorValue: createPomStringPattern("bar", "static"),
@@ -237,24 +294,25 @@ describe("webMcp runtime bridge", () => {
       testIdAttribute: "data-qa",
     });
 
-    expect([...registration.toolNames].sort()).toEqual(["bar", "foo"]);
+    expect([...registration.toolNames].sort()).toEqual(["click_bar", "click_foo_by_key", "click_save_foo"]);
 
     const tools = modelContext.listTools();
-    const barTool = tools.find(tool => tool.name === "bar");
-    const fooTool = tools.find(tool => tool.name === "foo");
+    const barTool = tools.find(tool => tool.name === "click_bar");
+    const fooByKeyTool = tools.find(tool => tool.name === "click_foo_by_key");
+    const saveFooTool = tools.find(tool => tool.name === "click_save_foo");
 
-    expect(tools).toHaveLength(2);
+    expect(tools).toHaveLength(3);
     expect(barTool).toMatchObject({
-      name: "bar",
-      description: "Interact with Bar. Calling this tool clicks clickBar.",
+      name: "click_bar",
+      description: "Click bar on Bar.",
       inputSchema: {
         type: "object",
         properties: {},
       },
     });
-    expect(fooTool).toMatchObject({
-      name: "foo",
-      description: "Interact with Foo. Use submitAction to choose one of: clickFooByKey, clickSaveFoo.",
+    expect(fooByKeyTool).toMatchObject({
+      name: "click_foo_by_key",
+      description: "Click foo by key on Foo.",
       inputSchema: {
         type: "object",
         properties: {
@@ -274,37 +332,56 @@ describe("webMcp runtime bridge", () => {
             type: "string",
             description: "foo notes",
           },
-          submitAction: {
+        },
+      },
+    });
+    expect(saveFooTool).toMatchObject({
+      name: "click_save_foo",
+      description: "Click save foo on Foo.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          enabled: {
+            type: "boolean",
+            description: "enabled",
+          },
+          key: {
             type: "string",
-            description: "Optional generated action to click after applying parameters.",
-            enum: ["clickFooByKey", "clickSaveFoo"],
+            description: "Variable used to resolve parameterized generated selectors.",
+          },
+          name: {
+            type: "string",
+            description: "foo name",
+          },
+          notes: {
+            type: "string",
+            description: "foo notes",
           },
         },
       },
     });
 
     const barResult = await modelContext.callTool({
-      name: "bar",
+      name: "click_bar",
       arguments: {},
     });
     expect(barClicks).toBe(1);
     expect(barResult.content[0]?.type).toBe("text");
     expect(JSON.parse(barResult.content[0]?.text ?? "null")).toEqual({
       component: "Bar",
-      tool: "bar",
+      tool: "click_bar",
       appliedParameters: [],
       selectorVariablesUsed: [],
       action: "clickBar",
     });
 
-    const fooResult = await modelContext.callTool({
-      name: "foo",
+    const fooByKeyResult = await modelContext.callTool({
+      name: "click_foo_by_key",
       arguments: {
         name: "Ayla",
         enabled: true,
         key: "alpha",
         notes: "hello",
-        submitAction: "clickFooByKey",
       },
     });
 
@@ -313,14 +390,118 @@ describe("webMcp runtime bridge", () => {
     expect(notesInput.value).toBe("hello");
     expect(saveClicks).toBe(0);
     expect(rowClicks).toBe(1);
-    expect(fooResult.content[0]?.type).toBe("text");
-    expect(JSON.parse(fooResult.content[0]?.text ?? "null")).toEqual({
+    expect(fooByKeyResult.content[0]?.type).toBe("text");
+    expect(JSON.parse(fooByKeyResult.content[0]?.text ?? "null")).toEqual({
       component: "Foo",
-      tool: "foo",
+      tool: "click_foo_by_key",
       appliedParameters: ["enabled", "name", "notes"],
       selectorVariablesUsed: ["key"],
       action: "clickFooByKey",
     });
+
+    const saveFooResult = await modelContext.callTool({
+      name: "click_save_foo",
+      arguments: {
+        name: "Bea",
+      },
+    });
+
+    expect(nameInput.value).toBe("Bea");
+    expect(saveClicks).toBe(1);
+    expect(rowClicks).toBe(1);
+    expect(saveFooResult.content[0]?.type).toBe("text");
+    expect(JSON.parse(saveFooResult.content[0]?.text ?? "null")).toEqual({
+      component: "Foo",
+      tool: "click_save_foo",
+      appliedParameters: ["name"],
+      selectorVariablesUsed: [],
+      action: "clickSaveFoo",
+    });
+
+    registration.unregister();
+    expect(modelContext.listTools()).toHaveLength(0);
+  });
+
+  it("can scope manifest-derived tools to the active route view tree", () => {
+    const webMcpManifest = buildFixtureManifest();
+
+    document.body.innerHTML = `
+      <div>
+        <button type="button" data-qa="bar">Bar</button>
+        <form>
+          <input data-qa="foo-name-input" />
+          <input type="checkbox" data-qa="foo-enabled-checkbox" />
+          <input data-qa="foo-alpha-notes-input" />
+          <button type="button" data-qa="foo-save-button">Save</button>
+          <button type="button" data-qa="foo-alpha-button">Row</button>
+        </form>
+      </div>
+    `;
+
+    cleanupWebModelContext();
+    initializeWebModelContext(TEST_INIT_OPTIONS);
+
+    const modelContext = requireModelContext();
+    const { router, navigate } = createTestingRouter(createMatchedRoute("FooRoute"));
+    const registration = registerRouteScopedWebMcpManifestTools({
+      manifest: webMcpManifest,
+      modelContext,
+      router,
+      root: document.body,
+      testIdAttribute: "data-qa",
+    });
+
+    expect([...registration.toolNames].sort()).toEqual(["click_foo_by_key", "click_save_foo"]);
+    expect(modelContext.listTools().map(tool => tool.name).sort()).toEqual(["click_foo_by_key", "click_save_foo"]);
+
+    navigate(createMatchedRoute("Bar"));
+
+    expect([...registration.toolNames].sort()).toEqual(["click_bar"]);
+    expect(modelContext.listTools().map(tool => tool.name).sort()).toEqual(["click_bar"]);
+
+    navigate(createMatchedRoute("MissingRoute"));
+
+    expect(registration.toolNames).toEqual([]);
+    expect(modelContext.listTools()).toEqual([]);
+
+    registration.unregister();
+    expect(modelContext.listTools()).toHaveLength(0);
+  });
+
+  it("refreshes route-scoped tools after router.isReady resolves initial navigation", async () => {
+    const webMcpManifest = buildFixtureManifest();
+
+    document.body.innerHTML = `
+      <div>
+        <form>
+          <input data-qa="foo-name-input" />
+          <button type="button" data-qa="foo-save-button">Save</button>
+          <button type="button" data-qa="foo-alpha-button">Row</button>
+        </form>
+      </div>
+    `;
+
+    cleanupWebModelContext();
+    initializeWebModelContext(TEST_INIT_OPTIONS);
+
+    const modelContext = requireModelContext();
+    const { router, navigate, resolveReady } = createTestingRouter({ matched: [] }, { withReady: true });
+    const registration = registerRouteScopedWebMcpManifestTools({
+      manifest: webMcpManifest,
+      modelContext,
+      router,
+      root: document.body,
+      testIdAttribute: "data-qa",
+    });
+
+    expect(registration.toolNames).toEqual([]);
+
+    navigate(createMatchedRoute("FooRoute"), false);
+    resolveReady();
+    await Promise.resolve();
+
+    expect([...registration.toolNames].sort()).toEqual(["click_foo_by_key", "click_save_foo"]);
+    expect(modelContext.listTools().map(tool => tool.name).sort()).toEqual(["click_foo_by_key", "click_save_foo"]);
 
     registration.unregister();
     expect(modelContext.listTools()).toHaveLength(0);

--- a/tests/webmcp-client.test.ts
+++ b/tests/webmcp-client.test.ts
@@ -294,16 +294,16 @@ describe("webMcp runtime bridge", () => {
       testIdAttribute: "data-qa",
     });
 
-    expect([...registration.toolNames].sort()).toEqual(["click_bar", "click_foo_by_key", "click_save_foo"]);
+    expect([...registration.toolNames].sort()).toEqual(["bar", "foo_by_key", "save_foo"]);
 
     const tools = modelContext.listTools();
-    const barTool = tools.find(tool => tool.name === "click_bar");
-    const fooByKeyTool = tools.find(tool => tool.name === "click_foo_by_key");
-    const saveFooTool = tools.find(tool => tool.name === "click_save_foo");
+    const barTool = tools.find(tool => tool.name === "bar");
+    const fooByKeyTool = tools.find(tool => tool.name === "foo_by_key");
+    const saveFooTool = tools.find(tool => tool.name === "save_foo");
 
     expect(tools).toHaveLength(3);
     expect(barTool).toMatchObject({
-      name: "click_bar",
+      name: "bar",
       description: "Click bar on Bar.",
       inputSchema: {
         type: "object",
@@ -311,7 +311,7 @@ describe("webMcp runtime bridge", () => {
       },
     });
     expect(fooByKeyTool).toMatchObject({
-      name: "click_foo_by_key",
+      name: "foo_by_key",
       description: "Click foo by key on Foo.",
       inputSchema: {
         type: "object",
@@ -336,7 +336,7 @@ describe("webMcp runtime bridge", () => {
       },
     });
     expect(saveFooTool).toMatchObject({
-      name: "click_save_foo",
+      name: "save_foo",
       description: "Click save foo on Foo.",
       inputSchema: {
         type: "object",
@@ -362,21 +362,21 @@ describe("webMcp runtime bridge", () => {
     });
 
     const barResult = await modelContext.callTool({
-      name: "click_bar",
+      name: "bar",
       arguments: {},
     });
     expect(barClicks).toBe(1);
     expect(barResult.content[0]?.type).toBe("text");
     expect(JSON.parse(barResult.content[0]?.text ?? "null")).toEqual({
       component: "Bar",
-      tool: "click_bar",
+      tool: "bar",
       appliedParameters: [],
       selectorVariablesUsed: [],
       action: "clickBar",
     });
 
     const fooByKeyResult = await modelContext.callTool({
-      name: "click_foo_by_key",
+      name: "foo_by_key",
       arguments: {
         name: "Ayla",
         enabled: true,
@@ -393,14 +393,14 @@ describe("webMcp runtime bridge", () => {
     expect(fooByKeyResult.content[0]?.type).toBe("text");
     expect(JSON.parse(fooByKeyResult.content[0]?.text ?? "null")).toEqual({
       component: "Foo",
-      tool: "click_foo_by_key",
+      tool: "foo_by_key",
       appliedParameters: ["enabled", "name", "notes"],
       selectorVariablesUsed: ["key"],
       action: "clickFooByKey",
     });
 
     const saveFooResult = await modelContext.callTool({
-      name: "click_save_foo",
+      name: "save_foo",
       arguments: {
         name: "Bea",
       },
@@ -412,7 +412,7 @@ describe("webMcp runtime bridge", () => {
     expect(saveFooResult.content[0]?.type).toBe("text");
     expect(JSON.parse(saveFooResult.content[0]?.text ?? "null")).toEqual({
       component: "Foo",
-      tool: "click_save_foo",
+      tool: "save_foo",
       appliedParameters: ["name"],
       selectorVariablesUsed: [],
       action: "clickSaveFoo",
@@ -451,13 +451,13 @@ describe("webMcp runtime bridge", () => {
       testIdAttribute: "data-qa",
     });
 
-    expect([...registration.toolNames].sort()).toEqual(["click_foo_by_key", "click_save_foo"]);
-    expect(modelContext.listTools().map(tool => tool.name).sort()).toEqual(["click_foo_by_key", "click_save_foo"]);
+    expect([...registration.toolNames].sort()).toEqual(["foo_by_key", "save_foo"]);
+    expect(modelContext.listTools().map(tool => tool.name).sort()).toEqual(["foo_by_key", "save_foo"]);
 
     navigate(createMatchedRoute("Bar"));
 
-    expect([...registration.toolNames].sort()).toEqual(["click_bar"]);
-    expect(modelContext.listTools().map(tool => tool.name).sort()).toEqual(["click_bar"]);
+    expect([...registration.toolNames].sort()).toEqual(["bar"]);
+    expect(modelContext.listTools().map(tool => tool.name).sort()).toEqual(["bar"]);
 
     navigate(createMatchedRoute("MissingRoute"));
 
@@ -500,8 +500,8 @@ describe("webMcp runtime bridge", () => {
     resolveReady();
     await Promise.resolve();
 
-    expect([...registration.toolNames].sort()).toEqual(["click_foo_by_key", "click_save_foo"]);
-    expect(modelContext.listTools().map(tool => tool.name).sort()).toEqual(["click_foo_by_key", "click_save_foo"]);
+    expect([...registration.toolNames].sort()).toEqual(["foo_by_key", "save_foo"]);
+    expect(modelContext.listTools().map(tool => tool.name).sort()).toEqual(["foo_by_key", "save_foo"]);
 
     registration.unregister();
     expect(modelContext.listTools()).toHaveLength(0);

--- a/tests/webmcp-client.test.ts
+++ b/tests/webmcp-client.test.ts
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupWebModelContext, initializeWebModelContext } from "@mcp-b/global";
+
+import { buildWebMcpManifest } from "../manifest-generator";
+import { createPomParameterSpec } from "../pom-params";
+import { createPomStringPattern } from "../pom-patterns";
+import type { IComponentDependencies } from "../utils";
+
+const TEST_INIT_OPTIONS = {
+  transport: {
+    tabServer: {
+      allowedOrigins: [window.location.origin] as string[],
+    },
+    iframeServer: false,
+  },
+  installTestingShim: true,
+} as const;
+
+type ModelContextToolSchema = {
+  type: string;
+  properties?: Record<string, {
+    type: string;
+    description?: string;
+  }>;
+};
+
+type ModelContextTool = {
+  name: string;
+  description: string;
+  inputSchema?: ModelContextToolSchema;
+};
+
+type ModelContextLike = {
+  registerTool(tool: {
+    name: string;
+    description: string;
+    inputSchema?: ModelContextToolSchema;
+    execute(args: Record<string, unknown>): Promise<{
+      content: Array<{
+        type: string;
+        text: string;
+      }>;
+    }>;
+  }): unknown;
+  listTools(): ModelContextTool[];
+  callTool(params: {
+    name: string;
+    arguments: Record<string, unknown>;
+  }): Promise<{
+    content: Array<{
+      type: string;
+      text: string;
+    }>;
+  }>;
+};
+
+afterEach(() => {
+  try {
+    cleanupWebModelContext();
+  }
+  catch {
+    // Best-effort cleanup only.
+  }
+});
+
+function createDependencies(testIds: IComponentDependencies["dataTestIdSet"], options: Partial<IComponentDependencies> = {}): IComponentDependencies {
+  return {
+    filePath: options.filePath ?? "/repo/src/views/Foo.vue",
+    childrenComponentSet: options.childrenComponentSet ?? new Set<string>(),
+    usedComponentSet: options.usedComponentSet ?? new Set<string>(),
+    dataTestIdSet: testIds,
+    isView: options.isView ?? true,
+    pomExtraMethods: options.pomExtraMethods,
+  };
+}
+
+function requireModelContext(): ModelContextLike {
+  const modelContext = (navigator as Navigator & { modelContext?: ModelContextLike }).modelContext;
+  if (!modelContext) {
+    throw new Error("Expected navigator.modelContext to be available");
+  }
+
+  return modelContext;
+}
+
+function buildFixtureManifest() {
+  const componentHierarchyMap = new Map<string, IComponentDependencies>([
+    ["Foo", createDependencies(new Set([
+      {
+        selectorValue: createPomStringPattern("foo-name-input", "static"),
+        pom: {
+          nativeRole: "input",
+          methodName: "FooName",
+          selector: createPomStringPattern("foo-name-input", "static"),
+          parameters: [],
+        },
+      },
+      {
+        selectorValue: createPomStringPattern("foo-enabled-checkbox", "static"),
+        pom: {
+          nativeRole: "checkbox",
+          methodName: "FooEnabled",
+          selector: createPomStringPattern("foo-enabled-checkbox", "static"),
+          parameters: [],
+        },
+      },
+      {
+        selectorValue: createPomStringPattern("foo-save-button", "static"),
+        pom: {
+          nativeRole: "button",
+          methodName: "SaveFoo",
+          selector: createPomStringPattern("foo-save-button", "static"),
+          parameters: [],
+        },
+      },
+      {
+        selectorValue: createPomStringPattern("foo-${key}-button", "parameterized"),
+        pom: {
+          nativeRole: "button",
+          methodName: "FooByKey",
+          selector: createPomStringPattern("foo-${key}-button", "parameterized"),
+          parameters: [createPomParameterSpec("key", "string")],
+        },
+      },
+    ]))],
+  ]);
+  const elementMetadata = new Map([
+    ["Foo", new Map([
+      ["foo-name-input", {
+        testId: "foo-name-input",
+        semanticName: "foo name",
+        tag: "input",
+        tagType: 0,
+      }],
+      ["foo-enabled-checkbox", {
+        testId: "foo-enabled-checkbox",
+        semanticName: "enabled",
+        tag: "input",
+        tagType: 0,
+      }],
+      ["foo-save-button", {
+        testId: "foo-save-button",
+        semanticName: "save foo",
+        tag: "button",
+        tagType: 0,
+        hasClickHandler: true,
+      }],
+      ["foo-${key}-button", {
+        testId: "foo-${key}-button",
+        semanticName: "foo item",
+        tag: "button",
+        tagType: 0,
+        hasClickHandler: true,
+      }],
+    ])],
+  ]);
+
+  return buildWebMcpManifest(componentHierarchyMap, elementMetadata);
+}
+
+function buildInputSchema(tool: {
+  params: Array<{ name: string; role: string; toolParamDescription: string }>;
+}) {
+  return {
+    type: "object",
+    properties: Object.fromEntries(tool.params.map(param => [
+      param.name,
+      {
+        type: param.role === "checkbox" ? "boolean" : "string",
+        description: param.toolParamDescription,
+      },
+    ])),
+    required: [],
+    additionalProperties: false,
+  } as const;
+}
+
+function registerManifestTools(modelContext: ModelContextLike, manifest: ReturnType<typeof buildFixtureManifest>): void {
+  for (const component of Object.values(manifest)) {
+    for (const tool of component.tools) {
+      modelContext.registerTool({
+        name: tool.toolName,
+        description: tool.toolDescription,
+        inputSchema: buildInputSchema(tool),
+        async execute(args: Record<string, unknown>) {
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({
+                component: component.componentName,
+                tool: tool.toolName,
+                args,
+                actions: tool.actions.map(action => action.name),
+              }),
+            }],
+          };
+        },
+      });
+    }
+  }
+}
+
+describe("webMcpManifest with a WebMCP runtime", () => {
+  it("registers manifest-derived tools and executes them through navigator.modelContext", async () => {
+    const webMcpManifest = buildFixtureManifest();
+
+    cleanupWebModelContext();
+    initializeWebModelContext(TEST_INIT_OPTIONS);
+
+    const modelContext = requireModelContext();
+    registerManifestTools(modelContext, webMcpManifest);
+
+    const tools = modelContext.listTools();
+
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toMatchObject({
+      name: "foo",
+      description: "Interact with Foo.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          enabled: {
+            type: "boolean",
+            description: "enabled",
+          },
+          name: {
+            type: "string",
+            description: "foo name",
+          },
+        },
+      },
+    });
+
+    const result = await modelContext.callTool({
+      name: "foo",
+      arguments: {
+        name: "Ayla",
+        enabled: true,
+      },
+    });
+
+    expect(result).toMatchObject({
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          component: "Foo",
+          tool: "foo",
+          args: {
+            name: "Ayla",
+            enabled: true,
+          },
+          actions: ["clickFooByKey", "clickSaveFoo"],
+        }),
+      }],
+    });
+  });
+});

--- a/transform.ts
+++ b/transform.ts
@@ -1464,10 +1464,21 @@ export function createTestIdTransform(
 
     if (handlerInfo) {
       const testId = getHandlerAttributeValueDataTestId(handlerInfo.semanticNameHint);
+      const handlerHintCandidates = [
+        handlerInfo.semanticNameHint,
+        getStaticIdOrNameHint(element),
+        innerText,
+        conditionalHint,
+      ]
+        .map(value => (value ?? "").trim())
+        .filter(Boolean)
+        .filter((value, index, values) => values.indexOf(value) === index);
+      const [semanticNameHint, ...semanticNameHintAlternates] = handlerHintCandidates;
 
       applyResolvedDataTestIdForElement({
         preferredGeneratedValue: testId,
-        semanticNameHint: handlerInfo.semanticNameHint || conditionalHint || undefined,
+        semanticNameHint,
+        semanticNameHintAlternates: semanticNameHintAlternates.length ? semanticNameHintAlternates : undefined,
         pomMergeKey: handlerInfo.mergeKey,
       });
       return;

--- a/utils.ts
+++ b/utils.ts
@@ -2908,7 +2908,82 @@ export function applyResolvedDataTestId(args: {
   const selectorPattern = createPomStringPattern(formattedDataTestIdForPom, selectorPatternKind);
   const selectorIsParameterized = selectorPatternKind === "parameterized";
 
-  const deriveBaseMethodNameFromHint = (hint: string | undefined) => {
+  const getPrimaryActionTransportPrefix = () => {
+    if (targetPageObjectModelClass) {
+      return "GoTo";
+    }
+
+    switch (normalizedRole) {
+      case "input":
+        return "Type";
+      case "select":
+      case "vselect":
+      case "radio":
+        return "Select";
+      default:
+        return "Click";
+    }
+  };
+
+  const hasPascalWordPrefix = (value: string, prefix: string) => {
+    if (!value.startsWith(prefix)) {
+      return false;
+    }
+    if (value.length === prefix.length) {
+      return true;
+    }
+    const nextCode = value.charCodeAt(prefix.length);
+    return isAsciiUppercaseLetterCode(nextCode) || isAsciiDigitCode(nextCode);
+  };
+
+  const stripRedundantPrimaryActionPrefix = (value: string) => {
+    const prefix = getPrimaryActionTransportPrefix();
+    let remaining = value;
+    while (remaining && hasPascalWordPrefix(remaining, prefix)) {
+      remaining = remaining.slice(prefix.length);
+    }
+    return remaining;
+  };
+
+  const getRoleFallbackMethodName = () => {
+    const roleName = upperFirst(toPascalCase(normalizedRole));
+    return roleName || "Element";
+  };
+
+  const getComponentFallbackMethodName = () => {
+    if (args.dependencies.isView) {
+      return null;
+    }
+
+    const componentName = safeMethodNameFromParts([args.parentComponentName]);
+    if (componentName === "Element") {
+      return null;
+    }
+
+    const fallbackSuffixes = targetPageObjectModelClass
+      ? ["Link", "Button"]
+      : normalizedRole === "input"
+        ? ["Input", "Field", "Editor"]
+        : normalizedRole === "select" || normalizedRole === "vselect"
+          ? ["Select", "Dropdown", "Picker"]
+          : normalizedRole === "radio"
+            ? ["Radio", "RadioGroup"]
+            : normalizedRole === "checkbox"
+              ? ["Checkbox"]
+              : normalizedRole === "toggle"
+                ? ["Toggle", "Switch"]
+                : ["Button", "Link"];
+
+    return fallbackSuffixes.some(suffix => componentName.endsWith(suffix) && componentName.length > suffix.length)
+      ? componentName
+      : null;
+  };
+
+  const getPreferredFallbackMethodName = () => {
+    return getComponentFallbackMethodName() ?? getRoleFallbackMethodName();
+  };
+
+  const deriveBaseMethodNameFromHint = (hint: string | undefined, options?: { allowRoleFallback?: boolean }): string | null => {
     const hintRaw = (hint ?? "").trim();
     const trimEdgeSeparators = (value: string): string => {
       if (!value) {
@@ -2930,19 +3005,23 @@ export function applyResolvedDataTestId(args: {
 
     // If we have no hint, fall back to a role-based name.
     if (!hintClean) {
-      const roleName = upperFirst(toPascalCase(normalizedRole));
-      return roleName || "Element";
+      return options?.allowRoleFallback === false ? null : getPreferredFallbackMethodName();
     }
 
     // Convert to a safe identifier-ish PascalCase.
     // We intentionally do NOT split/interpret `data-testid` values here.
-    const name = toPascalCase(hintClean);
-    const safe = safeMethodNameFromParts([name]);
-    return safe || "Element";
+    const name = safeMethodNameFromParts([toPascalCase(hintClean)]);
+    const strippedName = stripRedundantPrimaryActionPrefix(name);
+    if (!strippedName) {
+      return options?.allowRoleFallback === false ? null : getPreferredFallbackMethodName();
+    }
+
+    const safe = safeMethodNameFromParts([strippedName]);
+    return safe || (options?.allowRoleFallback === false ? null : getPreferredFallbackMethodName());
   };
 
-  const deriveBaseMethodName = () => {
-    return deriveBaseMethodNameFromHint(args.semanticNameHint);
+  const deriveBaseMethodName = (): string => {
+    return deriveBaseMethodNameFromHint(args.semanticNameHint) ?? getPreferredFallbackMethodName();
   };
 
   // Ensure the primary method name is unique within the class.
@@ -3111,9 +3190,7 @@ export function applyResolvedDataTestId(args: {
   let collisionDetails: { getterName: string; actionName: string } | null = null;
   let collisionHint: string | null = null;
 
-  // Try each hint candidate. In error mode, we only try suffix=1 for each hint.
-  for (const hint of hintCandidates) {
-    const base = hint ? deriveBaseMethodNameFromHint(hint) : deriveBaseMethodName();
+  const tryClaimMethodNameForBase = (base: string, hint: string | undefined) => {
     let suffix = 1;
 
     while (true) {
@@ -3153,7 +3230,7 @@ export function applyResolvedDataTestId(args: {
       if (conflicts && nameCollisionBehavior === "error" && tryMergeWithExistingPrimary(actionName)) {
         methodName = candidate;
         mergedIntoExisting = true;
-        break;
+        return true;
       }
 
       // In strict mode (error), prefer trying role-suffixed candidates over hint alternates
@@ -3197,7 +3274,7 @@ export function applyResolvedDataTestId(args: {
             getterNameOverride = chosenGetterOverrideWithRoleSuffix;
             reservedMembers.add(chosenGetterNameWithRoleSuffix);
             reservedMembers.add(actionNameWithRoleSuffix);
-            break;
+            return true;
           }
         }
       }
@@ -3221,7 +3298,7 @@ export function applyResolvedDataTestId(args: {
 
         reservedMembers.add(chosenGetterName);
         reservedMembers.add(actionName);
-        break;
+        return true;
       }
 
       if (!collisionDetails) {
@@ -3231,15 +3308,37 @@ export function applyResolvedDataTestId(args: {
 
       // In error mode, do not suffix; instead, try the next hint candidate.
       if (nameCollisionBehavior === "error") {
-        break;
+        return false;
       }
 
       suffix += 1;
+    }
+  };
+
+  // Try each hint candidate. In error mode, we only try suffix=1 for each hint.
+  let attemptedUsableHint = false;
+  let skippedUnusableHint = false;
+  for (const hint of hintCandidates) {
+    const base = hint
+      ? deriveBaseMethodNameFromHint(hint, { allowRoleFallback: false })
+      : deriveBaseMethodName();
+    if (!base) {
+      skippedUnusableHint = true;
+      continue;
+    }
+
+    attemptedUsableHint = true;
+    if (tryClaimMethodNameForBase(base, hint)) {
+      break;
     }
 
     if (methodName) {
       break;
     }
+  }
+
+  if (!methodName && skippedUnusableHint && !attemptedUsableHint) {
+    tryClaimMethodNameForBase(deriveBaseMethodName(), undefined);
   }
 
   if (!methodName) {

--- a/utils.ts
+++ b/utils.ts
@@ -1253,14 +1253,15 @@ export function nodeHandlerAttributeInfo(node: ElementNode): HandlerAttributeInf
   }
 
   const exp = handlerDirective.exp as SimpleExpressionNode | CompoundExpressionNode;
-  const source = getVueExpressionSource(exp, "content", "compiled");
-  if (!source) {
+  const transformedSource = getVueExpressionSource(exp, "content", "compiled");
+  const authorSource = getVueExpressionSource(exp, "loc", "content", "compiled");
+  if (!authorSource) {
     return null;
   }
 
   // Use a source-based key so identical handler expressions can converge.
   // NOTE: We intentionally do not normalize via regex/string parsing helpers in this package.
-  const mergeKey = `handler:expr:${source}`;
+  const mergeKey = `handler:expr:${authorSource}`;
 
   const expr = tryGetDirectiveBabelAst(handlerDirective, {
     preferredViews: ["content", "compiled"],
@@ -1269,10 +1270,9 @@ export function nodeHandlerAttributeInfo(node: ElementNode): HandlerAttributeInf
     // That is fine for Vue codegen, but our semantic-name extraction needs a normal Babel parse tree.
     preferExistingAst: false,
   });
-  if (!expr) {
-    // Even if parsing fails, still provide a merge identity.
-    return null;
-  }
+  const fallbackExpr = transformedSource !== authorSource
+    ? tryParseBabelExpressionFromSource(authorSource, ["typescript", "jsx"])
+    : null;
 
   const isNodeType = (node: object | null, type: string): node is { type: string } => {
     return node !== null && (node as { type?: string }).type === type;
@@ -1355,6 +1355,25 @@ export function nodeHandlerAttributeInfo(node: ElementNode): HandlerAttributeInf
     return typeof n.computed === "boolean"
       && typeof n.key === "object" && n.key !== null
       && typeof n.value === "object" && n.value !== null;
+  };
+  const isLogicalExpressionNode = (node: object | null): node is { type: "LogicalExpression"; right: object } => {
+    if (!isNodeType(node, "LogicalExpression"))
+      return false;
+    const n = node as { right?: object };
+    return typeof n.right === "object" && n.right !== null;
+  };
+  const isConditionalExpressionNode = (node: object | null): node is { type: "ConditionalExpression"; consequent: object; alternate: object } => {
+    if (!isNodeType(node, "ConditionalExpression"))
+      return false;
+    const n = node as { consequent?: object; alternate?: object };
+    return typeof n.consequent === "object" && n.consequent !== null
+      && typeof n.alternate === "object" && n.alternate !== null;
+  };
+  const isSequenceExpressionNode = (node: object | null): node is { type: "SequenceExpression"; expressions: object[] } => {
+    if (!isNodeType(node, "SequenceExpression"))
+      return false;
+    const n = node as { expressions?: object[] };
+    return Array.isArray(n.expressions);
   };
 
   const getLastIdentifierFromMemberChain = (node: object | null): string | null => {
@@ -1565,75 +1584,112 @@ export function nodeHandlerAttributeInfo(node: ElementNode): HandlerAttributeInf
     return limited.map(p => `${toPascalCase(p.key)}${p.value}`).join("");
   };
 
-  // :handler="myHandler" or :handler="obj.myHandler"
-  const direct = getLastIdentifierFromMemberChain(expr);
-  if (direct) {
-    return { semanticNameHint: toPascalCase(direct), mergeKey };
-  }
+  const tryFromCallExpression = (call: object | null) => {
+    const resolvedCall = isAwaitExpressionNode(call)
+      ? call.argument
+      : call;
+    if (!isCallExpressionNode(resolvedCall)) {
+      return null;
+    }
+    const name = getLastIdentifierFromMemberChain(resolvedCall.callee);
+    if (!name) {
+      return null;
+    }
+    const suffix = getStableSuffixFromCall(resolvedCall);
+    const semanticNameHint = suffix
+      ? `${toPascalCase(name)}${suffix}`
+      : toPascalCase(name);
+    return semanticNameHint;
+  };
 
-  // :handler="(x) => myHandler(x)" or :handler="() => obj.myHandler()"
-  if (isArrowFunctionExpressionNode(expr)) {
-    const body = expr.body;
+  const tryDeriveSemanticName = (candidate: object | null): string | null => {
+    if (!candidate) {
+      return null;
+    }
 
-    const tryFromCallExpression = (call: object | null) => {
-      const resolvedCall = isAwaitExpressionNode(call)
-        ? call.argument
-        : call;
-      if (!isCallExpressionNode(resolvedCall)) {
-        return null;
-      }
-      const name = getLastIdentifierFromMemberChain(resolvedCall.callee);
-      if (!name) {
-        return null;
-      }
-      const suffix = getStableSuffixFromCall(resolvedCall);
-      const semanticNameHint = suffix
-        ? `${toPascalCase(name)}${suffix}`
-        : toPascalCase(name);
-      return semanticNameHint;
-    };
-
-    // ArrowFunctionExpression with implicit return call: () => fn(...)
-    const directCall = tryFromCallExpression(body);
+    const directCall = tryFromCallExpression(candidate);
     if (directCall) {
-      return { semanticNameHint: directCall, mergeKey };
+      return directCall;
     }
 
-    // ArrowFunctionExpression with assignment body: () => someFlag = true
-    if (isAssignmentExpressionNode(body)) {
-      const lhs = getAssignmentTargetName(body.left);
+    if (isAssignmentExpressionNode(candidate)) {
+      const lhs = getAssignmentTargetName(candidate.left);
       if (lhs) {
-        const rhs = stableWordFromValue(body.right);
-        const semanticNameHint = `Set${toPascalCase(lhs)}${rhs ?? ""}`;
-        return { semanticNameHint, mergeKey };
+        const rhs = stableWordFromValue(candidate.right);
+        return `Set${toPascalCase(lhs)}${rhs ?? ""}`;
       }
+      return null;
     }
 
-    // ArrowFunctionExpression block: () => { return fn(...) } or () => { fn(...) }
-    if (isBlockStatementNode(body)) {
-      const stmts = body.body ?? [];
-      if (stmts.length > 0) {
-        const firstStmt = stmts[0] as object;
-        if (isReturnStatementNode(firstStmt)) {
-          const fromReturn = tryFromCallExpression(firstStmt.argument ?? null);
-          if (fromReturn) {
-            return { semanticNameHint: fromReturn, mergeKey };
-          }
-        }
-        if (isExpressionStatementNode(firstStmt)) {
-          const fromExpr = tryFromCallExpression(firstStmt.expression ?? null);
-          if (fromExpr) {
-            return { semanticNameHint: fromExpr, mergeKey };
-          }
-        }
-      }
+    if (isLogicalExpressionNode(candidate)) {
+      return tryDeriveSemanticName(candidate.right);
     }
 
-    // Fallback: () => myHandler
-    const bodyName = getLastIdentifierFromMemberChain(body);
+    if (isConditionalExpressionNode(candidate)) {
+      const consequent = tryDeriveSemanticName(candidate.consequent);
+      const alternate = tryDeriveSemanticName(candidate.alternate);
+      if (consequent && alternate && consequent === alternate) {
+        return consequent;
+      }
+      return consequent ?? alternate ?? null;
+    }
+
+    if (isSequenceExpressionNode(candidate)) {
+      const last = candidate.expressions.at(-1) ?? null;
+      return tryDeriveSemanticName(last);
+    }
+
+    const bodyName = getLastIdentifierFromMemberChain(candidate);
     if (bodyName) {
-      return { semanticNameHint: toPascalCase(bodyName), mergeKey };
+      return toPascalCase(bodyName);
     }
+
+    return null;
+  };
+
+  const resolveSemanticName = (candidateExpr: object | null): string | null => {
+    if (!candidateExpr) {
+      return null;
+    }
+
+    const direct = getLastIdentifierFromMemberChain(candidateExpr);
+    if (direct) {
+      return toPascalCase(direct);
+    }
+
+    if (isArrowFunctionExpressionNode(candidateExpr)) {
+      const body = candidateExpr.body;
+      const directSemanticName = tryDeriveSemanticName(body);
+      if (directSemanticName) {
+        return directSemanticName;
+      }
+
+      if (isBlockStatementNode(body)) {
+        const stmts = body.body ?? [];
+        if (stmts.length > 0) {
+          const firstStmt = stmts[0] as object;
+          if (isReturnStatementNode(firstStmt)) {
+            const fromReturn = tryDeriveSemanticName(firstStmt.argument ?? null);
+            if (fromReturn) {
+              return fromReturn;
+            }
+          }
+          if (isExpressionStatementNode(firstStmt)) {
+            const fromExpr = tryDeriveSemanticName(firstStmt.expression ?? null);
+            if (fromExpr) {
+              return fromExpr;
+            }
+          }
+        }
+      }
+    }
+
+    return null;
+  };
+
+  const semanticNameHint = resolveSemanticName(expr) ?? resolveSemanticName(fallbackExpr);
+  if (semanticNameHint) {
+    return { semanticNameHint, mergeKey };
   }
 
   return null;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         index: "./index.ts",
+        "webmcp-runtime": "./webmcp-runtime.ts",
         // eslint sub-export: import "@immense/vue-pom-generator/eslint"
         "eslint/index": "./eslint/index.ts",
       },

--- a/webmcp-runtime.ts
+++ b/webmcp-runtime.ts
@@ -1,0 +1,782 @@
+export type WebMcpSelectorPatternKind = "static" | "parameterized";
+export type WebMcpRuntimeParamRole = "input" | "select" | "vselect" | "checkbox" | "radio";
+
+export interface WebMcpManifestParameter {
+  name: string;
+  role: WebMcpRuntimeParamRole | string;
+  testId: string;
+  selectorPatternKind: WebMcpSelectorPatternKind;
+  selectorTemplateVariables: string[];
+  toolParamDescription: string;
+  generatedPropertyName: string | null;
+}
+
+export interface WebMcpManifestAction {
+  name: string;
+  testId: string;
+  description: string;
+  selectorPatternKind: WebMcpSelectorPatternKind;
+  selectorTemplateVariables: string[];
+  targetPageObjectModelClass?: string;
+}
+
+export interface WebMcpManifestTool {
+  toolName: string;
+  toolDescription: string;
+  toolAutoSubmit: boolean;
+  params: WebMcpManifestParameter[];
+  actions: WebMcpManifestAction[];
+}
+
+export interface WebMcpManifestComponent {
+  componentName: string;
+  className: string;
+  sourceFile: string;
+  kind: "component" | "view";
+  tools: WebMcpManifestTool[];
+}
+
+export type WebMcpManifest = Record<string, WebMcpManifestComponent>;
+
+export interface WebMcpJsonSchemaProperty {
+  type: "string" | "boolean";
+  description?: string;
+  enum?: string[];
+}
+
+export interface WebMcpJsonSchemaObject {
+  type: "object";
+  properties: Record<string, WebMcpJsonSchemaProperty>;
+  required: string[];
+  additionalProperties: false;
+}
+
+export interface WebMcpToolResponse {
+  content: Array<{
+    type: "text";
+    text: string;
+  }>;
+  isError?: boolean;
+}
+
+export interface WebMcpModelContextLike {
+  registerTool(tool: {
+    name: string;
+    description: string;
+    inputSchema?: WebMcpJsonSchemaObject;
+    execute(args: Record<string, unknown>): Promise<WebMcpToolResponse> | WebMcpToolResponse;
+  }): unknown;
+  unregisterTool(name: string): void;
+}
+
+export interface RegisterWebMcpManifestToolsOptions {
+  manifest: WebMcpManifest;
+  modelContext?: WebMcpModelContextLike;
+  root?: Document | DocumentFragment | Element;
+  testIdAttribute?: string;
+  actionParameterName?: string;
+}
+
+export interface RegisteredWebMcpToolsHandle {
+  toolNames: string[];
+  unregister(): void;
+}
+
+const DEFAULT_TEST_ID_ATTRIBUTE = "data-testid";
+const DEFAULT_ACTION_PARAMETER_NAME = "submitAction";
+const SELECTOR_VARIABLE_DESCRIPTION = "Variable used to resolve parameterized generated selectors.";
+
+function isElementNode(value: unknown): value is Element {
+  return typeof Element !== "undefined" && value instanceof Element;
+}
+
+function isHtmlElement(value: unknown): value is HTMLElement {
+  return typeof HTMLElement !== "undefined" && value instanceof HTMLElement;
+}
+
+function isHtmlInputElement(value: unknown): value is HTMLInputElement {
+  return typeof HTMLInputElement !== "undefined" && value instanceof HTMLInputElement;
+}
+
+function isHtmlTextAreaElement(value: unknown): value is HTMLTextAreaElement {
+  return typeof HTMLTextAreaElement !== "undefined" && value instanceof HTMLTextAreaElement;
+}
+
+function isHtmlSelectElement(value: unknown): value is HTMLSelectElement {
+  return typeof HTMLSelectElement !== "undefined" && value instanceof HTMLSelectElement;
+}
+
+function getNormalizedTestIdAttribute(value: string | undefined): string {
+  return (value ?? DEFAULT_TEST_ID_ATTRIBUTE).trim() || DEFAULT_TEST_ID_ATTRIBUTE;
+}
+
+function getRootDocument(root?: Document | DocumentFragment | Element): Document {
+  if (root && "ownerDocument" in root && root.ownerDocument) {
+    return root.ownerDocument;
+  }
+
+  if (typeof document !== "undefined") {
+    return document;
+  }
+
+  throw new Error("[vue-pom-generator] WebMCP runtime bridge requires a browser document.");
+}
+
+function getSearchRoot(root?: Document | DocumentFragment | Element): Document | DocumentFragment | Element {
+  return root ?? getRootDocument();
+}
+
+function getMatchingElements(
+  root: Document | DocumentFragment | Element,
+  attributeName: string,
+  testId: string,
+): Element[] {
+  const matches: Element[] = [];
+
+  if (isElementNode(root) && root.getAttribute(attributeName) === testId) {
+    matches.push(root);
+  }
+
+  for (const candidate of Array.from(root.querySelectorAll("*"))) {
+    if (candidate.getAttribute(attributeName) === testId) {
+      matches.push(candidate);
+    }
+  }
+
+  return matches;
+}
+
+function getUniqueElementByTestId(args: {
+  root: Document | DocumentFragment | Element;
+  testIdAttribute: string;
+  testId: string;
+  toolName: string;
+}): Element {
+  const matches = getMatchingElements(args.root, args.testIdAttribute, args.testId);
+  if (matches.length === 1) {
+    return matches[0];
+  }
+
+  if (matches.length === 0) {
+    throw new Error(
+      `[vue-pom-generator] WebMCP tool ${JSON.stringify(args.toolName)} could not find `
+      + `an element with ${JSON.stringify(args.testIdAttribute)}=${JSON.stringify(args.testId)}.`
+    );
+  }
+
+  throw new Error(
+    `[vue-pom-generator] WebMCP tool ${JSON.stringify(args.toolName)} found ${matches.length} matching elements `
+    + `for ${JSON.stringify(args.testIdAttribute)}=${JSON.stringify(args.testId)}. `
+    + "Scope the bridge with a narrower root before registering tools."
+  );
+}
+
+function findFirstDescendant(element: Element, selector: string): Element | null {
+  return typeof element.querySelector === "function" ? element.querySelector(selector) : null;
+}
+
+function resolveTextEntryControl(element: Element): Element | null {
+  if (isHtmlInputElement(element) && element.type !== "checkbox" && element.type !== "radio") {
+    return element;
+  }
+
+  if (isHtmlTextAreaElement(element)) {
+    return element;
+  }
+
+  if (isHtmlElement(element) && element.isContentEditable) {
+    return element;
+  }
+
+  return findFirstDescendant(
+    element,
+    "input:not([type='checkbox']):not([type='radio']), textarea, [contenteditable='true']",
+  );
+}
+
+function resolveNativeSelectControl(element: Element): HTMLSelectElement | null {
+  if (isHtmlSelectElement(element)) {
+    return element;
+  }
+
+  const descendant = findFirstDescendant(element, "select");
+  return isHtmlSelectElement(descendant) ? descendant : null;
+}
+
+function resolveCheckableControl(element: Element, type: "checkbox" | "radio"): HTMLInputElement | null {
+  if (isHtmlInputElement(element) && element.type === type) {
+    return element;
+  }
+
+  const descendant = findFirstDescendant(element, `input[type='${type}']`);
+  return isHtmlInputElement(descendant) ? descendant : null;
+}
+
+function resolveClickableElement(element: Element): HTMLElement | null {
+  if (isHtmlElement(element) && typeof element.click === "function") {
+    return element;
+  }
+
+  const descendant = findFirstDescendant(
+    element,
+    "button, [role='button'], [role='combobox'], a, input[type='button'], input[type='submit'], input[type='reset']",
+  );
+  return isHtmlElement(descendant) ? descendant : null;
+}
+
+function dispatchBubbledEvent(target: EventTarget, type: string): void {
+  target.dispatchEvent(new Event(type, { bubbles: true, cancelable: true }));
+}
+
+function setTextControlValue(element: Element, value: unknown, toolName: string, paramName: string): void {
+  const target = resolveTextEntryControl(element);
+  if (!target) {
+    throw new Error(
+      `[vue-pom-generator] WebMCP tool ${JSON.stringify(toolName)} could not find a text-like control `
+      + `for parameter ${JSON.stringify(paramName)}.`
+    );
+  }
+
+  const nextValue = value === null || value === undefined ? "" : String(value);
+  if (isHtmlInputElement(target) || isHtmlTextAreaElement(target)) {
+    target.focus();
+    target.value = nextValue;
+    dispatchBubbledEvent(target, "input");
+    dispatchBubbledEvent(target, "change");
+    return;
+  }
+
+  if (isHtmlElement(target) && target.isContentEditable) {
+    target.focus();
+    target.textContent = nextValue;
+    dispatchBubbledEvent(target, "input");
+    dispatchBubbledEvent(target, "change");
+    return;
+  }
+
+  throw new Error(
+    `[vue-pom-generator] WebMCP tool ${JSON.stringify(toolName)} could not write parameter `
+    + `${JSON.stringify(paramName)} to the resolved element.`
+  );
+}
+
+function setNativeSelectValue(select: HTMLSelectElement, value: unknown, toolName: string, paramName: string): void {
+  const desired = String(value ?? "");
+  const option = Array.from(select.options).find(currentOption => {
+    return currentOption.value === desired || currentOption.text.trim() === desired;
+  });
+
+  if (!option) {
+    throw new Error(
+      `[vue-pom-generator] WebMCP tool ${JSON.stringify(toolName)} could not find option `
+      + `${JSON.stringify(desired)} for parameter ${JSON.stringify(paramName)}.`
+    );
+  }
+
+  select.focus();
+  select.value = option.value;
+  option.selected = true;
+  dispatchBubbledEvent(select, "input");
+  dispatchBubbledEvent(select, "change");
+}
+
+function setCheckboxValue(element: Element, value: unknown, toolName: string, paramName: string): void {
+  const desired = Boolean(value);
+  const target = resolveCheckableControl(element, "checkbox");
+  if (target) {
+    if (target.checked !== desired) {
+      target.click();
+    }
+    return;
+  }
+
+  const clickable = resolveClickableElement(element);
+  if (!clickable) {
+    throw new Error(
+      `[vue-pom-generator] WebMCP tool ${JSON.stringify(toolName)} could not find a checkbox-like control `
+      + `for parameter ${JSON.stringify(paramName)}.`
+    );
+  }
+
+  const current = clickable.getAttribute("aria-checked");
+  if (current === String(desired)) {
+    return;
+  }
+  clickable.click();
+}
+
+function setRadioValue(element: Element, value: unknown, toolName: string, paramName: string): void {
+  if (!Boolean(value)) {
+    return;
+  }
+
+  const target = resolveCheckableControl(element, "radio");
+  if (target) {
+    if (!target.checked) {
+      target.click();
+    }
+    return;
+  }
+
+  const clickable = resolveClickableElement(element);
+  if (!clickable) {
+    throw new Error(
+      `[vue-pom-generator] WebMCP tool ${JSON.stringify(toolName)} could not find a radio-like control `
+      + `for parameter ${JSON.stringify(paramName)}.`
+    );
+  }
+
+  clickable.click();
+}
+
+function findOptionCandidate(rootDocument: Document, desired: string): HTMLElement | null {
+  const options = Array.from(rootDocument.querySelectorAll("[role='option'], option"));
+  for (const option of options) {
+    if (!isHtmlElement(option)) {
+      continue;
+    }
+
+    const value = option.getAttribute("value") || option.getAttribute("data-value") || option.textContent?.trim() || "";
+    if (value === desired || option.textContent?.trim() === desired) {
+      return option;
+    }
+  }
+
+  return null;
+}
+
+async function waitForOptionCandidate(rootDocument: Document, desired: string): Promise<HTMLElement | null> {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const option = findOptionCandidate(rootDocument, desired);
+    if (option) {
+      return option;
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+
+  return null;
+}
+
+async function setVSelectValue(
+  element: Element,
+  value: unknown,
+  rootDocument: Document,
+  toolName: string,
+  paramName: string,
+): Promise<void> {
+  const nativeSelect = resolveNativeSelectControl(element);
+  if (nativeSelect) {
+    setNativeSelectValue(nativeSelect, value, toolName, paramName);
+    return;
+  }
+
+  const textControl = resolveTextEntryControl(element);
+  if (textControl) {
+    setTextControlValue(textControl, value, toolName, paramName);
+    return;
+  }
+
+  // Best-effort wrapper fallback: open a combobox/button trigger, then choose an option by text/value.
+  const trigger = resolveClickableElement(element);
+  if (!trigger) {
+    throw new Error(
+      `[vue-pom-generator] WebMCP tool ${JSON.stringify(toolName)} could not find a select-like control `
+      + `for parameter ${JSON.stringify(paramName)}.`
+    );
+  }
+
+  trigger.click();
+  const option = await waitForOptionCandidate(rootDocument, String(value ?? ""));
+  if (!option) {
+    throw new Error(
+      `[vue-pom-generator] WebMCP tool ${JSON.stringify(toolName)} could not find an option matching `
+      + `${JSON.stringify(String(value ?? ""))} for parameter ${JSON.stringify(paramName)}.`
+    );
+  }
+
+  option.click();
+}
+
+function clickElement(element: Element, toolName: string, actionName: string): void {
+  const target = resolveClickableElement(element);
+  if (!target) {
+    throw new Error(
+      `[vue-pom-generator] WebMCP tool ${JSON.stringify(toolName)} could not find a clickable element `
+      + `for action ${JSON.stringify(actionName)}.`
+    );
+  }
+
+  target.click();
+}
+
+function resolvePatternTestId(
+  pattern: string,
+  selectorTemplateVariables: readonly string[],
+  args: Record<string, unknown>,
+  toolName: string,
+  targetLabel: string,
+): string {
+  if (!selectorTemplateVariables.length) {
+    return pattern;
+  }
+
+  return pattern.replace(/\$\{(\w+)\}/g, (_match, variableName: string) => {
+    const value = args[variableName];
+    if (value === undefined || value === null) {
+      throw new Error(
+        `[vue-pom-generator] WebMCP tool ${JSON.stringify(toolName)} requires argument `
+        + `${JSON.stringify(variableName)} to resolve ${targetLabel}.`
+      );
+    }
+
+    return String(value);
+  });
+}
+
+function getToolSelectorVariables(tool: WebMcpManifestTool): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const add = (value: string) => {
+    if (!value || seen.has(value)) {
+      return;
+    }
+    seen.add(value);
+    out.push(value);
+  };
+
+  for (const param of tool.params) {
+    for (const variableName of param.selectorTemplateVariables) {
+      add(variableName);
+    }
+  }
+
+  for (const action of tool.actions) {
+    for (const variableName of action.selectorTemplateVariables) {
+      add(variableName);
+    }
+  }
+
+  return out;
+}
+
+function getToolDescription(tool: WebMcpManifestTool, actionParameterName: string): string {
+  if (!tool.actions.length) {
+    return tool.toolDescription;
+  }
+
+  if (tool.toolAutoSubmit && tool.actions.length === 1) {
+    return `${tool.toolDescription} Calling this tool clicks ${tool.actions[0].name}.`;
+  }
+
+  const actionList = tool.actions.map(action => action.name).join(", ");
+  return `${tool.toolDescription} Use ${actionParameterName} to choose one of: ${actionList}.`;
+}
+
+function getToolInputSchema(tool: WebMcpManifestTool, actionParameterName: string): WebMcpJsonSchemaObject {
+  const properties: Record<string, WebMcpJsonSchemaProperty> = {};
+
+  for (const param of tool.params) {
+    properties[param.name] = {
+      type: param.role === "checkbox" || param.role === "radio" ? "boolean" : "string",
+      description: param.toolParamDescription,
+    };
+  }
+
+  for (const selectorVariable of getToolSelectorVariables(tool)) {
+    if (properties[selectorVariable]) {
+      continue;
+    }
+
+    properties[selectorVariable] = {
+      type: "string",
+      description: SELECTOR_VARIABLE_DESCRIPTION,
+    };
+  }
+
+  if (tool.actions.length > 0 && !tool.toolAutoSubmit) {
+    properties[actionParameterName] = {
+      type: "string",
+      description: "Optional generated action to click after applying parameters.",
+      enum: tool.actions.map(action => action.name),
+    };
+  }
+
+  return {
+    type: "object",
+    properties,
+    required: [],
+    additionalProperties: false,
+  };
+}
+
+function resolveModelContext(modelContext?: WebMcpModelContextLike): WebMcpModelContextLike {
+  if (modelContext) {
+    return modelContext;
+  }
+
+  const navigatorValue = (typeof navigator !== "undefined"
+    ? (navigator as Navigator & { modelContext?: WebMcpModelContextLike }).modelContext
+    : undefined);
+  if (navigatorValue) {
+    return navigatorValue;
+  }
+
+  throw new Error(
+    "[vue-pom-generator] WebMCP runtime bridge requires navigator.modelContext. "
+    + "Install a WebMCP runtime such as @mcp-b/global, or pass modelContext explicitly."
+  );
+}
+
+function getAllManifestTools(manifest: WebMcpManifest): Array<{ component: WebMcpManifestComponent; tool: WebMcpManifestTool }> {
+  const out: Array<{ component: WebMcpManifestComponent; tool: WebMcpManifestTool }> = [];
+  for (const component of Object.values(manifest)) {
+    for (const tool of component.tools) {
+      out.push({ component, tool });
+    }
+  }
+  return out;
+}
+
+function validateManifestToolNames(tools: Array<{ component: WebMcpManifestComponent; tool: WebMcpManifestTool }>): void {
+  const toolOwners = new Map<string, string>();
+  for (const { component, tool } of tools) {
+    const existingOwner = toolOwners.get(tool.toolName);
+    if (existingOwner) {
+      throw new Error(
+        `[vue-pom-generator] WebMCP runtime bridge found duplicate tool name ${JSON.stringify(tool.toolName)} `
+        + `for ${existingOwner} and ${component.componentName}.`
+      );
+    }
+
+    toolOwners.set(tool.toolName, component.componentName);
+  }
+}
+
+function validateActionParameterName(tool: WebMcpManifestTool, actionParameterName: string): void {
+  const paramNames = new Set<string>();
+  for (const param of tool.params) {
+    if (paramNames.has(param.name)) {
+      throw new Error(
+        `[vue-pom-generator] WebMCP runtime bridge found duplicate parameter name `
+        + `${JSON.stringify(param.name)} for tool ${JSON.stringify(tool.toolName)}.`
+      );
+    }
+    paramNames.add(param.name);
+  }
+
+  if (!tool.actions.length || tool.toolAutoSubmit) {
+    return;
+  }
+
+  const collision = tool.params.some(param => param.name === actionParameterName)
+    || getToolSelectorVariables(tool).includes(actionParameterName);
+  if (collision) {
+    throw new Error(
+      `[vue-pom-generator] WebMCP runtime bridge cannot use action parameter name `
+      + `${JSON.stringify(actionParameterName)} for tool ${JSON.stringify(tool.toolName)} because it collides with existing tool arguments.`
+    );
+  }
+}
+
+function getSelectedAction(
+  tool: WebMcpManifestTool,
+  args: Record<string, unknown>,
+  actionParameterName: string,
+): WebMcpManifestAction | null {
+  if (!tool.actions.length) {
+    return null;
+  }
+
+  const rawAction = args[actionParameterName];
+  if (rawAction === undefined || rawAction === null || rawAction === "") {
+    if (tool.toolAutoSubmit && tool.actions.length === 1) {
+      return tool.actions[0];
+    }
+    return null;
+  }
+
+  if (typeof rawAction !== "string") {
+    throw new Error(
+      `[vue-pom-generator] WebMCP runtime bridge expected ${JSON.stringify(actionParameterName)} `
+      + `to be a string action name for tool ${JSON.stringify(tool.toolName)}.`
+    );
+  }
+
+  const action = tool.actions.find(candidate => candidate.name === rawAction);
+  if (action) {
+    return action;
+  }
+
+  throw new Error(
+    `[vue-pom-generator] WebMCP runtime bridge could not find action ${JSON.stringify(rawAction)} `
+    + `for tool ${JSON.stringify(tool.toolName)}. Available actions: ${tool.actions.map(candidate => JSON.stringify(candidate.name)).join(", ")}.`
+  );
+}
+
+async function applyToolParameter(args: {
+  tool: WebMcpManifestTool;
+  param: WebMcpManifestParameter;
+  toolArgs: Record<string, unknown>;
+  value: unknown;
+  root: Document | DocumentFragment | Element;
+  rootDocument: Document;
+  testIdAttribute: string;
+}): Promise<void> {
+  const resolvedTestId = resolvePatternTestId(
+    args.param.testId,
+    args.param.selectorTemplateVariables,
+    args.toolArgs,
+    args.tool.toolName,
+    `parameter ${JSON.stringify(args.param.name)}`,
+  );
+
+  const element = getUniqueElementByTestId({
+    root: args.root,
+    testIdAttribute: args.testIdAttribute,
+    testId: resolvedTestId,
+    toolName: args.tool.toolName,
+  });
+
+  switch (args.param.role) {
+    case "checkbox":
+      setCheckboxValue(element, args.value, args.tool.toolName, args.param.name);
+      return;
+    case "radio":
+      setRadioValue(element, args.value, args.tool.toolName, args.param.name);
+      return;
+    case "select": {
+      const select = resolveNativeSelectControl(element);
+      if (!select) {
+        throw new Error(
+          `[vue-pom-generator] WebMCP tool ${JSON.stringify(args.tool.toolName)} could not find a native select `
+          + `for parameter ${JSON.stringify(args.param.name)}.`
+        );
+      }
+      setNativeSelectValue(select, args.value, args.tool.toolName, args.param.name);
+      return;
+    }
+    case "vselect":
+      await setVSelectValue(element, args.value, args.rootDocument, args.tool.toolName, args.param.name);
+      return;
+    case "input":
+    default:
+      setTextControlValue(element, args.value, args.tool.toolName, args.param.name);
+  }
+}
+
+export function registerWebMcpManifestTools(options: RegisterWebMcpManifestToolsOptions): RegisteredWebMcpToolsHandle {
+  const modelContext = resolveModelContext(options.modelContext);
+  const root = getSearchRoot(options.root);
+  const rootDocument = getRootDocument(root);
+  const testIdAttribute = getNormalizedTestIdAttribute(options.testIdAttribute);
+  const actionParameterName = (options.actionParameterName ?? DEFAULT_ACTION_PARAMETER_NAME).trim() || DEFAULT_ACTION_PARAMETER_NAME;
+  const allTools = getAllManifestTools(options.manifest);
+
+  validateManifestToolNames(allTools);
+  for (const { tool } of allTools) {
+    validateActionParameterName(tool, actionParameterName);
+  }
+
+  const registeredToolNames: string[] = [];
+
+  try {
+    for (const { component, tool } of allTools) {
+      modelContext.registerTool({
+        name: tool.toolName,
+        description: getToolDescription(tool, actionParameterName),
+        inputSchema: getToolInputSchema(tool, actionParameterName),
+        async execute(toolArgs: Record<string, unknown>) {
+          const appliedParameters: string[] = [];
+          const selectorVariablesUsed = getToolSelectorVariables(tool).filter((variableName) => {
+            return Object.prototype.hasOwnProperty.call(toolArgs, variableName) && toolArgs[variableName] !== undefined;
+          });
+
+          for (const param of tool.params) {
+            if (!Object.prototype.hasOwnProperty.call(toolArgs, param.name) || toolArgs[param.name] === undefined) {
+              continue;
+            }
+
+            await applyToolParameter({
+              tool,
+              param,
+              toolArgs,
+              value: toolArgs[param.name],
+              root,
+              rootDocument,
+              testIdAttribute,
+            });
+            appliedParameters.push(param.name);
+          }
+
+          const selectedAction = getSelectedAction(tool, toolArgs, actionParameterName);
+          if (selectedAction) {
+            const resolvedTestId = resolvePatternTestId(
+              selectedAction.testId,
+              selectedAction.selectorTemplateVariables,
+              toolArgs,
+              tool.toolName,
+              `action ${JSON.stringify(selectedAction.name)}`,
+            );
+            const actionElement = getUniqueElementByTestId({
+              root,
+              testIdAttribute,
+              testId: resolvedTestId,
+              toolName: tool.toolName,
+            });
+            clickElement(actionElement, tool.toolName, selectedAction.name);
+          }
+
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({
+                component: component.componentName,
+                tool: tool.toolName,
+                appliedParameters,
+                selectorVariablesUsed,
+                action: selectedAction?.name ?? null,
+                ...(selectedAction?.targetPageObjectModelClass
+                  ? { targetPageObjectModelClass: selectedAction.targetPageObjectModelClass }
+                  : {}),
+              }),
+            }],
+          };
+        },
+      });
+
+      registeredToolNames.push(tool.toolName);
+    }
+  }
+  catch (error) {
+    for (const toolName of registeredToolNames) {
+      modelContext.unregisterTool(toolName);
+    }
+    throw error;
+  }
+
+  let disposed = false;
+  return {
+    toolNames: [...registeredToolNames],
+    unregister() {
+      if (disposed) {
+        return;
+      }
+
+      disposed = true;
+      const errors: Error[] = [];
+      for (const toolName of [...registeredToolNames].reverse()) {
+        try {
+          modelContext.unregisterTool(toolName);
+        }
+        catch (error) {
+          errors.push(error instanceof Error ? error : new Error(String(error)));
+        }
+      }
+
+      if (errors.length > 0) {
+        throw errors[0];
+      }
+    },
+  };
+}

--- a/webmcp-runtime.ts
+++ b/webmcp-runtime.ts
@@ -33,6 +33,7 @@ export interface WebMcpManifestComponent {
   className: string;
   sourceFile: string;
   kind: "component" | "view";
+  usedComponents: string[];
   tools: WebMcpManifestTool[];
 }
 
@@ -80,6 +81,28 @@ export interface RegisterWebMcpManifestToolsOptions {
 export interface RegisteredWebMcpToolsHandle {
   toolNames: string[];
   unregister(): void;
+}
+
+export interface WebMcpRouteRecordLike {
+  components?: Record<string, unknown>;
+  instances?: Record<string, unknown>;
+  component?: unknown;
+}
+
+export interface WebMcpRouteLike {
+  matched?: WebMcpRouteRecordLike[];
+}
+
+export interface WebMcpRouterLike {
+  currentRoute?: { value?: WebMcpRouteLike } | WebMcpRouteLike;
+  afterEach?(guard: (to: WebMcpRouteLike) => void): (() => void) | void;
+  isReady?(): Promise<unknown>;
+}
+
+export interface RegisterRouteScopedWebMcpManifestToolsOptions extends RegisterWebMcpManifestToolsOptions {
+  router: WebMcpRouterLike;
+  includeComponentNames?: string[];
+  fallbackToGlobalWhenNoRouteMatch?: boolean;
 }
 
 const DEFAULT_TEST_ID_ATTRIBUTE = "data-testid";
@@ -466,7 +489,7 @@ function getToolDescription(tool: WebMcpManifestTool, actionParameterName: strin
   }
 
   if (tool.toolAutoSubmit && tool.actions.length === 1) {
-    return `${tool.toolDescription} Calling this tool clicks ${tool.actions[0].name}.`;
+    return tool.toolDescription;
   }
 
   const actionList = tool.actions.map(action => action.name).join(", ");
@@ -508,6 +531,193 @@ function getToolInputSchema(tool: WebMcpManifestTool, actionParameterName: strin
     required: [],
     additionalProperties: false,
   };
+}
+
+function getBasenameWithoutExtension(value: string): string {
+  const normalized = value.replace(/\\/g, "/");
+  const basename = normalized.split("/").pop() ?? normalized;
+  return basename.replace(/\.[^.]+$/u, "");
+}
+
+function normalizeManifestComponentIdentity(value: string): string {
+  return value.replace(/\\/g, "/").replace(/\.[^.]+$/u, "").trim().toLowerCase();
+}
+
+function addManifestComponentIdentity(index: Map<string, Set<string>>, identity: string, componentName: string): void {
+  const normalized = normalizeManifestComponentIdentity(identity);
+  if (!normalized) {
+    return;
+  }
+
+  const existing = index.get(normalized);
+  if (existing) {
+    existing.add(componentName);
+    return;
+  }
+
+  index.set(normalized, new Set([componentName]));
+}
+
+function buildManifestComponentIdentityIndex(manifest: WebMcpManifest): Map<string, Set<string>> {
+  const index = new Map<string, Set<string>>();
+
+  for (const component of Object.values(manifest)) {
+    addManifestComponentIdentity(index, component.componentName, component.componentName);
+    addManifestComponentIdentity(index, component.className, component.componentName);
+    addManifestComponentIdentity(index, component.sourceFile, component.componentName);
+    addManifestComponentIdentity(index, getBasenameWithoutExtension(component.sourceFile), component.componentName);
+  }
+
+  return index;
+}
+
+function collectRuntimeComponentIdentityCandidates(
+  value: unknown,
+  out: Set<string>,
+  seen: Set<unknown> = new Set(),
+): void {
+  if (value === null || value === undefined) {
+    return;
+  }
+
+  if (typeof value === "string") {
+    out.add(value);
+    out.add(getBasenameWithoutExtension(value));
+    return;
+  }
+
+  if (typeof value !== "object" && typeof value !== "function") {
+    return;
+  }
+
+  if (seen.has(value)) {
+    return;
+  }
+  seen.add(value);
+
+  const record = value as Record<string, unknown>;
+
+  if (typeof value === "function" && value.name) {
+    out.add(value.name);
+  }
+
+  for (const key of ["name", "__name", "displayName", "__file"] as const) {
+    const identity = record[key];
+    if (typeof identity === "string" && identity.trim()) {
+      out.add(identity);
+      out.add(getBasenameWithoutExtension(identity));
+    }
+  }
+
+  if ("default" in record) {
+    collectRuntimeComponentIdentityCandidates(record.default, out, seen);
+  }
+  if ("type" in record) {
+    collectRuntimeComponentIdentityCandidates(record.type, out, seen);
+  }
+  if ("__asyncResolved" in record) {
+    collectRuntimeComponentIdentityCandidates(record.__asyncResolved, out, seen);
+  }
+  if ("__vccOpts" in record) {
+    collectRuntimeComponentIdentityCandidates(record.__vccOpts, out, seen);
+  }
+  if ("$" in record && record.$ && typeof record.$ === "object" && "type" in (record.$ as Record<string, unknown>)) {
+    collectRuntimeComponentIdentityCandidates((record.$ as Record<string, unknown>).type, out, seen);
+  }
+}
+
+function getRouteRecordComponentValues(record: WebMcpRouteRecordLike): unknown[] {
+  const out: unknown[] = [];
+
+  if (record.component !== undefined) {
+    out.push(record.component);
+  }
+
+  if (record.components && typeof record.components === "object") {
+    out.push(...Object.values(record.components));
+  }
+
+  if (record.instances && typeof record.instances === "object") {
+    out.push(...Object.values(record.instances));
+  }
+
+  return out;
+}
+
+function getCurrentRoute(router: WebMcpRouterLike): WebMcpRouteLike | undefined {
+  const currentRoute = router.currentRoute;
+  if (currentRoute && typeof currentRoute === "object" && "value" in currentRoute) {
+    return currentRoute.value;
+  }
+
+  return currentRoute as WebMcpRouteLike | undefined;
+}
+
+function resolveRouteMatchedManifestComponentNames(manifest: WebMcpManifest, route: WebMcpRouteLike | undefined): string[] {
+  const index = buildManifestComponentIdentityIndex(manifest);
+  const resolved = new Set<string>();
+
+  for (const record of route?.matched ?? []) {
+    for (const componentValue of getRouteRecordComponentValues(record)) {
+      const candidates = new Set<string>();
+      collectRuntimeComponentIdentityCandidates(componentValue, candidates);
+      for (const candidate of candidates) {
+        for (const componentName of index.get(normalizeManifestComponentIdentity(candidate)) ?? []) {
+          resolved.add(componentName);
+        }
+      }
+    }
+  }
+
+  return [...resolved].sort((a, b) => a.localeCompare(b));
+}
+
+function expandManifestComponentNames(manifest: WebMcpManifest, seedNames: readonly string[]): string[] {
+  const resolved = new Set<string>();
+  const stack = [...seedNames];
+
+  while (stack.length > 0) {
+    const componentName = stack.pop();
+    if (!componentName || resolved.has(componentName)) {
+      continue;
+    }
+
+    const component = manifest[componentName];
+    if (!component) {
+      continue;
+    }
+
+    resolved.add(componentName);
+    for (const childComponentName of component.usedComponents) {
+      if (!resolved.has(childComponentName)) {
+        stack.push(childComponentName);
+      }
+    }
+  }
+
+  return [...resolved].sort((a, b) => a.localeCompare(b));
+}
+
+function getScopedManifest(
+  manifest: WebMcpManifest,
+  route: WebMcpRouteLike | undefined,
+  includeComponentNames: readonly string[],
+  fallbackToGlobalWhenNoRouteMatch: boolean,
+): WebMcpManifest {
+  const componentNames = expandManifestComponentNames(manifest, [
+    ...includeComponentNames,
+    ...resolveRouteMatchedManifestComponentNames(manifest, route),
+  ]);
+
+  if (!componentNames.length) {
+    return fallbackToGlobalWhenNoRouteMatch ? manifest : {};
+  }
+
+  const allowedNames = new Set(componentNames);
+  return Object.fromEntries(
+    Object.entries(manifest)
+      .filter(([componentName]) => allowedNames.has(componentName)),
+  );
 }
 
 function resolveModelContext(modelContext?: WebMcpModelContextLike): WebMcpModelContextLike {
@@ -777,6 +987,87 @@ export function registerWebMcpManifestTools(options: RegisterWebMcpManifestTools
       if (errors.length > 0) {
         throw errors[0];
       }
+    },
+  };
+}
+
+export function registerRouteScopedWebMcpManifestTools(
+  options: RegisterRouteScopedWebMcpManifestToolsOptions,
+): RegisteredWebMcpToolsHandle {
+  const toolNames: string[] = [];
+  const includeComponentNames = [...(options.includeComponentNames ?? [])];
+  const fallbackToGlobalWhenNoRouteMatch = options.fallbackToGlobalWhenNoRouteMatch === true;
+  const baseOptions: RegisterWebMcpManifestToolsOptions = {
+    manifest: options.manifest,
+    ...(options.modelContext ? { modelContext: options.modelContext } : {}),
+    ...(options.root ? { root: options.root } : {}),
+    ...(options.testIdAttribute ? { testIdAttribute: options.testIdAttribute } : {}),
+    ...(options.actionParameterName ? { actionParameterName: options.actionParameterName } : {}),
+  };
+
+  let disposed = false;
+  let activeRegistration: RegisteredWebMcpToolsHandle | null = null;
+  let removeAfterEach: (() => void) | null = null;
+  let activeScopeKey = "";
+
+  const syncToolNames = (nextToolNames: readonly string[]) => {
+    toolNames.splice(0, toolNames.length, ...nextToolNames);
+  };
+
+  const refreshRegistration = (route: WebMcpRouteLike | undefined) => {
+    if (disposed) {
+      return;
+    }
+
+    const scopedManifest = getScopedManifest(
+      options.manifest,
+      route,
+      includeComponentNames,
+      fallbackToGlobalWhenNoRouteMatch,
+    );
+    const scopeKey = Object.keys(scopedManifest).sort((a, b) => a.localeCompare(b)).join("|");
+    if (scopeKey === activeScopeKey && activeRegistration) {
+      return;
+    }
+
+    activeRegistration?.unregister();
+    activeRegistration = registerWebMcpManifestTools({
+      ...baseOptions,
+      manifest: scopedManifest,
+    });
+    activeScopeKey = scopeKey;
+    syncToolNames(activeRegistration.toolNames);
+  };
+
+  if (options.router.afterEach) {
+    const maybeRemoveAfterEach = options.router.afterEach((to) => {
+      refreshRegistration(to);
+    });
+    if (typeof maybeRemoveAfterEach === "function") {
+      removeAfterEach = maybeRemoveAfterEach;
+    }
+  }
+
+  refreshRegistration(getCurrentRoute(options.router));
+  if (options.router.isReady) {
+    void options.router.isReady().then(() => {
+      refreshRegistration(getCurrentRoute(options.router));
+    });
+  }
+
+  return {
+    toolNames,
+    unregister() {
+      if (disposed) {
+        return;
+      }
+
+      disposed = true;
+      removeAfterEach?.();
+      activeRegistration?.unregister();
+      activeRegistration = null;
+      activeScopeKey = "";
+      syncToolNames([]);
     },
   };
 }


### PR DESCRIPTION
## Summary
- keep the WebMCP manifest generation, but extend it with selector-variable and auto-submit metadata
- add a browser-safe `@immense/vue-pom-generator/webmcp-runtime` helper plus a generated `virtual:webmcp-bridge` module
- cover the bridge with virtual-module tests and an end-to-end jsdom runtime test using `@mcp-b/global`

## Notes
- `virtual:webmcp-manifest` is still the metadata-only surface
- `virtual:webmcp-bridge` is the opt-in runtime layer that registers generated tools against `navigator.modelContext`
- the runtime bridge supports native text inputs, checkboxes, radios, native selects, parameterized test ids, and a best-effort `vselect` path

## Validation
- npm test
- npm run typecheck
- npm run build