### PR TITLE
feat: emit singleton accessor for slot-scope callback click handlers

### DIFF
--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -668,6 +668,53 @@ describe('createTestIdTransform', () => {
     expect(testId).toBe('`MyComp-${key}-Remove-button`')
   })
 
+  it('emits a singleton (non-keyed) test id for a slot-scope callback click handler', () => {
+    // A scoped slot that hands the consumer an event callback (here `toggle` from
+    // a popover `#trigger`) is a singleton control, not an iterated row. The click
+    // handler is a bare slot-scope identifier — a callback reference, not row data —
+    // so the generated selector must be a plain singleton, not keyed by a fallback
+    // expression interpolated off the callback.
+    const componentHierarchyMap = new Map()
+
+    const ast = compileAndCaptureAst(
+      `
+        <MyPopover>
+          <template #trigger="{ toggle, isOpen }">
+            <button @click="toggle">Open</button>
+          </template>
+        </MyPopover>
+      `,
+      {
+        filename: '/src/components/MyComp.vue',
+        nodeTransforms: [createTestIdTransform('MyComp', componentHierarchyMap, {}, [], '/src/views')],
+      },
+    )
+
+    const testId = findFirstDataTestId(ast)
+    expect(testId).toBe('MyComp-Toggle-button')
+  })
+
+  it('emits a singleton test id for a slot-scope callback wrapped in withModifiers', () => {
+    const componentHierarchyMap = new Map()
+
+    const ast = compileAndCaptureAst(
+      `
+        <MyPopover>
+          <template #trigger="{ toggle }">
+            <button @click="withModifiers(toggle, ['prevent'])">Open</button>
+          </template>
+        </MyPopover>
+      `,
+      {
+        filename: '/src/components/MyComp.vue',
+        nodeTransforms: [createTestIdTransform('MyComp', componentHierarchyMap, {}, [], '/src/views')],
+      },
+    )
+
+    const testId = findFirstDataTestId(ast)
+    expect(testId).toBe('MyComp-Toggle-button')
+  })
+
   it('keys child component testids via cross-file key registry', () => {
     // Simulate two-pass compilation: parent records key context, child consumes it.
     const componentHierarchyMap = new Map()

--- a/transform.ts
+++ b/transform.ts
@@ -58,6 +58,7 @@ import {
   findTemplateSlotScopeExpression,
   tryExtractSlotScopeVariableNames,
   getContainedInSlotTemplateNode,
+  isSlotScopeCallbackClickHandler,
 } from "./utils";
 
 const CLICK_EVENT_NAME = TESTID_CLICK_EVENT_NAME;
@@ -1174,6 +1175,16 @@ export function createTestIdTransform(
 
         const slotKeyInfo = getContainedInSlotDataKeyInfo(element, hierarchyMap);
         if (slotKeyInfo) {
+          // A click handler that is a bare slot-scope variable (e.g. @click="toggle"
+          // inside <template #trigger="{ toggle }">) is an event callback, not
+          // per-iteration row data. The enclosing scoped slot renders a single
+          // trigger control, so it must not inherit the slot's keyed selector —
+          // otherwise the generator emits an unusable keyed accessor for what is
+          // always one element. Method-call handlers (`remove(item)`) and member
+          // access (`data.action()`) pass row data and stay keyed.
+          if (isSlotScopeCallbackClickHandler(element, hierarchyMap)) {
+            return null;
+          }
           return slotKeyInfo;
         }
 

--- a/utils.ts
+++ b/utils.ts
@@ -679,6 +679,120 @@ export function tryExtractSlotScopeVariableNames(expression: VueExpressionNode):
 }
 
 /**
+ * Unwraps a parsed click-handler AST down to a bare identifier name, but only
+ * when the handler is a callback *reference* — i.e. the expression is (or
+ * unwraps to) a plain identifier. Method calls (`remove(item)`), member access
+ * (`data.action()`), assignments, and conditionals are NOT bare callbacks, so
+ * they return `null` and keep their existing (keyed) handling.
+ *
+ * Recognized wrappers that still denote "invoke this callback reference":
+ * - `withModifiers(fn, [...])` / `_withModifiers(fn, [...])` (Vue modifier wrapper)
+ * - `() => fn` (arrow with an expression body)
+ * - statement/expression-statement envelopes
+ *
+ * @internal
+ */
+function unwrapToBareCallbackIdentifier(node: BabelNode | null | undefined): string | null {
+  if (!node) {
+    return null;
+  }
+
+  if (isFile(node)) {
+    const stmt = node.program.body[0];
+    return isExpressionStatement(stmt) ? unwrapToBareCallbackIdentifier(stmt.expression) : null;
+  }
+
+  if (isProgram(node)) {
+    const stmt = node.body[0];
+    return isExpressionStatement(stmt) ? unwrapToBareCallbackIdentifier(stmt.expression) : null;
+  }
+
+  if (isExpressionStatement(node)) {
+    return unwrapToBareCallbackIdentifier(node.expression);
+  }
+
+  if (isIdentifier(node)) {
+    return node.name;
+  }
+
+  // withModifiers(fn, [...]) / _withModifiers(...) — the underlying handler is arg 0.
+  if (isCallExpression(node) || isOptionalCallExpression(node)) {
+    const callee = node.callee;
+    if (isIdentifier(callee) && (callee.name === "withModifiers" || callee.name === "_withModifiers")) {
+      return unwrapToBareCallbackIdentifier(node.arguments[0] as BabelNode);
+    }
+    return null;
+  }
+
+  // () => callback
+  if (isArrowFunctionExpression(node)) {
+    return isBlockStatement(node.body) ? null : unwrapToBareCallbackIdentifier(node.body);
+  }
+
+  return null;
+}
+
+/**
+ * Returns the name of an element's `@click` handler when that handler is a bare
+ * identifier callback reference (optionally wrapped in `withModifiers(...)`, an
+ * arrow expression body, or an expression statement), and `null` otherwise.
+ *
+ * @internal
+ */
+export function tryGetBareCallbackClickHandlerName(node: ElementNode): string | null {
+  const click = tryGetClickDirective(node);
+  if (!click?.exp) {
+    return null;
+  }
+
+  const source = getVueExpressionSource(click.exp as SimpleExpressionNode | CompoundExpressionNode, "content", "compiled");
+  if (!source) {
+    return null;
+  }
+
+  const parsed = tryParseBabelAstFromHandlerSource(source);
+  if (!parsed) {
+    return null;
+  }
+
+  return unwrapToBareCallbackIdentifier(parsed as BabelNode);
+}
+
+/**
+ * Determines whether an element is a singleton trigger rendered inside a scoped
+ * slot: its `@click` handler is a bare identifier that is one of the enclosing
+ * slot's scope variables.
+ *
+ * A scoped slot that hands the consumer an event callback (e.g. `toggle` from
+ * `<template #trigger="{ toggle }">`) renders a single control, not one row per
+ * iteration. The bare-identifier click handler is a callback reference — not
+ * per-iteration row data — so the element must not inherit the slot's keyed
+ * selector; otherwise the generator emits an unusable keyed accessor for what is
+ * always a single element. Method-call handlers (`remove(item)`) and member
+ * access (`data.action()`) pass row data and remain keyed.
+ *
+ * @internal
+ */
+export function isSlotScopeCallbackClickHandler(node: ElementNode, hierarchyMap: HierarchyMap): boolean {
+  const handlerName = tryGetBareCallbackClickHandlerName(node);
+  if (!handlerName) {
+    return false;
+  }
+
+  const templateNode = getContainedInSlotTemplateNode(node, hierarchyMap);
+  if (!templateNode) {
+    return false;
+  }
+
+  const scopeExpression = findTemplateSlotScopeExpression(templateNode);
+  if (!scopeExpression) {
+    return false;
+  }
+
+  return tryExtractSlotScopeVariableNames(scopeExpression).includes(handlerName);
+}
+
+/**
  * Checks if node has a :to directive (for router links)
  *
  * Returns the directive if found, undefined otherwise


### PR DESCRIPTION
## Problem

A scoped slot that hands the consumer an event callback (e.g. `toggle` from `<template #trigger="{ toggle }">`) renders a **single** control, not one row per iteration. The generator treated every destructured slot-scope binding as a key candidate, so a trigger like:

```vue
<template #trigger="{ toggle, isOpen }">
  <button @click="toggle">Open</button>
</template>
```

received a keyed selector:

```
`Comp-${toggle.key ?? toggle.data?.id ?? toggle.id ?? toggle.value ?? toggle}-Toggle-button`
```

This is unusable as a POM accessor for what is always a single element (the fallback expression interpolates `.key` off a function).

## Fix

Detect the singleton-trigger case: when an element's `@click` handler is a **bare identifier** that is one of the enclosing slot's scope variables, it is a callback reference rather than per-iteration row data, so the element does **not** inherit the slot's keyed selector and emits a plain singleton:

```
Comp-Toggle-button
```

The check is AST-based and product-agnostic. It distinguishes callback references from:
- method calls (`@click="remove(item)"`) — pass row data, stay keyed
- member access (`@click="data.action()"`) — pass row data, stay keyed

`withModifiers(cb, [...])` and arrow-body (`@click="() => cb"`) wrappers are unwrapped to the underlying callback.

## Why no slot-name heuristic

The generator discards the slot name (`slotProp.arg`), and a name-based singleton/iterated allowlist would reintroduce product-specific magic (per #40). The bare-identifier-callback signal is general: iterated slots differentiate rows by passing row data into the handler, so a bare callback invocation is a strong singleton signal.

## Testing

- New TDD tests in `tests/transform.test.ts` for the bare-identifier and `withModifiers` cases.
- All 207 tests pass (24 files); existing keyed scoped-slot fixtures (data-object fallbacks, `key` prop, cross-file key registry) unchanged.

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)