### PR TITLE
fix: preserve existing data-testid on @click elements with existingIdBehavior=preserve

### DIFF
--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -346,6 +346,24 @@ describe('createTestIdTransform', () => {
     expect(testId).toBe('already')
   })
 
+  it('preserves existing dynamic data-testid on @click element when existingIdBehavior is preserve', () => {
+    const componentHierarchyMap = new Map<string, IComponentDependencies>()
+
+    const ast = compileAndCaptureAst(
+      `<button :data-testid="\`select-all-\${subject.id}\`" @click="selectAll">Select All</button>`,
+      {
+        filename: '/src/components/MyComp.vue',
+        nodeTransforms: [createTestIdTransform('MyComp', componentHierarchyMap, {}, [], '/src/views', { existingIdBehavior: 'preserve' })],
+      },
+    )
+
+    // The author's dynamic testid must be preserved, NOT overwritten with
+    // a generated one like "MyComp-SelectAll-button".
+    const testId = findFirstDataTestId(ast)
+    expect(testId).toContain('select-all-')
+    expect(testId).not.toBe('MyComp-SelectAll-button')
+  })
+
   it('preserves simple member-expression data-testid when existingIdBehavior is preserve', () => {
     const componentHierarchyMap = new Map<string, IComponentDependencies>()
 

--- a/transform.ts
+++ b/transform.ts
@@ -1505,8 +1505,16 @@ export function createTestIdTransform(
     // - @click nodes
     // - submit buttons with an id/name
     // - nodes that require option-data-testid-prefix (even if they don't have click/submit)
+    // Check for an existing data-testid BEFORE the @click path so that
+    // existingIdBehavior="preserve" is honored for clickable elements too.
+    // Without this, a <button @click="selectAll" :data-testid="`select-all-${id}`">
+    // would be silently overwritten with a generated testid.
+    // When existingIdBehavior is "overwrite", we still want the @click path to run
+    // so the generated testid reflects the click handler semantics.
+    const existingElementDataTestId = tryGetExistingElementDataTestId(element, testIdAttribute);
+    const shouldPreserveExisting = existingElementDataTestId && existingIdBehavior === "preserve";
     const clickDirective = tryGetClickDirective(element);
-    if (clickDirective) {
+    if (clickDirective && !shouldPreserveExisting) {
       const clickSuffix = getComposedClickHandlerContent(element, context, innerText, clickDirective, {
         componentName,
         contextFilename: context.filename,
@@ -1547,7 +1555,6 @@ export function createTestIdTransform(
       return;
     }
 
-    const existingElementDataTestId = tryGetExistingElementDataTestId(element, testIdAttribute);
     if (existingElementDataTestId) {
       // Only generate POM members for existing test ids when the element is something we
       // consider interactive (based on role inferred from tag suffix).


### PR DESCRIPTION
## Problem

When an element has both @click and an existing :data-testid, the generator routed it through the click-directive path — generating a new testid and silently overwriting the author's existing one, even when existingIdBehavior was set to 'preserve'.

This was especially problematic for dynamically-keyed testids on buttons rendered in slot contexts (no v-for key to match), where the generated testid lost per-item uniqueness.

## Fix

Check for an existing data-testid before entering the click-directive path when existingIdBehavior is 'preserve'. When it's 'overwrite' or 'error', the click-directive path still runs as before.

## Test

Added a test verifying a <button> with @click and a dynamic :data-testid preserves the author's testid instead of generating a new one.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>