### PR TITLE
feat: export mountAnnotatorClient from main entry point

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 import createVuePomGeneratorPlugins from "./plugin/create-vue-pom-generator-plugins";
+import { mountAnnotatorClient } from "./plugin/runtime/annotator/client";
 
 import type { NuxtPomGeneratorPluginOptions, VuePomGeneratorPluginOptions } from "./plugin/types";
 
@@ -7,6 +8,8 @@ const nuxtConfigMarker = Symbol.for("@immense/vue-pom-generator.nuxt");
 export { createVuePomGeneratorPlugins };
 export { createVuePomGeneratorPlugins as vuePomGenerator };
 export default createVuePomGeneratorPlugins;
+
+export { mountAnnotatorClient };
 
 export function defineVuePomGeneratorConfig(options: VuePomGeneratorPluginOptions): VuePomGeneratorPluginOptions {
   return options;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@babel/types": "^7.28.5",
         "@floating-ui/core": "^1.7.5",
         "@github/copilot-sdk": "^0.1.8",
-        "@playwright/test": "1.59.1",
+        "@playwright/test": "1.61.0",
         "@types/jsdom": "^27.0.0",
         "@types/node": "^24.1.0",
         "@vitest/coverage-v8": "^4.0.16",
@@ -25,7 +25,7 @@
         "eslint": "^9.27.0",
         "jsdom": "^27.4.0",
         "knip": "^5.82.1",
-        "playwright": "1.59.1",
+        "playwright": "1.61.0",
         "simple-git-hooks": "^2.13.1",
         "typescript": "^5.9.2",
         "vite": "^7.3.1",
@@ -40,7 +40,7 @@
         "@vue/compiler-dom": ">=3.5",
         "@vue/compiler-sfc": ">=3.5",
         "eslint": ">=9",
-        "playwright": ">=1.59.1 <2",
+        "playwright": ">=1.61.0 <2",
         "vite": "^5 || ^6 || ^7"
       },
       "peerDependenciesMeta": {
@@ -1818,13 +1818,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -6603,13 +6603,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -6622,9 +6622,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@vue/compiler-dom": ">=3.5",
     "@vue/compiler-sfc": ">=3.5",
     "eslint": ">=9",
-    "playwright": ">=1.59.1 <2",
+    "playwright": ">=1.61.0 <2",
     "vite": "^5 || ^6 || ^7"
   },
   "peerDependenciesMeta": {
@@ -79,7 +79,7 @@
     "@babel/types": "^7.28.5",
     "@floating-ui/core": "^1.7.5",
     "@github/copilot-sdk": "^0.1.8",
-    "@playwright/test": "1.59.1",
+    "@playwright/test": "1.61.0",
     "@types/jsdom": "^27.0.0",
     "@types/node": "^24.1.0",
     "@vitest/coverage-v8": "^4.0.16",
@@ -87,7 +87,7 @@
     "eslint": "^9.27.0",
     "jsdom": "^27.4.0",
     "knip": "^5.82.1",
-    "playwright": "1.59.1",
+    "playwright": "1.61.0",
     "simple-git-hooks": "^2.13.1",
     "typescript": "^5.9.2",
     "vite": "^7.3.1",


### PR DESCRIPTION
Allows consumers to import `mountAnnotatorClient` directly from `@immense/vue-pom-generator` instead of needing a deep path alias to `plugin/runtime/annotator/client.ts`.

This is needed for the Immybot PR #8752 to enable the annotator in preview builds with a clean import path.