### PR TITLE
fix: preserve slot-scope key detection through v-if wrappers

### DIFF
--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -619,6 +619,54 @@ describe('createTestIdTransform', () => {
     expect(testId).toBe('`MyComp-${data.key ?? data.data?.id ?? data.id ?? data.value ?? data}-OpenProject-button`')
   })
 
+  it('injects a stable keyed test id for scoped slot data objects through v-if wrappers', () => {
+    const componentHierarchyMap = new Map()
+
+    const ast = compileAndCaptureAst(
+      `
+        <ImmyList :items="items">
+          <template #item="{ data: maintenanceItem }">
+            <ImmyRow>
+              <ImmyCol>
+                <div v-if="!readonly">
+                  <ImmyButton @click="moveToTop(maintenanceItem)">Top</ImmyButton>
+                </div>
+              </ImmyCol>
+            </ImmyRow>
+          </template>
+        </ImmyList>
+      `,
+      {
+        filename: '/src/components/MyComp.vue',
+        nodeTransforms: [createTestIdTransform('MyComp', componentHierarchyMap, {}, [], '/src/views')],
+      },
+    )
+
+    const testId = findFirstDataTestId(ast)
+    expect(testId).toBe('`MyComp-${maintenanceItem.key ?? maintenanceItem.data?.id ?? maintenanceItem.id ?? maintenanceItem.value ?? maintenanceItem}-MoveToTop-button`')
+  })
+
+  it('injects a stable keyed test id for scoped slot data objects with key prop', () => {
+    const componentHierarchyMap = new Map()
+
+    const ast = compileAndCaptureAst(
+      `
+        <ImmyList :items="items">
+          <template #item="{ data, key }">
+            <button @click="remove(data)">Remove</button>
+          </template>
+        </ImmyList>
+      `,
+      {
+        filename: '/src/components/MyComp.vue',
+        nodeTransforms: [createTestIdTransform('MyComp', componentHierarchyMap, {}, [], '/src/views')],
+      },
+    )
+
+    const testId = findFirstDataTestId(ast)
+    expect(testId).toBe('`MyComp-${key}-Remove-button`')
+  })
+
   it('injects native input test ids from static ids before falling back to v-model', () => {
     const componentHierarchyMap = new Map()
 

--- a/transform.ts
+++ b/transform.ts
@@ -1027,9 +1027,16 @@ export function createTestIdTransform(
           && !!p.exp,
       );
     }
+    // When the immediate parent is a non-element wrapper (IF_BRANCH, FOR, IF),
+    // fall back to context.grandParent to maintain the element-to-element chain
+    // in the hierarchy map. This ensures slot-scope and v-for key detection can
+    // walk past v-if/v-for wrappers to find the enclosing <template> or v-for element.
+    const grandParent = (context as { grandParent?: { type?: number } }).grandParent;
     const parentElement = (!parentIsRoot && context?.parent?.type === NodeTypes.ELEMENT)
       ? (context.parent as ElementNode)
-      : null;
+      : (!parentIsRoot && grandParent?.type === NodeTypes.ELEMENT)
+        ? (grandParent as ElementNode)
+        : null;
     hierarchyMap.set(element, parentElement);
 
     // Convert any path (including Windows "C:\\..." and Vite /@fs/ paths) into a


### PR DESCRIPTION
## Problem

When an element inside a scoped slot (e.g. `<template #item="{ data }">`) was wrapped in a `v-if` directive, Vue's compiler inserts an `IF_BRANCH` node between the element and its parent. The generator's hierarchy map only recorded element-to-element parents, breaking the chain at the `IF_BRANCH` boundary.

This caused the slot-scope key detection walk (in `getContainedInSlotDataKeyInfo`) to stop at the `v-if` wrapper and never reach the enclosing `<template>` slot element. The result: **static (non-keyed) testids** instead of keyed ones for any `@click` element inside a `v-if` inside a slot.

### Example

```vue
<ImmyList :items="items">
  <template #item="{ data: maintenanceItem }">
    <div v-if="!readonly">
      <ImmyButton @click="moveToTop(maintenanceItem)">Top</ImmyButton>
    </div>
  </template>
</ImmyList>
```

**Before:** `MaintenanceItemOrderList-MoveToTop-button` (static — all rows share one testid)

**After:** `MaintenanceItemOrderList-${maintenanceItem.key ?? maintenanceItem.data?.id ?? ...}-MoveToTop-button` (keyed per row)

## Fix

Fall back to `context.grandParent` when the immediate parent (`context.parent`) is a non-element wrapper (`IF_BRANCH`, `FOR`, `IF`), maintaining the element-to-element chain in the hierarchy map.

## Tests

Added 2 tests:
- Scoped slot with v-if wrapper (renamed binding `{ data: maintenanceItem }`)
- Scoped slot with explicit `key` prop (`{ data, key }`)

All 202 tests pass (200 existing + 2 new).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>