### PR TITLE
fix: normalize file scope path checks

### DIFF
--- a/plugin/path-utils.ts
+++ b/plugin/path-utils.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 
 import { toPascalCase } from "../utils";
 
+type ScopePathApi = Pick<typeof path, "basename" | "isAbsolute" | "normalize" | "resolve" | "sep">;
+
 function toPosixSlashes(value: string): string {
   let out = "";
   for (let i = 0; i < value.length; i++) {
@@ -31,6 +33,16 @@ function safeRealpath(value: string): string {
   return resolvedParent === parent
     ? value
     : path.join(resolvedParent, path.basename(value));
+}
+
+function normalizeScopePath(value: string, pathImpl: ScopePathApi = path): string {
+  return pathImpl.normalize(value);
+}
+
+function isNormalizedPathWithinDir(filePathAbs: string, dirPathAbs: string, pathImpl: ScopePathApi = path): boolean {
+  const normalizedFileAbs = normalizeScopePath(filePathAbs, pathImpl);
+  const normalizedDirAbs = normalizeScopePath(dirPathAbs, pathImpl);
+  return normalizedFileAbs === normalizedDirAbs || normalizedFileAbs.startsWith(`${normalizedDirAbs}${pathImpl.sep}`);
 }
 
 export function isPathWithinDir(filePathAbs: string, dirPathAbs: string): boolean {
@@ -62,6 +74,15 @@ export interface ResolveComponentNameOptions {
    * config.root to the app/ subdirectory rather than the web project root.
    */
   extraRoots?: string[];
+}
+
+export interface FileInConfiguredSourceScopeOptions {
+  filename: string | undefined;
+  projectRoot: string;
+  viewsDirAbs: string;
+  sourceDirs: string[];
+  extraRoots?: string[];
+  pathImpl?: ScopePathApi;
 }
 
 /**
@@ -110,6 +131,53 @@ export function resolveComponentNameFromPath(options: ResolveComponentNameOption
 
   // Fallback: use just the filename without extension.
   return toPascalCase(path.parse(normalizedAbsFilename).name);
+}
+
+export function isFileInConfiguredSourceScope(options: FileInConfiguredSourceScopeOptions): boolean {
+  const { filename, projectRoot, viewsDirAbs, sourceDirs, extraRoots = [], pathImpl = path } = options;
+  if (!filename) {
+    return false;
+  }
+
+  const cleanFilename = filename.includes("?")
+    ? filename.substring(0, filename.indexOf("?"))
+    : filename;
+  const normalizedProjectRoot = normalizeScopePath(projectRoot, pathImpl);
+  const normalizedAbsFilename = normalizeScopePath(
+    pathImpl.isAbsolute(cleanFilename) ? cleanFilename : pathImpl.resolve(normalizedProjectRoot, cleanFilename),
+    pathImpl,
+  );
+
+  if (normalizedAbsFilename.includes(`${pathImpl.sep}node_modules${pathImpl.sep}`) || normalizedAbsFilename.includes("/node_modules/")) {
+    return false;
+  }
+
+  const normalizedViewsDirAbs = normalizeScopePath(viewsDirAbs, pathImpl);
+  if (isNormalizedPathWithinDir(normalizedAbsFilename, normalizedViewsDirAbs, pathImpl)) {
+    return true;
+  }
+
+  const rootsToTry = Array.from(new Set([
+    normalizedProjectRoot,
+    ...extraRoots.map(root => normalizeScopePath(root, pathImpl)),
+  ]));
+
+  return sourceDirs.some((dir) => {
+    return rootsToTry.some((root) => {
+      const normalizedAbsDir = normalizeScopePath(pathImpl.resolve(root, dir), pathImpl);
+      if (isNormalizedPathWithinDir(normalizedAbsFilename, normalizedAbsDir, pathImpl)) {
+        return true;
+      }
+
+      if (dir.startsWith("app/") && pathImpl.basename(root) === "app") {
+        const relativeDir = dir.substring(4);
+        const normalizedAbsDirAlt = normalizeScopePath(pathImpl.resolve(root, relativeDir), pathImpl);
+        return isNormalizedPathWithinDir(normalizedAbsFilename, normalizedAbsDirAlt, pathImpl);
+      }
+
+      return false;
+    });
+  });
 }
 
 export function toPosixRelativeImport(fromDirAbs: string, toPathAbs: string): string {

--- a/plugin/vue-plugin.ts
+++ b/plugin/vue-plugin.ts
@@ -15,7 +15,7 @@ import { createTestIdTransform } from "../transform";
 import type { IComponentDependencies, NativeWrappersMap } from "../utils";
 
 import type { VuePomGeneratorLogger } from "./logger";
-import { resolveComponentNameFromPath } from "./path-utils";
+import { isFileInConfiguredSourceScope, resolveComponentNameFromPath } from "./path-utils";
 import type { MissingSemanticNameBehavior, PomNameCollisionBehavior } from "./types";
 
 interface InternalFactoryOptions {
@@ -161,37 +161,16 @@ export function createVuePluginWithTestIds(options: InternalFactoryOptions): {
     // Strip any Vite/Nuxt query parameters (e.g. ?vue&type=template)
     const cleanPath = filename.includes("?") ? filename.substring(0, filename.indexOf("?")) : filename;
     const projectRoot = getProjectRoot();
-    const absFilename = path.isAbsolute(cleanPath) ? cleanPath : path.resolve(projectRoot, cleanPath);
-
-    // Never touch node_modules
-    if (absFilename.includes(`${path.sep}node_modules${path.sep}`) || absFilename.includes("/node_modules/"))
-      return false;
-
-    // Must be in one of the configured page/component/layout dirs.
-    const viewsDirAbs = getViewsDirAbs();
-    if (absFilename.startsWith(viewsDirAbs + path.sep) || absFilename === viewsDirAbs)
-      return true;
-
-    // Root paths to check against.
-    const rootsToTry = [projectRoot, process.cwd()];
-
-    const matched = getSourceDirs().some((dir) => {
-      return rootsToTry.some((root) => {
-        const absDir = path.resolve(root, dir);
-        if (absFilename.startsWith(absDir + path.sep) || absFilename === absDir)
-          return true;
-
-        if (dir.startsWith("app/") && root.endsWith("/app")) {
-          const relativeDir = dir.substring(4);
-          const absDirAlt = path.resolve(root, relativeDir);
-          return absFilename.startsWith(absDirAlt + path.sep) || absFilename === absDirAlt;
-        }
-
-        return false;
-      });
+    const matched = isFileInConfiguredSourceScope({
+      filename,
+      projectRoot,
+      viewsDirAbs: getViewsDirAbs(),
+      sourceDirs: getSourceDirs(),
+      extraRoots: [process.cwd()],
     });
 
     if (cleanPath.endsWith(".vue") && !matched) {
+      const absFilename = path.normalize(path.isAbsolute(cleanPath) ? cleanPath : path.resolve(projectRoot, cleanPath));
       loggerRef.current.debug(`[isFileInScope] REJECTED: ${absFilename} (Clean: ${cleanPath})`);
     }
 

--- a/tests/path-utils-scope.test.ts
+++ b/tests/path-utils-scope.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment node
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { isFileInConfiguredSourceScope } from "../plugin/path-utils";
+
+describe("isFileInConfiguredSourceScope", () => {
+  it("matches mixed-separator Windows paths against cwd-based Nuxt source dirs", () => {
+    expect(isFileInConfiguredSourceScope({
+      filename: "C:/repo/app/pages/administration/firms/index.vue?vue&type=template",
+      projectRoot: "C:\\repo\\app",
+      viewsDirAbs: "C:\\repo\\app\\src\\views",
+      sourceDirs: ["app/pages", "app/components", "app/layouts"],
+      extraRoots: ["C:\\repo"],
+      pathImpl: path.win32,
+    })).toBe(true);
+  });
+
+  it("matches app/* source dirs when the configured root is already the app directory", () => {
+    expect(isFileInConfiguredSourceScope({
+      filename: "C:\\repo\\app\\pages\\index.vue",
+      projectRoot: "C:\\repo\\app",
+      viewsDirAbs: "C:\\repo\\app\\src\\views",
+      sourceDirs: ["app/pages"],
+      pathImpl: path.win32,
+    })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- normalize file-scope path comparisons so mixed-separator paths match consistently
- treat an app-root project directory consistently when resolving `app/*` source dirs
- add focused win32 regressions for Nuxt-style source roots

## Validation
- `npx eslint plugin/path-utils.ts plugin/vue-plugin.ts tests/path-utils-scope.test.ts`
- `npm run typecheck`
- `npm test -- tests/path-utils-scope.test.ts tests/component-naming.test.ts tests/build-serve-parity.test.ts tests/vue-plugin-state.test.ts`
- `npm run build`

## Notes
- `npm run lint` fails on current `main` with pre-existing unrelated errors outside these files; this change keeps the touched files lint-clean.