### PR TITLE
feat: add no-raw-playwright-apis ESLint rule

### DIFF
--- a/eslint/index.ts
+++ b/eslint/index.ts
@@ -2,6 +2,7 @@ import type { Rule } from "eslint";
 import type { CallExpression, Expression, MemberExpression } from "estree";
 
 import { noPageFixtureInSpecsRule } from "./no-page-fixture-in-specs";
+import { noRawPlaywrightApisRule } from "./no-raw-playwright-apis";
 import { removeExistingTestIdAttributesRule } from "./remove-existing-test-id-attributes";
 
 /**
@@ -106,9 +107,11 @@ export const plugin = {
 	rules: {
 		"no-page-fixture-in-specs": noPageFixtureInSpecsRule,
 		"no-raw-locator-action": noRawLocatorActionRule,
+		"no-raw-playwright-apis": noRawPlaywrightApisRule,
 		"remove-existing-test-id-attributes": removeExistingTestIdAttributesRule,
 	},
 } satisfies { rules: Record<string, Rule.RuleModule> };
 
 export { noPageFixtureInSpecsRule };
+export { noRawPlaywrightApisRule };
 export { removeExistingTestIdAttributesRule };

--- a/eslint/no-raw-playwright-apis.ts
+++ b/eslint/no-raw-playwright-apis.ts
@@ -1,0 +1,97 @@
+import type { Rule } from "eslint";
+
+const bannedPlaywrightApis = new Set(["locator", "getByRole", "getByText", "getByLabel"]);
+
+const bannedPageApis = new Set([
+	"$eval",
+	"$$eval",
+	"click",
+	"evaluate",
+	"isHidden",
+	"isVisible",
+	"waitForSelector",
+]);
+
+const SPEC_FILE_SUFFIXES = [".spec.ts", ".spec.tsx", ".spec.js", ".spec.jsx"];
+
+function isSpecFile(filename: string): boolean {
+	return SPEC_FILE_SUFFIXES.some((suffix) => filename.endsWith(suffix));
+}
+
+export const noRawPlaywrightApisRule: Rule.RuleModule = {
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Ban raw Playwright APIs in spec files. Use generated fixtures/POMs or a custom POM for unsupported surfaces instead.",
+		},
+		messages: {
+			legacyCursorHelper:
+				"Do not use {{name}} in Playwright spec files. Prefer generated fixtures/POMs or a custom POM for unsupported surfaces.",
+			rawPlaywrightApi:
+				"Do not call {{name}} directly in Playwright spec files. Prefer generated fixtures/POM methods or a custom POM for unsupported surfaces.",
+			rawPlaywrightPageApi:
+				"Do not call page.{{name}} directly in Playwright spec files. Prefer generated fixtures/POM methods or a custom POM for unsupported surfaces.",
+		},
+		schema: [],
+	},
+	create(context) {
+		if (!isSpecFile(context.filename)) {
+			return {};
+		}
+
+		const sourceCode = context.sourceCode;
+
+		return {
+			CallExpression(node) {
+				if (node.callee.type === "Identifier" && node.callee.name.includes("animateCursor")) {
+					context.report({
+						node: node.callee,
+						messageId: "legacyCursorHelper",
+						data: {
+							name: node.callee.name,
+						},
+					});
+					return;
+				}
+
+				if (
+					node.callee.type !== "MemberExpression"
+					|| node.callee.computed
+					|| node.callee.property.type !== "Identifier"
+				) {
+					return;
+				}
+
+				const objectText = sourceCode.getText(node.callee.object);
+				const apiName = node.callee.property.name;
+
+				if (
+					(objectText === "page" || objectText === "playwrightPage")
+					&& bannedPageApis.has(apiName)
+				) {
+					context.report({
+						node: node.callee.property,
+						messageId: "rawPlaywrightPageApi",
+						data: {
+							name: apiName,
+						},
+					});
+					return;
+				}
+
+				if (!bannedPlaywrightApis.has(apiName)) {
+					return;
+				}
+
+				context.report({
+					node: node.callee.property,
+					messageId: "rawPlaywrightApi",
+					data: {
+						name: apiName,
+					},
+				});
+			},
+		};
+	},
+};

--- a/tests/eslint.test.ts
+++ b/tests/eslint.test.ts
@@ -2,7 +2,7 @@
 import { RuleTester } from "eslint";
 import { describe, it } from "vitest";
 
-import { noPageFixtureInSpecsRule, noRawLocatorActionRule } from "../eslint/index";
+import { noPageFixtureInSpecsRule, noRawLocatorActionRule, noRawPlaywrightApisRule } from "../eslint/index";
 
 const tester = new RuleTester({
 	languageOptions: { ecmaVersion: 2022, sourceType: "module" },
@@ -122,6 +122,80 @@ describe("no-page-fixture-in-specs", () => {
 					code: "it('aliases page', async ({ page: currentPage }) => { await currentPage.goto('/'); });",
 					filename: "/tmp/dashboard.spec.ts",
 					errors: [{ messageId: "noPageFixture" }],
+				},
+			],
+		});
+	});
+});
+ 
+describe("no-raw-playwright-apis", () => {
+	it("allows generated fixture/POM usage in spec files", () => {
+		tester.run("no-raw-playwright-apis", noRawPlaywrightApisRule, {
+			valid: [
+				{
+					code: "test('example', async ({ tagsListPage }) => { await tagsListPage.clickRemove(); });",
+					filename: "/tmp/example.spec.ts",
+				},
+			],
+			invalid: [],
+		});
+	});
+
+	it("ignores non-spec files", () => {
+		tester.run("no-raw-playwright-apis", noRawPlaywrightApisRule, {
+			valid: [
+				{
+					code: "export function useHelper(page) { return page.getByText('ok'); }",
+					filename: "/tmp/helpers.ts",
+				},
+			],
+			invalid: [],
+		});
+	});
+
+	it("flags animateCursor helper calls", () => {
+		tester.run("no-raw-playwright-apis", noRawPlaywrightApisRule, {
+			valid: [],
+			invalid: [
+				{
+					code: "animateCursorToElementAndClick(page, '#btn');",
+					filename: "/tmp/example.spec.ts",
+					errors: [{ messageId: "legacyCursorHelper" }],
+				},
+			],
+		});
+	});
+
+	it("flags raw locator query APIs", () => {
+		tester.run("no-raw-playwright-apis", noRawPlaywrightApisRule, {
+			valid: [],
+			invalid: [
+				{
+					code: "page.locator('button'); page.getByRole('button'); page.getByText('Save'); page.getByLabel('Name');",
+					filename: "/tmp/example.spec.ts",
+					errors: [
+						{ messageId: "rawPlaywrightApi" },
+						{ messageId: "rawPlaywrightApi" },
+						{ messageId: "rawPlaywrightApi" },
+						{ messageId: "rawPlaywrightApi" },
+					],
+				},
+			],
+		});
+	});
+
+	it("flags direct page selector APIs", () => {
+		tester.run("no-raw-playwright-apis", noRawPlaywrightApisRule, {
+			valid: [],
+			invalid: [
+				{
+					code: "await page.click('#save'); await page.evaluate(() => 1); await page.waitForSelector('#save');",
+					filename: "/tmp/example.spec.ts",
+					errors: [
+						{ messageId: "rawPlaywrightPageApi" },
+						{ messageId: "rawPlaywrightPageApi" },
+						{ messageId: "rawPlaywrightPageApi" },
+					],
 				},
 			],
 		});


### PR DESCRIPTION
Moves the `no-legacy-playwright-spec-apis` rule from immybot's local `frontend/eslint-rules/` into the vue-pom-generator ESLint plugin so all POM-related lint rules live in one place.

## What it does

Bans raw Playwright APIs in spec files:
- **Locator queries**: `locator`, `getByRole`, `getByText`, `getByLabel`
- **Page methods**: `page.click`, `page.evaluate`, `page.waitForSelector`, `page.$eval`, `page.$$eval`, `page.isHidden`, `page.isVisible`
- **Cursor helpers**: any function matching `*animateCursor*`

Only applies to `.spec.ts` / `.spec.tsx` / `.spec.js` / `.spec.jsx` files.

## Why

The generator produces typed fixtures and POMs. This rule enforces their adoption by blocking the raw APIs they replace — catching regressions when specs are written or migrated.

## Tests

5 new test cases covering: generated fixture usage (valid), non-spec files (valid), animateCursor helpers (invalid), raw locator queries (invalid), direct page APIs (invalid).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>