### PR TITLE
feat!: export withPomFixtures instead of a generated `test`

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,26 @@ test("shows the list", async ({ page }) => {
 
 **After**
 
+First compose your project's `test` once. The generator does **not** export a `test` — it
+exports `withPomFixtures`, which attaches the generated POM fixtures to a base you own:
+
 ```ts
-import { test, expect } from "../tests/playwright/__generated__/fixtures.g";
+// tests/playwright/test-base.ts
+import { test as playwrightTest, expect } from "@playwright/test";
+import { withPomFixtures } from "./__generated__/fixtures.g";
+
+// Anything added here is inherited by every spec: console-error capture,
+// error-overlay detection, auth, API cleanup, ...
+const base = playwrightTest.extend({ /* project-wide fixtures */ });
+
+export const test = withPomFixtures(base);
+export { expect };
+```
+
+Then specs import `test` from that module:
+
+```ts
+import { test, expect } from "../tests/playwright/test-base";
 
 test("shows the list", async ({ userListPage }) => {
   await userListPage.goTo();
@@ -150,6 +168,8 @@ Why this is better:
 - less setup noise in tests
 - fixture types stay aligned with generated classes
 - if `tests/playwright/pom/overrides/UserListPage.ts` exists, the fixture will instantiate that override class automatically
+- there is exactly one `test` object in the project, so project-wide fixtures cannot silently
+  miss some specs
 
 Without fixtures, you still use the generated POMs, but every test has to construct them manually.
 
@@ -612,6 +632,27 @@ Without `flatten`, helper composition still works; you just call through the hel
 
 When `generation.playwright.fixtures` is enabled, the generator emits a strongly typed Playwright fixture module.
 
+### The generated module does not own `test`
+
+`fixtures.g.ts` exports `withPomFixtures`, not a ready-made `test`. Owning the `test` object
+is a project concern: a project needs exactly one `test` so that project-wide fixtures
+(console-error capture, error-overlay detection, auth) are inherited by *every* spec. If the
+generator exported its own `test`, a project would end up with two runners and specs would
+silently miss whichever fixtures were attached to the other one.
+
+```ts
+// tests/playwright/test-base.ts — the single `test` your specs import
+import { test as playwrightTest, expect } from "@playwright/test";
+import { withPomFixtures } from "./__generated__/fixtures.g";
+
+export const test = withPomFixtures(playwrightTest.extend({ /* project-wide fixtures */ }));
+export { expect };
+```
+
+The module also exports the fixture types (`PomFixtures`, `GeneratedPageFixtures`,
+`GeneratedComponentFixtures`, `PlaywrightOptions`, `PomFactory`) and re-exports `expect`
+for convenience.
+
 What it gives you:
 
 - lower-camel-case fixtures for views (`UserListPage` → `userListPage`)
@@ -622,6 +663,7 @@ What it gives you:
 
 Current caveats:
 
+- `withPomFixtures` requires a base whose test args include Playwright's `page` (i.e. anything derived from `@playwright/test`'s `test`)
 - there are no generated `openXPage` helpers; tests call `goTo()` explicitly when available
 - override preference only affects fixture construction
 - component fixtures are skipped when their lower-camel-case name would collide with reserved Playwright fixture names such as `page`, `context`, `browser`, or `request`
@@ -808,8 +850,9 @@ Why it exists:
 Recommended usage:
 
 1. enable generated fixtures in the generator
-2. migrate specs from `({ page })` to generated fixtures like `({ dashboardPage })`
-3. turn this rule on for `tests/playwright/**/*.spec.ts`
+2. compose a single project `test` with `withPomFixtures` (see the fixtures section) and have specs import it
+3. migrate specs from `({ page })` to generated fixtures like `({ dashboardPage })`
+4. turn this rule on for `tests/playwright/**/*.spec.ts`
 
 Example flat config:
 

--- a/class-generation/index.ts
+++ b/class-generation/index.ts
@@ -1417,17 +1417,24 @@ function maybeGenerateFixtureRegistry(
   const fixturesContent = renderSourceFile(fixtureFileName, (sourceFile) => {
     sourceFile.addStatements("/** Generated Playwright fixtures (typed page objects). */");
 
+    // NOTE: this file intentionally does NOT create or export a `test` runner.
+    // Owning the `test` object is a project concern, not a code-generation concern:
+    // projects need to attach their own global fixtures (console-error capture,
+    // error-overlay detection, auth, ...) and there must be exactly one `test` that
+    // specs import. Instead we export `withPomFixtures`, which attaches the generated
+    // POM fixtures to whatever base `test` the project owns.
     addNamedImport(sourceFile, {
       moduleSpecifier: "@playwright/test",
-      namedImports: [
-        "expect",
-        { name: "test", alias: "base" },
-      ],
+      namedImports: ["expect"],
     });
     addNamedImport(sourceFile, {
       moduleSpecifier: "@playwright/test",
       isTypeOnly: true,
-      namedImports: [{ name: "Page", alias: "PwPage" }],
+      namedImports: [
+        { name: "Page", alias: "PwPage" },
+        "PlaywrightTestArgs",
+        "TestType",
+      ],
     });
     sourceFile.addImportDeclaration({
       namespaceImport: "Pom",
@@ -1514,6 +1521,15 @@ function maybeGenerateFixtureRegistry(
       name: "GeneratedComponentFixtures",
       type: "{ [K in keyof typeof componentCtors]: InstanceType<(typeof componentCtors)[K]> }",
     });
+    sourceFile.addTypeAlias({
+      isExported: true,
+      name: "PomFixtures",
+      docs: [{
+        description: "Every fixture contributed by the generator: the `animation` option, the internal\n"
+          + "`pomSetup`/`pomFactory` fixtures, and one fixture per generated page/component POM.",
+      }],
+      type: "PlaywrightOptions & PomSetupFixture & PomFactoryFixture & GeneratedPageFixtures & GeneratedComponentFixtures",
+    });
 
     sourceFile.addFunction({
       name: "makePomFixture",
@@ -1538,44 +1554,66 @@ function maybeGenerateFixtureRegistry(
       ],
     });
 
-    sourceFile.addVariableStatement({
-      declarationKind: VariableDeclarationKind.Const,
-      declarations: [{
-        name: "test",
-        initializer: (writer) => {
-          writer.write("base.extend<PlaywrightOptions & PomSetupFixture & PomFactoryFixture & GeneratedPageFixtures & GeneratedComponentFixtures>(");
-          writer.block(() => {
-            writer.writeLine("animation: [{");
-            writer.indent(() => {
-              writer.writeLine('pointer: { durationMilliseconds: 250, transitionStyle: "ease-in-out", clickDelayMilliseconds: 0 },');
-              writer.writeLine("keyboard: { typeDelayMilliseconds: 100 },");
-            });
-            writer.writeLine("}, { option: true }],");
-            writer.writeLine("pomSetup: [async ({ animation }, use) => {");
-            writer.indent(() => {
-              writer.writeLine("Pom.setPlaywrightAnimationOptions(animation);");
-              writer.writeLine("await use();");
-            });
-            writer.writeLine("}, { auto: true }],");
-            writer.writeLine("pomFactory: async ({ page }, use) => {");
-            writer.indent(() => {
-              writer.writeLine("await use({");
-              writer.indent(() => {
-                writer.writeLine("create: <T>(ctor: PomConstructor<T>) => new ctor(page),");
-              });
-              writer.writeLine("});");
-            });
-            writer.writeLine("},");
-            writer.writeLine("...createPomFixtures(pageCtors),");
-            writer.writeLine("...createPomFixtures(componentCtors),");
+    sourceFile.addStatements([
+      "/**",
+      " * Attach the generated POM fixtures to a project-owned Playwright `test`.",
+      " *",
+      " * This generator deliberately does not export a `test` of its own. Projects should own",
+      " * exactly one `test` object so project-wide fixtures (console-error capture, error-overlay",
+      " * detection, auth, ...) are inherited by every spec. Compose it once in a project module:",
+      " *",
+      " *   const base = playwrightTest.extend({ ...project-wide fixtures... });",
+      " *   export const test = withPomFixtures(base);",
+      " *",
+      " * Then have every spec import `test` from that module.",
+      " */",
+    ].join("\n"));
+    sourceFile.addFunction({
+      isExported: true,
+      name: "withPomFixtures",
+      typeParameters: [
+        { name: "TTestArgs", constraint: "PlaywrightTestArgs" },
+        { name: "TWorkerArgs", constraint: "object" },
+      ],
+      parameters: [{ name: "base", type: "TestType<TTestArgs, TWorkerArgs>" }],
+      returnType: "TestType<TTestArgs & PomFixtures, TWorkerArgs>",
+      statements: (writer) => {
+        writer.write("return base.extend<PomFixtures>(");
+        writer.block(() => {
+          writer.writeLine("animation: [{");
+          writer.indent(() => {
+            writer.writeLine('pointer: { durationMilliseconds: 250, transitionStyle: "ease-in-out", clickDelayMilliseconds: 0 },');
+            writer.writeLine("keyboard: { typeDelayMilliseconds: 100 },");
           });
-          writer.write(")");
-        },
-      }],
+          writer.writeLine("}, { option: true }],");
+          // The fixture callbacks are annotated explicitly rather than relying on
+          // contextual typing: `base` is generic here, so TypeScript cannot resolve
+          // Playwright's `Fixtures<...>` parameter types and the callbacks would
+          // otherwise be implicitly `any` (an error under `noImplicitAny`).
+          writer.writeLine("pomSetup: [async ({ animation }: PomFixtures, use: (r: void) => Promise<void>) => {");
+          writer.indent(() => {
+            writer.writeLine("Pom.setPlaywrightAnimationOptions(animation);");
+            writer.writeLine("await use();");
+          });
+          writer.writeLine("}, { auto: true }],");
+          writer.writeLine("pomFactory: async ({ page }: { page: PwPage }, use: (r: PomFactory) => Promise<void>) => {");
+          writer.indent(() => {
+            writer.writeLine("await use({");
+            writer.indent(() => {
+              writer.writeLine("create: <T>(ctor: PomConstructor<T>) => new ctor(page),");
+            });
+            writer.writeLine("});");
+          });
+          writer.writeLine("},");
+          writer.writeLine("...createPomFixtures(pageCtors),");
+          writer.writeLine("...createPomFixtures(componentCtors),");
+        });
+        writer.write(") as TestType<TTestArgs & PomFixtures, TWorkerArgs>;");
+      },
     });
 
     sourceFile.addExportDeclaration({
-      namedExports: ["test", "expect"],
+      namedExports: ["expect"],
     });
   }, {
     prefixText: buildFilePrefix({

--- a/tests/fixtures/generated-tsc/playwright-test.d.ts
+++ b/tests/fixtures/generated-tsc/playwright-test.d.ts
@@ -1,5 +1,9 @@
 /* eslint-disable */
 export type Page = any;
 export type Locator = any;
-export const test: { extend<T>(_fixtures: any): any };
+export type PlaywrightTestArgs = { page: Page };
+export type TestType<TestArgs = any, WorkerArgs = any> = {
+  extend<T>(_fixtures: any): TestType<TestArgs & T, WorkerArgs>;
+};
+export const test: TestType<PlaywrightTestArgs, {}>;
 export const expect: any;

--- a/tests/generated-tsc.test.ts
+++ b/tests/generated-tsc.test.ts
@@ -53,6 +53,12 @@ function runTscNoEmit(files: string[], options?: { cwd?: string }) {
     "false",
     // Keep this focused on syntactic/structural validity of generated output.
     // We provide a small stub BasePage so the generated file can typecheck.
+    //
+    // NOTE: deliberately no `--noImplicitAny` here. The Playwright stubs in
+    // tests/fixtures/generated-tsc type `Page`/`Locator` as `any`, so callbacks that
+    // real Playwright types would infer (e.g. `locator.evaluate((element) => ...)`)
+    // report false implicit-any errors. Generated code that depends on contextual
+    // typing must therefore be validated against real @playwright/test types, not here.
     "--target",
     "ES2022",
     "--module",
@@ -330,6 +336,14 @@ describe("generated output", () => {
     const fixtureContent = fs.readFileSync(fixtureFile, "utf8");
     expect(fixtureContent).toContain("import { PersonListPage as PersonListPageOverride }");
     expect(fixtureContent).toContain("personListPage: PersonListPageOverride");
+
+    // The generated file must NOT own a `test` runner: projects compose their own via
+    // `withPomFixtures` so project-wide fixtures are inherited by every spec.
+    expect(fixtureContent).toContain("export function withPomFixtures");
+    expect(fixtureContent).toContain("export type PomFixtures =");
+    expect(fixtureContent).not.toMatch(/^\s*const test = /m);
+    expect(fixtureContent).not.toMatch(/export\s*\{[^}]*\btest\b[^}]*\}/);
+    expect(fixtureContent).not.toMatch(/import\s*\{[^}]*test as base[^}]*\}/);
 
     const result = runTscNoEmit([fixtureFile, basePagePath], { cwd: tempRoot });
 


### PR DESCRIPTION
## Why

The generated `fixtures.g.ts` used to create and export its own Playwright `test`:

```ts
import { test as base } from "@playwright/test";
const test = base.extend<...>({ /* POM fixtures */ });
export { test, expect };
```

That makes the generator the owner of the project's test runner, which is the wrong layer:

- **A project needs exactly one `test` object.** Project-wide fixtures — console-error capture, error-overlay detection, auth, API cleanup — only reach a spec if that spec's `test` was extended from the base defining them. When the generator exports its own `test`, a project that also wants those fixtures ends up with **two** runners, and specs silently miss whichever fixtures live on the other one. That failure mode is invisible: the spec passes, it just isn't checking what you think.
- **Attaching POM fixtures is code generation. Deciding what every test does is not.** The generator knows the POM class names; it should not have an opinion about console errors.

## What changed

`fixtures.g.ts` now exports `withPomFixtures(base)` instead of `test`. It attaches the generated POM fixtures (plus `animation`, `pomSetup`, `pomFactory`) to a base the project owns:

```ts
// tests/playwright/test-base.ts — the single `test` your specs import
import { test as playwrightTest, expect } from "@playwright/test";
import { withPomFixtures } from "./__generated__/fixtures.g";

// inherited by EVERY spec
const base = playwrightTest.extend({ /* project-wide fixtures */ });

export const test = withPomFixtures(base);
export { expect };
```

Also:
- exports a `PomFixtures` aggregate type (all generator-contributed fixtures)
- keeps re-exporting `expect` for convenience
- README updated: usage example, a "the generated module does not own `test`" section, and the lint-rule migration steps

### One subtlety worth calling out

The emitted fixture callbacks are now **annotated explicitly**:

```ts
pomSetup: [async ({ animation }: PomFixtures, use: (r: void) => Promise<void>) => { ... }, { auto: true }],
pomFactory: async ({ page }: { page: PwPage }, use: (r: PomFactory) => Promise<void>) => { ... },
```

Inside `withPomFixtures` the base is generic (`TestType<TTestArgs, TWorkerArgs>`), so TypeScript cannot resolve Playwright's `Fixtures<...>` parameter types and the callbacks would otherwise be implicitly `any` — an error in any consumer project with `noImplicitAny`.

This class of bug is **not** catchable by this repo's `runTscNoEmit` helper, because the Playwright stubs in `tests/fixtures/generated-tsc` type `Page`/`Locator` as `any`. I verified it by typechecking the real generated output against real `@playwright/test` types under `--strict`, with a consumer `test-base.ts` (console-error capture via a `page` override) and a spec destructuring **both** generated POM fixtures and a project fixture — `tsc` exit 0. I added a comment recording why `--noImplicitAny` is deliberately absent from the stub-based check (it false-positives on `locator.evaluate((element) => ...)`).

## Tests

- `204/204` pass; build clean
- new assertions in `tests/generated-tsc.test.ts`: the generated file exports `withPomFixtures` + `PomFixtures`, and does **not** declare or export a `test`, nor import `test as base`
- stub `playwright-test.d.ts` gained `TestType` / `PlaywrightTestArgs`
- lint: 62 errors, all pre-existing on `main` (verified by stashing this branch's changes and re-running) — this PR adds none

## BREAKING CHANGE

`fixtures.g.ts` no longer exports `test`. Consumers compose a project `test` with `withPomFixtures` and repoint specs at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)