### PR TITLE
fix: stop passing glob paths to server.watcher.add()

### DIFF
--- a/plugin/internal/dev-plugin.ts
+++ b/plugin/internal/dev-plugin.ts
@@ -455,12 +455,14 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
         return currentRun;
       };
 
-      const watchedVueGlobs = getSourceDirRoots().map(scanDirAbs => path.resolve(scanDirAbs, "**", "*.vue"));
-      const watchedPluginGlob = path.resolve(projectRootRef.current, "vite-plugins", "vue-pom-generator", "**", "*.ts");
+      // Never pass globs to watcher.add(): Vite creates chokidar with disableGlobbing,
+      // and on Windows the resulting ENOENT fallback poisons the glob's parent directory,
+      // permanently disabling watching/HMR for that subtree. Source dirs are already
+      // covered by Vite's recursive root watch, so only real paths are added here.
       const runtimeDir = path.dirname(basePageClassPath);
+      const localPluginDir = path.resolve(projectRootRef.current, "vite-plugins", "vue-pom-generator");
       server.watcher.add([
-        ...watchedVueGlobs,
-        watchedPluginGlob,
+        ...(fs.existsSync(localPluginDir) ? [localPluginDir] : []),
         basePageClassPath,
         path.resolve(runtimeDir, "pointer.ts"),
         path.resolve(runtimeDir, "callout.ts"),


### PR DESCRIPTION
## Why

The dev plugin passed `path.resolve(dir, "**", "*.vue")` globs to `server.watcher.add()`. Vite creates its chokidar watcher with `disableGlobbing: true`, so these are treated as literal paths. On Windows they stat ENOENT and chokidar's retry logic registers the glob's parent directory (src/views, src/components, src/layouts) as already-watched before the initial scan reaches it. The scan then skips those directories permanently: no file events, no HMR, no errors. macOS is unaffected (fsevents code path), which is why this only ever bit Windows devs.

## What this changes

Drop the globs entirely. They were inert on every platform (chokidar never expands them under `disableGlobbing`), and source dirs are already covered by Vite's recursive root watch. The real runtime file adds are kept, and the optional `vite-plugins/vue-pom-generator` dir is now added as a literal path when it exists, so the existing restart-on-change handler for it still works.

## Proven

- Bisected in a consuming app on Windows: watcher healthy with every plugin until vue-pom-generator-dev loads; replaying just its `watcher.add()` call reproduces the dead subtree, one directory per glob.
- With the globs removed, the same setup restores full watching of the entire source tree and live component-level HMR, verified in the browser with no reloads.
- Typecheck clean; vitest identical before and after (same pre-existing Windows env failures only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)