### PR TITLE
chore: remove product-specific (Immy/Ayla) heuristics and fixtures

### DIFF
--- a/tests/class-generation-coverage.test.ts
+++ b/tests/class-generation-coverage.test.ts
@@ -933,11 +933,11 @@ describe("class-generation coverage", () => {
 
     try {
       const keyedNav: IDataTestId = {
-        selectorValue: createPomStringPattern("NavHost-${value}-immynavitem", "parameterized"),
+        selectorValue: createPomStringPattern("NavHost-${value}-mynavitem", "parameterized"),
         pom: {
           nativeRole: "button",
           methodName: "ValueByKey",
-          selector: createPomStringPattern("NavHost-${key}-immynavitem", "parameterized"),
+          selector: createPomStringPattern("NavHost-${key}-mynavitem", "parameterized"),
           parameters: createPomParameters(["key", "string"]),
         },
         targetPageObjectModelClass: "UsersPage",

--- a/tests/existing-id-error.test.ts
+++ b/tests/existing-id-error.test.ts
@@ -40,7 +40,7 @@ describe("existingIdBehavior: 'preserve'", () => {
         existingIdBehavior: "preserve",
         componentDirs: ["."],
         nativeWrappers: {
-          ImmyRadioGroup: {
+          MyRadioGroup: {
             role: "radio",
             requiresOptionDataTestIdPrefix: true,
           },
@@ -57,7 +57,7 @@ describe("existingIdBehavior: 'preserve'", () => {
       throw new Error("Could not find metadata collector plugin");
     }
 
-    const code = `<template><ImmyRadioGroup data-testid="database-type" v-model="selectedGroup" /></template>`;
+    const code = `<template><MyRadioGroup data-testid="database-type" v-model="selectedGroup" /></template>`;
     const id = path.resolve(process.cwd(), "TestComponent.vue");
 
     const expectedError = "existingIdBehavior=\"preserve\" cannot safely preserve nested option ids";

--- a/tests/generated-tsc.test.ts
+++ b/tests/generated-tsc.test.ts
@@ -473,8 +473,8 @@ describe("generated output", () => {
 
     const deps: IComponentDependencies = {
       filePath: path.join(tempRoot, "src", "components", "UsersTable.vue"),
-      childrenComponentSet: new Set(["ImmyDxDataGrid"]),
-      usedComponentSet: new Set(["ImmyDxDataGrid"]),
+      childrenComponentSet: new Set(["MyDataGrid"]),
+      usedComponentSet: new Set(["MyDataGrid"]),
       dataTestIdSet: new Set([
         {
           selectorValue: createPomStringPattern("UsersTable-Refresh-button", "static"),
@@ -495,7 +495,7 @@ describe("generated output", () => {
       customPomAttachments: [{
         className: "Grid",
         propertyName: "grid",
-        attachWhenUsesComponents: ["ImmyDxDataGrid"],
+        attachWhenUsesComponents: ["MyDataGrid"],
         attachTo: "pagesAndComponents",
         flatten: true,
       }],
@@ -545,7 +545,7 @@ describe("generated output", () => {
     const deps: IComponentDependencies = {
       filePath: path.join(tempRoot, "src", "views", "UsersView.vue"),
       childrenComponentSet: new Set(),
-      usedComponentSet: new Set(["Page", "ImmyDxDataGrid"]),
+      usedComponentSet: new Set(["Page", "MyDataGrid"]),
       dataTestIdSet: new Set([
         {
           selectorValue: createPomStringPattern("UsersView-EnableSessionEmails-toggle", "static"),
@@ -568,7 +568,7 @@ describe("generated output", () => {
         {
           className: "Grid",
           propertyName: "grid",
-          attachWhenUsesComponents: ["ImmyDxDataGrid"],
+          attachWhenUsesComponents: ["MyDataGrid"],
           attachTo: "both",
           flatten: true,
         },

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -504,14 +504,14 @@ describe('createTestIdTransform', () => {
   it('injects click instrumentation by default', () => {
     const code = compileWithRuntimeTemplateOptions(
       `
-        <ImmyTable>
+        <MyTable>
           <template #actions="{ item }">
-            <ImmyButton @click="remove(item)">Remove</ImmyButton>
+            <MyButton @click="remove(item)">Remove</MyButton>
           </template>
-        </ImmyTable>
+        </MyTable>
       `,
       {
-        nativeWrappers: { ImmyButton: { role: 'button' } },
+        nativeWrappers: { MyButton: { role: 'button' } },
         bindingMetadata: {
           remove: BindingTypes.SETUP_CONST,
         },
@@ -606,7 +606,7 @@ describe('createTestIdTransform', () => {
         <DxDataGrid :data-source="items" key-expr="id">
           <DxColumn cell-template="selectCell" />
           <template #selectCell="{ data }">
-            <AylaButton @click="openProject(data.data)">Select</AylaButton>
+            <CustomButton @click="openProject(data.data)">Select</CustomButton>
           </template>
         </DxDataGrid>
       `,
@@ -625,17 +625,17 @@ describe('createTestIdTransform', () => {
 
     const ast = compileAndCaptureAst(
       `
-        <ImmyList :items="items">
+        <MyList :items="items">
           <template #item="{ data: maintenanceItem }">
-            <ImmyRow>
-              <ImmyCol>
+            <MyRow>
+              <MyCol>
                 <div v-if="!readonly">
-                  <ImmyButton @click="moveToTop(maintenanceItem)">Top</ImmyButton>
+                  <MyButton @click="moveToTop(maintenanceItem)">Top</MyButton>
                 </div>
-              </ImmyCol>
-            </ImmyRow>
+              </MyCol>
+            </MyRow>
           </template>
-        </ImmyList>
+        </MyList>
       `,
       {
         filename: '/src/components/MyComp.vue',
@@ -652,11 +652,11 @@ describe('createTestIdTransform', () => {
 
     const ast = compileAndCaptureAst(
       `
-        <ImmyList :items="items">
+        <MyList :items="items">
           <template #item="{ data, key }">
             <button @click="remove(data)">Remove</button>
           </template>
-        </ImmyList>
+        </MyList>
       `,
       {
         filename: '/src/components/MyComp.vue',
@@ -676,13 +676,13 @@ describe('createTestIdTransform', () => {
     // Pass 1: PARENT — RolePermissions.vue renders RolePermissionSubject in a keyed slot
     compileAndCaptureAst(
       `
-        <ImmyList :items="subjects">
+        <MyList :items="subjects">
           <template #item="{ data, key }">
             <div>
               <RolePermissionSubject :subject="data" :disabled="isDisabled" />
             </div>
           </template>
-        </ImmyList>
+        </MyList>
       `,
       {
         filename: '/src/components/RolePermissions.vue',
@@ -1270,23 +1270,23 @@ describe('createTestIdTransform', () => {
 
   it('infers radio wrappers through nested local SFCs without nativeWrappers config', () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vue-pom-generator-transform-'))
-    const radioPath = path.join(tempRoot, 'src', 'components', 'ImmyRadio.vue')
-    const radioGroupPath = path.join(tempRoot, 'src', 'components', 'ImmyRadioGroup.vue')
+    const radioPath = path.join(tempRoot, 'src', 'components', 'MyRadio.vue')
+    const radioGroupPath = path.join(tempRoot, 'src', 'components', 'MyRadioGroup.vue')
     fs.mkdirSync(path.dirname(radioPath), { recursive: true })
     fs.writeFileSync(radioPath, '<template><div><input type="radio" /></div></template>')
     fs.writeFileSync(
       radioGroupPath,
-      '<template><div><ImmyRadio v-for="option in props.options" :key="option.value" :text="option.text" :modelValue="option.value" /></div></template>',
+      '<template><div><MyRadio v-for="option in props.options" :key="option.value" :text="option.text" :modelValue="option.value" /></div></template>',
     )
 
     const componentHierarchyMap = new Map<string, IComponentDependencies>()
     const vueFilesPathMap = new Map<string, string>([
-      ['ImmyRadio', radioPath],
-      ['ImmyRadioGroup', radioGroupPath],
+      ['MyRadio', radioPath],
+      ['MyRadioGroup', radioGroupPath],
     ])
 
     const ast = compileAndCaptureAst(
-      '<ImmyRadioGroup :options="[\'Cloud\', \'Local\']" v-model="databaseType" />',
+      '<MyRadioGroup :options="[\'Cloud\', \'Local\']" v-model="databaseType" />',
       {
         filename: path.join(tempRoot, 'src', 'views', 'MyPage.vue'),
         nodeTransforms: [createTestIdTransform('MyPage', componentHierarchyMap, {}, [], path.join(tempRoot, 'src', 'views'), { vueFilesPathMap })],

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -1282,7 +1282,7 @@ describe("utils.ts coverage", () => {
   });
 
   it("merges keyed primaries with identical selectors before strict role suffixing invents duplicates", () => {
-    const root = parseTemplate("<ImmyNavItem /><ImmyNavItem />");
+    const root = parseTemplate("<MyNavItem /><MyNavItem />");
     const els = (root.children ?? []).filter((c) => c?.type === NodeTypes.ELEMENT) as ElementNode[];
     expect(els.length).toBe(2);
 
@@ -1305,7 +1305,7 @@ describe("utils.ts coverage", () => {
         dependencies: deps,
         generatedMethodContentByComponent,
         nativeRole: "button",
-        preferredGeneratedValue: templateAttributeValue("MyComp-${value}-immynavitem"),
+        preferredGeneratedValue: templateAttributeValue("MyComp-${value}-mynavitem"),
         keyInfo: null,
         testIdAttribute: "data-testid",
         existingIdBehavior: "overwrite",

--- a/transform.ts
+++ b/transform.ts
@@ -1154,7 +1154,7 @@ export function createTestIdTransform(
         // Cache onto the nativeWrappers map so downstream utilities (formatTagName, wrapper transform)
         // see it consistently.
         (nativeWrappers as NativeWrappersMap)[element.tag] = { role: inferred.role, inferred: true };
-      } else if (element.tag.endsWith("Button") || element.tag === "AylaButton") {
+      } else if (element.tag.endsWith("Button")) {
         // Recognition of conventional naming for button components.
         (nativeWrappers as NativeWrappersMap)[element.tag] = { role: "button" };
       } else if (element.tag === "DxDataGrid") {


### PR DESCRIPTION
## Summary

This library (`vue-pom-generator`) must be **product-agnostic** — it must not embed any consuming project's component-naming conventions or internal identifiers. This PR strips the two product-specific strings (`Immy`, `Ayla`) from the codebase entirely.

### `transform.ts` — remove the `AylaButton` special-case
The native-wrapper role fallback special-cased the literal tag `'AylaButton'` alongside the generic `endsWith('Button')` check:

```diff
-      } else if (element.tag.endsWith("Button") || element.tag === "AylaButton") {
+      } else if (element.tag.endsWith("Button")) {
```

The special case is **redundant** (`'AylaButton'` already ends with `'Button'`) and bakes a specific product's component name into library code. Removing it changes no behavior — `endsWith('Button')` covers every button-named component generically.

### Tests — rename product-specific fixtures to neutral identifiers
Renamed every `Immy*`/`Ayla*` fixture component:

| Before | After | Note |
|---|---|---|
| `ImmyButton` | `MyButton` | |
| `AylaButton` | `CustomButton` | still ends in `Button` — `endsWith('Button')` heuristic stays exercised |
| `ImmyList` / `ImmyRow` / `ImmyCol` / `ImmyTable` | `MyList` / `MyRow` / `MyCol` / `MyTable` | |
| `ImmyRadio` / `ImmyRadioGroup` | `MyRadio` / `MyRadioGroup` | |
| `ImmyNavItem` | `MyNavItem` | derived suffix `immynavitem` -> `mynavitem` |
| `ImmyDxDataGrid` | `MyDataGrid` | (drops the product-specific `Dx` prefix) |

Derived lowercased data-testid suffixes were updated to match the renamed tags, and `nativeWrappers` keys, `Set`/config entries, and constructed fixture paths were renamed in lock with their tags. **No assertion's meaning changed** — only fixture identifiers moved.

### Docs
Replaced `Ayla`/`Immy` references in the `pom-element-wrapper` design and implementation plans with generic "consuming project" phrasing.

## Verification
- `npx vitest run` -> **204/204 passing** (identical to baseline — no newly failing or skipped tests).
- `grep -rInEi 'immy|ayla'` over all source/config/docs (excluding `node_modules`/`dist`/lockfiles) -> **zero hits**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)