### PR TITLE
feat: cross-file key registry for child components in keyed slots

### DIFF
--- a/plugin/create-vue-pom-generator-plugins.ts
+++ b/plugin/create-vue-pom-generator-plugins.ts
@@ -217,6 +217,7 @@ interface SharedGeneratorState {
   elementMetadata: Map<string, Map<string, ElementMetadata>>;
   semanticNameMap: Map<string, string>;
   componentHierarchyMap: Map<string, IComponentDependencies>;
+  crossFileKeyRegistry: Map<string, string>;
   vueFilesPathMap: Map<string, string>;
 }
 
@@ -233,6 +234,7 @@ function getSharedGeneratorState(key: string): SharedGeneratorState {
       elementMetadata: new Map<string, Map<string, ElementMetadata>>(),
       semanticNameMap: new Map<string, string>(),
       componentHierarchyMap: new Map<string, IComponentDependencies>(),
+      crossFileKeyRegistry: new Map<string, string>(),
       vueFilesPathMap: new Map<string, string>(),
     };
     sharedGeneratorStateRegistry.set(key, state);
@@ -487,7 +489,7 @@ export function createVuePomGeneratorPlugins(options: PomGeneratorPluginOptions 
   const getViewsDirAbs = () => resolveFromProjectRoot(projectRootRef.current, getViewsDir());
   const getWrapperSearchRootsAbs = () => getWrapperSearchRoots().map(root => resolveFromProjectRoot(projectRootRef.current, root));
 
-  const { elementMetadata, semanticNameMap, componentHierarchyMap, vueFilesPathMap } = sharedState;
+  const { elementMetadata, semanticNameMap, componentHierarchyMap, crossFileKeyRegistry, vueFilesPathMap } = sharedState;
 
   const { metadataCollectorPlugin, internalVuePlugin, templateCompilerOptions } = createVuePluginWithTestIds({
     vueOptions,
@@ -498,6 +500,7 @@ export function createVuePomGeneratorPlugins(options: PomGeneratorPluginOptions 
     elementMetadata,
     semanticNameMap,
     componentHierarchyMap,
+    crossFileKeyRegistry,
     vueFilesPathMap,
     excludedComponents,
     getViewsDirAbs,
@@ -516,6 +519,7 @@ export function createVuePomGeneratorPlugins(options: PomGeneratorPluginOptions 
 
   const internalPlugins = createInternalPlugins({
     componentHierarchyMap,
+    crossFileKeyRegistry,
     elementMetadata,
     vueFilesPathMap,
     nativeWrappers,

--- a/plugin/internal-plugins.ts
+++ b/plugin/internal-plugins.ts
@@ -13,6 +13,7 @@ import { createAnnotatorUiPlugin } from "./runtime/annotator/plugin";
 
 interface InternalPluginFactoryOptions {
   componentHierarchyMap: Map<string, IComponentDependencies>;
+  crossFileKeyRegistry: Map<string, string>;
   elementMetadata: Map<string, Map<string, ElementMetadata>>;
   vueFilesPathMap: Map<string, string>;
   nativeWrappers: NativeWrappersMap;
@@ -43,6 +44,7 @@ interface InternalPluginFactoryOptions {
 export function createInternalPlugins(options: InternalPluginFactoryOptions): PluginOption[] {
   const {
     componentHierarchyMap,
+    crossFileKeyRegistry,
     elementMetadata,
     vueFilesPathMap,
     nativeWrappers,
@@ -108,6 +110,7 @@ export function createInternalPlugins(options: InternalPluginFactoryOptions): Pl
 
   const tsProcessor = createBuildProcessorPlugin({
     componentHierarchyMap,
+    crossFileKeyRegistry,
     vueFilesPathMap,
     getPageDirs,
     getComponentDirs,

--- a/plugin/internal/build-plugin.ts
+++ b/plugin/internal/build-plugin.ts
@@ -18,6 +18,7 @@ import type { ResolvedGenerationSupportOptions } from "../resolved-generation-op
 
 interface BuildProcessorOptions {
   componentHierarchyMap: Map<string, IComponentDependencies>;
+  crossFileKeyRegistry: Map<string, string>;
   vueFilesPathMap: Map<string, string>;
   getPageDirs: () => string[];
   getComponentDirs: () => string[];
@@ -80,6 +81,7 @@ function isLessRich(candidate: HierarchyGenerationMetrics, previous: HierarchyGe
 export function createBuildProcessorPlugin(options: BuildProcessorOptions): PluginOption {
   const {
     componentHierarchyMap,
+    crossFileKeyRegistry,
     vueFilesPathMap,
     getPageDirs,
     getComponentDirs,
@@ -252,6 +254,7 @@ export function createBuildProcessorPlugin(options: BuildProcessorOptions): Plug
                   warn: (message: string) => loggerRef.current.warn(message),
                   vueFilesPathMap,
                   wrapperSearchRoots: getWrapperSearchRoots(),
+                  crossFileKeyRegistry,
                 },
               ),
             ],

--- a/plugin/internal/dev-plugin.ts
+++ b/plugin/internal/dev-plugin.ts
@@ -288,6 +288,7 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
         const { bindings: bindingMetadata, isScriptSetup } = getScriptInfo(sfc, absolutePath);
 
         const provisionalHierarchy = new Map<string, IComponentDependencies>();
+        const provisionalKeyRegistry = new Map<string, string>();
         const provisionalVuePathMap = new Map(targetVuePathMap);
         provisionalVuePathMap.set(componentName, absolutePath);
 
@@ -317,6 +318,7 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
                 warn: message => loggerRef.current.warn(message),
                 vueFilesPathMap: provisionalVuePathMap,
                 wrapperSearchRoots: getWrapperSearchRoots(),
+                crossFileKeyRegistry: provisionalKeyRegistry,
               },
             ),
           ],

--- a/plugin/vue-plugin.ts
+++ b/plugin/vue-plugin.ts
@@ -12,6 +12,7 @@ import { findDataTestIdProp, tryCreateElementMetadata } from "../compiler-metada
 import { buildPomManifest } from "../manifest-generator";
 import type { ElementMetadata } from "../metadata-collector";
 import { createTestIdTransform } from "../transform";
+import type { CrossFileKeyRegistry } from "../transform";
 import type { IComponentDependencies, NativeWrappersMap } from "../utils";
 
 import type { VuePomGeneratorLogger } from "./logger";
@@ -27,6 +28,7 @@ interface InternalFactoryOptions {
   elementMetadata: Map<string, Map<string, ElementMetadata>>;
   semanticNameMap: Map<string, string>;
   componentHierarchyMap: Map<string, IComponentDependencies>;
+  crossFileKeyRegistry: CrossFileKeyRegistry;
   vueFilesPathMap: Map<string, string>;
   excludedComponents: string[];
   getViewsDirAbs: () => string;
@@ -131,6 +133,7 @@ export function createVuePluginWithTestIds(options: InternalFactoryOptions): {
     elementMetadata,
     semanticNameMap,
     componentHierarchyMap,
+    crossFileKeyRegistry,
     vueFilesPathMap,
     excludedComponents,
     getViewsDirAbs,
@@ -219,6 +222,7 @@ export function createVuePluginWithTestIds(options: InternalFactoryOptions): {
                   vueFilesPathMap,
                   wrapperSearchRoots: getWrapperSearchRoots(),
                   annotatorMetadata,
+                  crossFileKeyRegistry,
                 },
               ),
             );
@@ -283,6 +287,7 @@ export function createVuePluginWithTestIds(options: InternalFactoryOptions): {
                 vueFilesPathMap,
                 wrapperSearchRoots: getWrapperSearchRoots(),
                 annotatorMetadata,
+                crossFileKeyRegistry,
               },
             );
           perFileTransform.set(componentName, transform);

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -97,6 +97,7 @@ function compileWithRuntimeTemplateOptions(
     elementMetadata: new Map(),
     semanticNameMap: new Map(),
     componentHierarchyMap,
+    crossFileKeyRegistry: new Map(),
     vueFilesPathMap: new Map(),
     excludedComponents: [],
     getViewsDirAbs: () => '/src/views',
@@ -665,6 +666,67 @@ describe('createTestIdTransform', () => {
 
     const testId = findFirstDataTestId(ast)
     expect(testId).toBe('`MyComp-${key}-Remove-button`')
+  })
+
+  it('keys child component testids via cross-file key registry', () => {
+    // Simulate two-pass compilation: parent records key context, child consumes it.
+    const componentHierarchyMap = new Map()
+    const crossFileKeyRegistry = new Map<string, string>()
+
+    // Pass 1: PARENT — RolePermissions.vue renders RolePermissionSubject in a keyed slot
+    compileAndCaptureAst(
+      `
+        <ImmyList :items="subjects">
+          <template #item="{ data, key }">
+            <div>
+              <RolePermissionSubject :subject="data" :disabled="isDisabled" />
+            </div>
+          </template>
+        </ImmyList>
+      `,
+      {
+        filename: '/src/components/RolePermissions.vue',
+        nodeTransforms: [createTestIdTransform('RolePermissions', componentHierarchyMap, {}, [], '/src/views', { crossFileKeyRegistry })],
+      },
+    )
+
+    // The parent should have recorded that RolePermissionSubject receives slot data via "subject" prop
+    expect(crossFileKeyRegistry.get('RolePermissionSubject')).toBe('subject')
+
+    // Pass 2: CHILD — RolePermissionSubject.vue has @click buttons
+    const childAst = compileAndCaptureAst(
+      `
+        <button v-if="!disabled" @click="selectAll">Select All</button>
+      `,
+      {
+        filename: '/src/components/RolePermissionSubject.vue',
+        nodeTransforms: [createTestIdTransform('RolePermissionSubject', componentHierarchyMap, {}, [], '/src/views', { crossFileKeyRegistry })],
+      },
+    )
+
+    const testId = findFirstDataTestId(childAst)
+    expect(testId).toBe('`RolePermissionSubject-${subject.key ?? subject.data?.id ?? subject.id ?? subject.value ?? subject}-SelectAll-button`')
+  })
+
+  it('does not key child component testids when not in a keyed slot', () => {
+    const componentHierarchyMap = new Map()
+    const crossFileKeyRegistry = new Map<string, string>()
+
+    // Parent does NOT use a keyed slot — just renders the child directly
+    compileAndCaptureAst(
+      `
+        <div>
+          <RolePermissionSubject :subject="someData" :disabled="false" />
+        </div>
+      `,
+      {
+        filename: '/src/components/RolePermissions.vue',
+        nodeTransforms: [createTestIdTransform('RolePermissions', componentHierarchyMap, {}, [], '/src/views', { crossFileKeyRegistry })],
+      },
+    )
+
+    // Registry should NOT have an entry for RolePermissionSubject
+    expect(crossFileKeyRegistry.has('RolePermissionSubject')).toBe(false)
   })
 
   it('injects native input test ids from static ids before falling back to v-model', () => {

--- a/transform.ts
+++ b/transform.ts
@@ -53,6 +53,11 @@ import {
   NativeRole,
   applyResolvedDataTestId,
   tryGetExistingElementDataTestId,
+  buildSlotScopeFallbackKeyExpression,
+  toResolvedKeyInfo,
+  findTemplateSlotScopeExpression,
+  tryExtractSlotScopeVariableNames,
+  getContainedInSlotTemplateNode,
 } from "./utils";
 
 const CLICK_EVENT_NAME = TESTID_CLICK_EVENT_NAME;
@@ -847,6 +852,17 @@ function tryWrapClickDirectiveForTestEvents(
 
 let previousFileName = "";
 const hierarchyMap: HierarchyMap = new Map(); // key is child, value is parent
+
+/**
+ * Cross-file key context: when a child component is rendered inside a keyed slot scope,
+ * the parent records which prop receives the slot data. The child then uses that prop
+ * to key its internal testids.
+ *
+ * Key: child component name (PascalCase, as seen in the parent's template)
+ * Value: the prop name on the child that receives the slot-scope data object
+ */
+export type CrossFileKeyRegistry = Map<string, string>;
+
 /**
  * Creates a NodeTransform that adds data-testid attributes to elements
  */
@@ -868,6 +884,8 @@ export function createTestIdTransform(
       sourceAttribute: string;
       metadataAttributePrefix: string;
     } | null;
+    /** Shared registry for cross-file keyed slot context. */
+    crossFileKeyRegistry?: CrossFileKeyRegistry;
   } = {},
 ): NodeTransform {
   const existingIdBehavior = options.existingIdBehavior ?? "error";
@@ -878,6 +896,7 @@ export function createTestIdTransform(
   const vueFilesPathMap = options.vueFilesPathMap;
   const wrapperSearchRoots = options.wrapperSearchRoots ?? [];
   const annotatorMetadata = options.annotatorMetadata ?? null;
+  const crossFileKeyRegistry = options.crossFileKeyRegistry;
 
   // Some projects (and dev environments) use symlinks. We want viewsDir containment checks
   // to behave like the filesystem does (real paths), but we must not crash for virtual
@@ -1087,6 +1106,43 @@ export function createTestIdTransform(
     // This supports per-view helper attachment (e.g. Grid) based on component usage.
     if (isComponentLikeTag(element.tag)) {
       dependencies.usedComponentSet.add(element.tag);
+
+      // Cross-file key registry: if this component is inside a keyed slot scope,
+      // record which prop receives the slot data so the child can key its testids.
+      if (crossFileKeyRegistry && context.scopes.vSlot > 0) {
+        const findSlotTemplate = (): ElementNode | null => {
+          const gp = (context as { grandParent?: { type?: number; tag?: string } }).grandParent;
+          if (gp?.type === NodeTypes.ELEMENT && gp.tag === "template") {
+            return gp as ElementNode;
+          }
+          return getContainedInSlotTemplateNode(element, hierarchyMap);
+        };
+
+        const slotTemplate = findSlotTemplate();
+        if (slotTemplate) {
+          const slotScopeExpression = findTemplateSlotScopeExpression(slotTemplate);
+          if (slotScopeExpression) {
+            // Parse the slot scope to extract variable names (e.g. { data, key } → ["data", "key"])
+            const slotVarNames = tryExtractSlotScopeVariableNames(slotScopeExpression);
+            if (slotVarNames.length > 0) {
+              // Find a :prop="slotVar" binding where slotVar is one of the slot scope variables.
+              for (const prop of element.props) {
+                if (
+                  prop.type === NodeTypes.DIRECTIVE
+                  && prop.name === "bind"
+                  && prop.arg?.type === NodeTypes.SIMPLE_EXPRESSION
+                  && prop.exp?.type === NodeTypes.SIMPLE_EXPRESSION
+                  && slotVarNames.includes(prop.exp.content)
+                ) {
+                  const propName = (prop.arg as SimpleExpressionNode).content;
+                  crossFileKeyRegistry.set(element.tag, propName);
+                  break;
+                }
+              }
+            }
+          }
+        }
+      }
     }
 
     // Opportunistically infer wrapper semantics for simple "single native input" components
@@ -1116,7 +1172,22 @@ export function createTestIdTransform(
           return vForKeyInfo;
         }
 
-        return getContainedInSlotDataKeyInfo(element, hierarchyMap);
+        const slotKeyInfo = getContainedInSlotDataKeyInfo(element, hierarchyMap);
+        if (slotKeyInfo) {
+          return slotKeyInfo;
+        }
+
+        // Cross-file key registry: if this component was recorded by a parent as being
+        // rendered inside a keyed slot, use the registered prop to build a keyed expression.
+        if (crossFileKeyRegistry) {
+          const propName = crossFileKeyRegistry.get(componentName);
+          if (propName) {
+            const fallbackExpr = buildSlotScopeFallbackKeyExpression(propName);
+            return toResolvedKeyInfo(fallbackExpr, fallbackExpr);
+          }
+        }
+
+        return null;
       };
 
       // `bestKeyInfo` carries the keyed selector shape end-to-end:

--- a/utils.ts
+++ b/utils.ts
@@ -379,7 +379,7 @@ export function nodeHasClickDirective(node: ElementNode): boolean {
   return tryGetClickDirective(node) !== undefined;
 }
 
-function findTemplateSlotScopeExpression(node: ElementNode): VueExpressionNode | null {
+export function findTemplateSlotScopeExpression(node: ElementNode): VueExpressionNode | null {
   if (node.tag !== "template") {
     return null;
   }
@@ -427,7 +427,7 @@ function isSimpleScopeIdentifier(value: string): boolean {
   }
 }
 
-function buildSlotScopeFallbackKeyExpression(identifier: string): string {
+export function buildSlotScopeFallbackKeyExpression(identifier: string): string {
   return `${identifier}.key ?? ${identifier}.data?.id ?? ${identifier}.id ?? ${identifier}.value ?? ${identifier}`;
 }
 
@@ -617,7 +617,7 @@ function toResolvedTemplateFragment(source: string): InterpolatedTemplateFragmen
   return toInterpolatedTemplateFragment(source);
 }
 
-function toResolvedKeyInfo(selectorSource: string | null, runtimeSource: string | null = selectorSource): ResolvedKeyInfo | null {
+export function toResolvedKeyInfo(selectorSource: string | null, runtimeSource: string | null = selectorSource): ResolvedKeyInfo | null {
   const selectorFragment = selectorSource ? toResolvedTemplateFragment(selectorSource) : null;
   const runtimeFragment = runtimeSource ? toResolvedTemplateFragment(runtimeSource) : null;
   const selectorTemplate = selectorFragment?.template ?? runtimeFragment?.template ?? null;
@@ -633,10 +633,49 @@ function toResolvedKeyInfo(selectorSource: string | null, runtimeSource: string 
   };
 }
 
-function tryGetTemplateSlotScopeKeyInfo(expression: VueExpressionNode): ResolvedKeyInfo | null {
+export function tryGetTemplateSlotScopeKeyInfo(expression: VueExpressionNode): ResolvedKeyInfo | null {
   const bindingNode = tryGetTemplateSlotScopeBindingNode(expression);
   const candidateExpression = bindingNode ? tryGetSlotScopeKeyCandidate(bindingNode)?.expression ?? null : null;
   return candidateExpression ? toResolvedKeyInfo(candidateExpression) : null;
+}
+
+/**
+ * Extracts the variable names from a slot scope expression.
+ * e.g. `{ data, key }` → `["data", "key"]`
+ *      `{ data: maintenanceItem }` → `["maintenanceItem"]`
+ *      `item` → `["item"]`
+ */
+export function tryExtractSlotScopeVariableNames(expression: VueExpressionNode): string[] {
+  const bindingNode = tryGetTemplateSlotScopeBindingNode(expression);
+  if (!bindingNode) {
+    return [];
+  }
+
+  // Simple identifier: v-slot="item" → ["item"]
+  if (isIdentifier(bindingNode)) {
+    return [bindingNode.name];
+  }
+
+  // Object destructuring: { data, key } or { data: maintenanceItem }
+  if (!isObjectPattern(bindingNode)) {
+    return [];
+  }
+
+  const names: string[] = [];
+  for (const property of bindingNode.properties) {
+    if (isRestElement(property)) {
+      const argName = tryGetBindingIdentifierName(property.argument as BabelNode);
+      if (argName) names.push(argName);
+    }
+    else if (isObjectProperty(property)) {
+      const bindingName = tryGetBindingIdentifierName(property.value as BabelNode)
+        ?? tryGetBindingIdentifierName(property.key as BabelNode);
+      if (bindingName) {
+        names.push(bindingName);
+      }
+    }
+  }
+  return names;
 }
 
 /**
@@ -1082,12 +1121,26 @@ export function isNodeContainedInTemplateWithData(node: ElementNode, hierarchyMa
 }
 
 export function getContainedInSlotDataKeyInfo(node: ElementNode, hierarchyMap: HierarchyMap): ResolvedKeyInfo | null {
+  const templateNode = getContainedInSlotTemplateNode(node, hierarchyMap);
+  if (templateNode) {
+    const slotScopeExpression = findTemplateSlotScopeExpression(templateNode);
+    if (slotScopeExpression) {
+      return tryGetTemplateSlotScopeKeyInfo(slotScopeExpression);
+    }
+  }
+  return null;
+}
+
+/**
+ * Walks the hierarchy map upward to find the nearest enclosing <template> element
+ * that has a v-slot directive (i.e., a scoped slot template).
+ */
+export function getContainedInSlotTemplateNode(node: ElementNode, hierarchyMap: HierarchyMap): ElementNode | null {
   let parent = getParent(hierarchyMap, node);
   while (parent) {
     if (parent.type === NodeTypes.ELEMENT && parent.tag === "template") {
-      const slotScopeExpression = findTemplateSlotScopeExpression(parent);
-      if (slotScopeExpression) {
-        return tryGetTemplateSlotScopeKeyInfo(slotScopeExpression);
+      if (findTemplateSlotScopeExpression(parent)) {
+        return parent;
       }
     }
     parent = getParent(hierarchyMap, parent);


### PR DESCRIPTION
## What

When a child component is rendered inside a keyed slot scope (e.g. `<template #item="{ data, key }">`), the generator now automatically keys the child component's internal testids using the prop that receives the slot data.

## How

1. **Parent transform** (e.g. `RolePermissions.vue`): When visiting `<RolePermissionSubject :subject="data" />` inside a keyed slot, records to a shared registry: `RolePermissionSubject → "subject"`
2. **Child transform** (e.g. `RolePermissionSubject.vue`): When visiting `<button @click="selectAll">`, looks up the registry. If found, keys all testids: `RolePermissionSubject-${subject.key ?? subject.id ?? ...}-SelectAll-button`

This works because Rolldown processes modules depth-first from the entry point, guaranteeing the parent is always compiled before the child.

## Tests

- `keys child component testids via cross-file key registry` — full parent→child simulation
- `does not key child component testids when not in a keyed slot` — negative case

All 204 tests pass.

## Depends on

- PR #36 (merged, published as 1.0.77) — slot-scope key detection through v-if wrappers

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>