### PR TITLE
ci: update GitHub actions for Node 24

### DIFF
--- a/.github/workflows/agentic-release-notes.lock.yml
+++ b/.github/workflows/agentic-release-notes.lock.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -59,12 +59,12 @@ jobs:
       packages: write
     steps:
       - name: Checkout (full history + tags)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -236,7 +236,7 @@ jobs:
         run: npx --yes npm@11.5.1 publish --provenance --access public
 
       - name: Setup Node for GitHub Packages
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: https://npm.pkg.github.com

--- a/.github/workflows/workflows/ci.yml
+++ b/.github/workflows/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Checkout repository (CI only)
         if: github.actor != 'nektos/act'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -110,7 +110,7 @@ jobs:
       # unexpectedly because it relies on GitHub cache backends.
       - name: Setup Node.js (CI)
         if: github.actor != 'nektos/act'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: npm
@@ -373,7 +373,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -382,7 +382,7 @@ jobs:
           git submodule update --init --depth 1 external/vscode-test-playwright
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
           cache: npm
@@ -477,14 +477,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Init required submodules
         run: |
           git submodule update --init --depth 1 external/vscode-test-playwright
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -534,7 +534,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Mark workspace as safe for git
         run: |
@@ -546,7 +546,7 @@ jobs:
           git submodule update --init --depth 1 external/vscode-test-playwright
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -604,7 +604,7 @@ jobs:
       USE_CODEX: 'false' # Set to 'true' to use OpenAI Codex instead of Claude
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -618,7 +618,7 @@ jobs:
           git submodule update --init --depth 1 external/vscode-test-playwright
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
           cache: npm
@@ -766,14 +766,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Init required submodules
         run: |
           git submodule update --init --depth 1 external/vscode-test-playwright
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
           cache: npm
@@ -804,14 +804,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Init required submodules
         run: |
           git submodule update --init --depth 1 external/vscode-test-playwright
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
           cache: npm


### PR DESCRIPTION
## Summary
- Update actions/checkout usages to v6, including the pinned agentic workflow lock entry
- Update actions/setup-node usages to v6
- Remove the remaining checkout/setup-node v4 references that trigger Node.js 20 action deprecation warnings

## Verification
- Parsed changed workflow YAML with Ruby YAML.load_file
- Confirmed no actions/checkout@v4, actions/setup-node@v4, or old pinned checkout v4 SHA remain under .github

Note: local actionlint still reports pre-existing unrelated issues in workflow shell snippets, custom ubuntu-slim labels, and softprops/action-gh-release@v1.