### PR TITLE
test: add broad coverage for class-generation and plugin internals

### DIFF
--- a/tests/annotator-runtime-helpers.test.ts
+++ b/tests/annotator-runtime-helpers.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+//
+// Covers the pure, side-effect-free helpers in the annotator runtime. These
+// helpers operate on plain strings (display text, file paths, placement tokens)
+// — no DOM access — so they can be exercised directly in a node environment.
+import { describe, expect, it } from "vitest";
+
+import { __internal as clientInternal } from "../plugin/runtime/annotator/client";
+import { __internal as pluginInternal } from "../plugin/runtime/annotator/plugin";
+import { normalizeInlineText } from "../plugin/runtime/annotator/text-utils";
+import { __internal as vueDetectorInternal, formatSourceLabel } from "../plugin/runtime/annotator/vue-detector";
+
+describe("normalizeInlineText", () => {
+  it("collapses whitespace runs and trims ends", () => {
+    expect(normalizeInlineText("  foo\n  bar ")).toBe("foo bar");
+  });
+
+  it("returns undefined for blank input", () => {
+    expect(normalizeInlineText("   ")).toBeUndefined();
+    expect(normalizeInlineText("")).toBeUndefined();
+    expect(normalizeInlineText(undefined)).toBeUndefined();
+  });
+
+  it("preserves non-blank single-token input", () => {
+    expect(normalizeInlineText("save")).toBe("save");
+  });
+});
+
+describe("normalizePathSeparators", () => {
+  it("converts backslashes to forward slashes", () => {
+    expect(pluginInternal.normalizePathSeparators("src\\widgets\\Item.vue")).toBe("src/widgets/Item.vue");
+  });
+
+  it("leaves posix paths unchanged", () => {
+    expect(pluginInternal.normalizePathSeparators("src/widgets/Item.vue")).toBe("src/widgets/Item.vue");
+  });
+
+  it("handles mixed separators", () => {
+    expect(pluginInternal.normalizePathSeparators("src\\widgets/Item.vue")).toBe("src/widgets/Item.vue");
+  });
+});
+
+describe("placementPrimarySide", () => {
+  it("returns the side before the first dash", () => {
+    expect(clientInternal.placementPrimarySide("top-start")).toBe("top");
+    expect(clientInternal.placementPrimarySide("right-end")).toBe("right");
+  });
+
+  it("returns the whole token when there is no dash", () => {
+    expect(clientInternal.placementPrimarySide("bottom")).toBe("bottom");
+  });
+});
+
+describe("vue-detector string helpers", () => {
+  it("ignoredComponentNamePattern matches synthetic runtime names", () => {
+    expect(vueDetectorInternal.ignoredComponentNamePattern.test("template")).toBe(true);
+    expect(vueDetectorInternal.ignoredComponentNamePattern.test("slot")).toBe(true);
+    expect(vueDetectorInternal.ignoredComponentNamePattern.test("items[0].template")).toBe(true);
+    expect(vueDetectorInternal.ignoredComponentNamePattern.test("UserCard")).toBe(false);
+  });
+
+  it("stripSourcePosition drops a trailing line:column", () => {
+    expect(vueDetectorInternal.stripSourcePosition("src/Foo.vue:12:3")).toBe("src/Foo.vue");
+    expect(vueDetectorInternal.stripSourcePosition("src/Foo.vue")).toBe("src/Foo.vue");
+  });
+
+  it("inferNameFromFile derives a name from a file path", () => {
+    expect(vueDetectorInternal.inferNameFromFile("src/widgets/Item.vue")).toBe("Item");
+    expect(vueDetectorInternal.inferNameFromFile("src/widgets/Item.vue:4:2")).toBe("Item");
+    expect(vueDetectorInternal.inferNameFromFile("")).toBeNull();
+  });
+
+  it("isComponentLikeSourceTag recognizes Vue component tags", () => {
+    expect(vueDetectorInternal.isComponentLikeSourceTag("UserCard")).toBe(true);
+    expect(vueDetectorInternal.isComponentLikeSourceTag("my-button")).toBe(true);
+    expect(vueDetectorInternal.isComponentLikeSourceTag("div")).toBe(false);
+    expect(vueDetectorInternal.isComponentLikeSourceTag(null)).toBe(false);
+  });
+
+  it("formatSourceLabel trims to the frontend/src portion and optionally keeps position", () => {
+    expect(formatSourceLabel("/x/frontend/src/Foo.vue:4:2")).toBe("src/Foo.vue:4:2");
+    expect(formatSourceLabel("/x/frontend/src/Foo.vue:4:2", false)).toBe("src/Foo.vue");
+    expect(formatSourceLabel("src/Foo.vue")).toBe("src/Foo.vue");
+  });
+});

--- a/tests/broad/accessibility-audit-ts.test.ts
+++ b/tests/broad/accessibility-audit-ts.test.ts
@@ -1,0 +1,196 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import type { ElementMetadata } from "../../metadata-collector";
+import { buildAccessibilityAudit, collectAccessibilityReviewWarnings } from "../../accessibility-audit";
+
+function makeMetadata(overrides: Partial<ElementMetadata> = {}): ElementMetadata {
+  return {
+    testId: "test",
+    tag: "button",
+    tagType: 0,
+    dynamicProps: [],
+    ...overrides,
+  } as ElementMetadata;
+}
+
+describe("accessibility-audit.ts buildAccessibilityAudit", () => {
+  it("returns undefined when metadata is missing or role is null", () => {
+    expect(buildAccessibilityAudit(undefined, "button")).toBeUndefined();
+    expect(buildAccessibilityAudit(makeMetadata(), null)).toBeUndefined();
+  });
+
+  it("treats missing dynamicProps as an empty set (missing branch)", () => {
+    const meta = { testId: "x", tag: "div", tagType: 0 } as ElementMetadata;
+    const result = buildAccessibilityAudit(meta, "link");
+    expect(result?.accessibleNameSource).toBe("missing");
+  });
+
+  it("prefers static aria-label as the accessible name source", () => {
+    const result = buildAccessibilityAudit(
+      makeMetadata({ staticAriaLabel: "Save" }),
+      "button",
+    );
+    expect(result?.accessibleNameSource).toBe("aria-label");
+    expect(result?.needsReview).toBe(false);
+    expect(result?.staticAriaLabel).toBe("Save");
+  });
+
+  it("uses static text content for inline-text roles (button/radio)", () => {
+    const result = buildAccessibilityAudit(
+      makeMetadata({ staticTextContent: "Submit" }),
+      "button",
+    );
+    expect(result?.accessibleNameSource).toBe("text");
+    expect(result?.staticTextContent).toBe("Submit");
+    expect(result?.needsReview).toBe(false);
+  });
+
+  it("falls back to title when role does not support inline text and no aria-label", () => {
+    const result = buildAccessibilityAudit(
+      makeMetadata({ staticTitle: "Info" }),
+      "link",
+    );
+    expect(result?.accessibleNameSource).toBe("title");
+    expect(result?.staticTitle).toBe("Info");
+  });
+
+  it("reports dynamic when only dynamic accessible-name signals are present", () => {
+    const result = buildAccessibilityAudit(
+      makeMetadata({ dynamicProps: ["aria-label"], hasDynamicText: false }),
+      "button",
+    );
+    expect(result?.accessibleNameSource).toBe("dynamic");
+    expect(result?.needsReview).toBe(false);
+  });
+
+  it("reports dynamic for dynamic title prop", () => {
+    const result = buildAccessibilityAudit(
+      makeMetadata({ dynamicProps: ["title"] }),
+      "link",
+    );
+    expect(result?.accessibleNameSource).toBe("dynamic");
+  });
+
+  it("reports dynamic when hasDynamicText is set", () => {
+    const result = buildAccessibilityAudit(
+      makeMetadata({ hasDynamicText: true }),
+      "link",
+    );
+    expect(result?.accessibleNameSource).toBe("dynamic");
+  });
+
+  it("reports unknown for input role with no accessible-name signal and pushes a reason", () => {
+    const result = buildAccessibilityAudit(makeMetadata(), "input");
+    expect(result?.accessibleNameSource).toBe("unknown");
+    expect(result?.needsReview).toBe(true);
+    expect(result?.reasons.length).toBeGreaterThan(0);
+    expect(result?.reasons[0]).toMatch(/label/i);
+  });
+
+  it("reports unknown for select role with no accessible-name signal", () => {
+    const result = buildAccessibilityAudit(makeMetadata(), "select");
+    expect(result?.accessibleNameSource).toBe("unknown");
+    expect(result?.needsReview).toBe(true);
+  });
+
+  it("reports missing for other roles with no accessible-name signal", () => {
+    const result = buildAccessibilityAudit(makeMetadata(), "link");
+    expect(result?.accessibleNameSource).toBe("missing");
+    expect(result?.needsReview).toBe(true);
+    expect(result?.reasons[0]).toMatch(/no compile-time/i);
+  });
+
+  it("includes staticRole in the result when present", () => {
+    const result = buildAccessibilityAudit(
+      makeMetadata({ staticRole: "navigation", staticAriaLabel: "Main" }),
+      "link",
+    );
+    expect(result?.staticRole).toBe("navigation");
+  });
+
+  it("normalizes vselect role to select when choosing input/select branch", () => {
+    const result = buildAccessibilityAudit(makeMetadata(), "vselect");
+    expect(result?.accessibleNameSource).toBe("unknown");
+  });
+});
+
+describe("accessibility-audit.ts collectAccessibilityReviewWarnings", () => {
+  it("collects warnings for entries that need review, using generatedPropertyName", () => {
+    const manifest: Parameters<typeof collectAccessibilityReviewWarnings>[0] = {
+      MyComp: {
+        entries: [
+          {
+            testId: "my-input",
+            generatedPropertyName: "myInput",
+            inferredRole: "input",
+            accessibility: {
+              needsReview: true,
+              accessibleNameSource: "unknown",
+              reasons: ["No inline accessible-name signal was found."],
+            },
+          },
+        ],
+      },
+    };
+
+    const warnings = collectAccessibilityReviewWarnings(manifest);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("MyComp.myInput");
+    expect(warnings[0]).toContain("role=input");
+    expect(warnings[0]).toContain('"my-input"');
+  });
+
+  it("falls back to testId in the warning label when generatedPropertyName is null", () => {
+    const manifest: Parameters<typeof collectAccessibilityReviewWarnings>[0] = {
+      OtherComp: {
+        entries: [
+          {
+            testId: "raw-link",
+            generatedPropertyName: null,
+            inferredRole: null,
+            accessibility: {
+              needsReview: true,
+              accessibleNameSource: "missing",
+              reasons: ["No compile-time accessible-name signal was found."],
+            },
+          },
+        ],
+      },
+    };
+
+    const warnings = collectAccessibilityReviewWarnings(manifest);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("OtherComp.raw-link");
+    expect(warnings[0]).toContain("role=unknown");
+  });
+
+  it("skips entries that do not need review", () => {
+    const manifest: Parameters<typeof collectAccessibilityReviewWarnings>[0] = {
+      A: {
+        entries: [
+          {
+            testId: "ok",
+            generatedPropertyName: "ok",
+            inferredRole: "button",
+            accessibility: { needsReview: false, accessibleNameSource: "aria-label", reasons: [] },
+          },
+          {
+            testId: "bad",
+            generatedPropertyName: null,
+            inferredRole: "link",
+            accessibility: { needsReview: true, accessibleNameSource: "missing", reasons: ["x"] },
+          },
+        ],
+      },
+    };
+
+    const warnings = collectAccessibilityReviewWarnings(manifest);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("A.bad");
+  });
+
+  it("returns no warnings for an empty manifest", () => {
+    expect(collectAccessibilityReviewWarnings({})).toEqual([]);
+  });
+});

--- a/tests/broad/class-generation-base-page-ts.test.ts
+++ b/tests/broad/class-generation-base-page-ts.test.ts
@@ -1,0 +1,428 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+
+import { BasePage, ObjectId, type Fluent } from "../../class-generation/base-page";
+import type { AfterPointerClick } from "../../class-generation/pointer";
+import type { PwLocator } from "../../class-generation/playwright-types";
+import { FakeLocator, FakePage } from "./helpers/fake-runtime";
+
+/**
+ * Typed view of a fluent/value proxy's dynamic surface. The proxies intentionally
+ * dispatch arbitrary property accesses (returning thenables that reject for
+ * missing members, or throwing for non-function members), so the typed surface is
+ * a record of callable, thenable members. This lets the missing-member probes
+ * access properties that do not exist on the underlying object without `as any`.
+ */
+type DynamicMember = (() => Promise<unknown>) & PromiseLike<unknown>;
+
+function dynamicMembers(proxy: object): Record<string, DynamicMember> {
+  return proxy as Record<string, DynamicMember>;
+}
+
+/** Read a symbol-keyed property off a record without a `symbol` index assertion at the call site. */
+function symbolKey(record: object, sym: symbol) {
+  return Reflect.get(record, sym);
+}
+
+class ExposedBasePage extends BasePage {
+  public sel(testId: string) {
+    return this.selectorForTestId(testId);
+  }
+  public loc(testId: string, description?: string) {
+    return this.locatorByTestId(testId, description);
+  }
+  public locByLabel(rootTestId: string, label: string, options?: { exact?: boolean; description?: string }) {
+    return this.locatorWithinTestIdByLabel(rootTestId, label, options);
+  }
+  public animate(target: string | PwLocator, executeClick = true, delayMs = 0, annotation = "", options?: { afterClick?: AfterPointerClick }) {
+    return this.animateCursorToElement(target, executeClick, delayMs, annotation, options);
+  }
+  public keyed<T extends string>(fn: (key: T) => PwLocator) {
+    return this.keyedLocators(fn);
+  }
+  public async objId(options?: { timeoutMs?: number }) {
+    return this.getObjectId(options);
+  }
+  public async objIdInt(options?: { timeoutMs?: number }) {
+    return this.getObjectIdAsInt(options);
+  }
+  public makeFluent<T extends object>(factory: () => Promise<T>): Fluent<T> {
+    return this.fluent(factory);
+  }
+  public clickTestId(testId: string, annotation = "", wait = true, description?: string) {
+    return this.clickByTestId(testId, annotation, wait, description);
+  }
+  public clickLoc(locator: PwLocator, annotation = "", wait = true) {
+    return this.clickLocator(locator, annotation, wait);
+  }
+  public clickWithinLabel(rootTestId: string, label: string, annotation = "", wait = true, options?: { exact?: boolean; description?: string }) {
+    return this.clickWithinTestIdByLabel(rootTestId, label, annotation, wait, options);
+  }
+  public fillTestId(testId: string, text: string, annotation = "", description?: string) {
+    return this.fillInputByTestId(testId, text, annotation, description);
+  }
+  public selectVSelect(testId: string, value: string, timeOut = 0, annotation = "", description?: string) {
+    return this.selectVSelectByTestId(testId, value, timeOut, annotation, description);
+  }
+  public fillLoc(locator: PwLocator, text: string, annotation = "") {
+    return this.fillInputByLocator(locator, text, annotation);
+  }
+  public clickAria(label: string, annotation = "") {
+    return this.clickByAriaLabel(label, annotation);
+  }
+  public typeTestId(testId: string, text: string) {
+    return this.typeByTestId(testId, text);
+  }
+  public visibleTestId(testId: string) {
+    return this.isVisibleByTestId(testId);
+  }
+  public textTestId(testId: string) {
+    return this.getTextByTestId(testId);
+  }
+  public waitTestId(testId: string, options?: { timeout?: number }) {
+    return this.waitForTestId(testId, options);
+  }
+  public hoverTestId(testId: string) {
+    return this.hoverByTestId(testId);
+  }
+  public selectTestId(testId: string, value: string) {
+    return this.selectByTestId(testId, value);
+  }
+}
+
+describe("ObjectId", () => {
+  it("round-trips raw value through toString/asInt", () => {
+    const id = new ObjectId("123");
+    expect(id.toString()).toBe("123");
+    expect(id.asInt()).toBe(123);
+    expect(id.AsInt()).toBe(123);
+  });
+
+  it("throws when constructed with an empty value", () => {
+    expect(() => new ObjectId("")).toThrow("ObjectId: raw value is empty");
+  });
+
+  it("throws when AsInt receives a non base-10 integer string", () => {
+    const id = new ObjectId("abc");
+    expect(() => id.AsInt()).toThrow("is not a base-10 integer string");
+  });
+
+  it("throws when AsInt receives an unsafe integer string", () => {
+    const huge = `${Number.MAX_SAFE_INTEGER + 2}`;
+    const id = new ObjectId(huge);
+    expect(() => id.AsInt()).toThrow("is not a safe integer");
+  });
+});
+
+describe("BasePage construction", () => {
+  it("defaults the test id attribute to data-testid", () => {
+    const page = new ExposedBasePage(new FakePage());
+    expect(page.sel("save")).toBe('[data-testid="save"]');
+  });
+
+  it("honours a custom test id attribute and trims whitespace", () => {
+    const page = new ExposedBasePage(new FakePage(), { testIdAttribute: "  data-qa  " });
+    expect(page.sel("save")).toBe('[data-qa="save"]');
+  });
+
+  it("falls back to data-testid when the custom attribute is blank", () => {
+    const page = new ExposedBasePage(new FakePage(), { testIdAttribute: "   " });
+    expect(page.sel("save")).toBe('[data-testid="save"]');
+  });
+});
+
+describe("BasePage locators", () => {
+  it("builds a selector and locator by test id without a description", () => {
+    const rawLocator = new FakeLocator({ tagName: "DIV" });
+    const locatorMock = vi.fn(() => rawLocator);
+    const fakePage = new FakePage();
+    fakePage.locator = locatorMock;
+    const page = new ExposedBasePage(fakePage);
+    expect(page.loc("save")).toBe(rawLocator);
+    expect(locatorMock).toHaveBeenCalledWith('[data-testid="save"]');
+  });
+
+  it("locates within a test id by label with exact + description options", () => {
+    const described = new FakeLocator({ tagName: "DIV" });
+    const rawLocator = new FakeLocator({ tagName: "DIV" });
+    const byLabelLocator = new FakeLocator({ tagName: "DIV" });
+    vi.spyOn(rawLocator, "describe").mockReturnValue(described);
+    vi.spyOn(byLabelLocator, "getByLabel").mockReturnValue(rawLocator);
+    const fakePage = new FakePage();
+    fakePage.locator = vi.fn(() => byLabelLocator);
+    const page = new ExposedBasePage(fakePage);
+    const result = page.locByLabel("panel", "Email", { exact: false, description: "email field" });
+    expect(byLabelLocator.getByLabel).toHaveBeenCalledWith("Email", { exact: false });
+    expect(rawLocator.describe).toHaveBeenCalledWith("email field");
+    expect(result).toBe(described);
+  });
+
+  it("defaults the exact flag to true when locating by label", () => {
+    const byLabelLocator = new FakeLocator({ tagName: "DIV" });
+    const rawLocator = new FakeLocator({ tagName: "DIV" });
+    vi.spyOn(byLabelLocator, "getByLabel").mockReturnValue(rawLocator);
+    const fakePage = new FakePage();
+    fakePage.locator = vi.fn(() => byLabelLocator);
+    const page = new ExposedBasePage(fakePage);
+    page.locByLabel("panel", "Email");
+    expect(byLabelLocator.getByLabel).toHaveBeenCalledWith("Email", { exact: true });
+  });
+});
+
+describe("BasePage keyed locators", () => {
+  it("returns a locator per key and ignores symbol/then probes", async () => {
+    const page = new ExposedBasePage(new FakePage());
+    const proxy = page.keyed<string>((key) => new FakeLocator({ tagName: "DIV" }, { testId: key }));
+    const alpha = proxy.alpha;
+    expect(await alpha.getAttribute("data-testid")).toBe("alpha");
+    expect(proxy.then).toBeUndefined();
+    expect(symbolKey(proxy, Symbol("x"))).toBeUndefined();
+  });
+});
+
+describe("BasePage object id from url", () => {
+  it("parses a numeric id out of the url", async () => {
+    const fakePage = new FakePage();
+    fakePage.urlValue = "http://host/tenants/42/edit";
+    const page = new ExposedBasePage(fakePage);
+    const id = await page.objId();
+    expect(id.toString()).toBe("42");
+    expect(await page.objIdInt()).toBe(42);
+  });
+
+  it("throws when no numeric id appears before the timeout", async () => {
+    const fakePage = new FakePage();
+    fakePage.urlValue = "http://host/tenants";
+    const page = new ExposedBasePage(fakePage);
+    await expect(page.objId({ timeoutMs: 10 })).rejects.toThrow("could not find a numeric id");
+  });
+});
+
+describe("BasePage callout delegation", () => {
+  it("shows a callout by selector and by test id, then hides it", async () => {
+    const fakePage = new FakePage();
+    const page = new ExposedBasePage(fakePage);
+    await page.showCallout("#target", "note");
+    await page.showCalloutByTestId("save", "note");
+    await page.hideCallout();
+    const annotation = fakePage.dom.window.document.getElementById("__pw_pointer_callout__");
+    expect(annotation?.getAttribute("data-placement")).toBe("hidden");
+  });
+});
+
+describe("BasePage action helpers", () => {
+  it("animates the cursor via the pointer", async () => {
+    const fakePage = new FakePage();
+    const page = new ExposedBasePage(fakePage);
+    const target = new FakeLocator({ tagName: "BUTTON" }, { boundingBox: { x: 0, y: 0, width: 10, height: 10 }, testId: "btn" });
+    await page.animate(target, false, 0, "hi");
+    expect(target.scrollCalls).toBeGreaterThan(0);
+  });
+
+  it("clicks by test id and propagates afterClick for instrumented clicks", async () => {
+    const fakePage = new FakePage();
+    const btn = new FakeLocator({ tagName: "BUTTON" }, { testId: "btn" });
+    fakePage.locator = () => btn;
+    const page = new ExposedBasePage(fakePage);
+    await page.clickTestId("btn", "note", true, "the button");
+    // exercise the wait=false early return path
+    await page.clickTestId("btn", "note", false);
+    expect(btn.clicks).toBe(2);
+  });
+
+  it("clicks a locator directly", async () => {
+    const fakePage = new FakePage();
+    const page = new ExposedBasePage(fakePage);
+    const target = new FakeLocator({ tagName: "BUTTON" }, { testId: "btn" });
+    await page.clickLoc(target, "note", true);
+    await page.clickLoc(target, "note", false);
+    expect(target.clicks).toBe(2);
+  });
+
+  it("clicks within a test id by label", async () => {
+    const fakePage = new FakePage();
+    const page = new ExposedBasePage(fakePage);
+    const input = new FakeLocator({ tagName: "INPUT" }, { testId: "btn" });
+    const root = new FakeLocator({ tagName: "DIV" }, { testId: "panel" });
+    root.descendant = input;
+    fakePage.locator = (selector: string) => (selector.includes("panel") ? root : input);
+    await page.clickWithinLabel("panel", "Email", "note", true, { exact: true, description: "email" });
+    expect(root.clicks).toBe(1);
+  });
+
+  it("fills an input by test id", async () => {
+    const fakePage = new FakePage();
+    const page = new ExposedBasePage(fakePage);
+    const input = new FakeLocator({ tagName: "INPUT" }, { testId: "name" });
+    fakePage.locator = () => input;
+    await page.fillTestId("name", "Acme", "note", "name field");
+    expect(input.fills.length + input.clears).toBeGreaterThan(0);
+  });
+
+  it("fills by locator", async () => {
+    const fakePage = new FakePage();
+    const page = new ExposedBasePage(fakePage);
+    const input = new FakeLocator({ tagName: "INPUT" }, { testId: "name" });
+    await page.fillLoc(input, "Acme", "note");
+    const enteredViaKeyboard = fakePage.keyboard.typed.some((t) => t.text === "Acme");
+    const enteredViaFill = input.fills.includes("Acme");
+    expect(enteredViaKeyboard || enteredViaFill).toBe(true);
+  });
+
+  it("selects a vue-select option when a dropdown option is present", async () => {
+    const fakePage = new FakePage();
+    const page = new ExposedBasePage(fakePage);
+    const input = new FakeLocator({ tagName: "INPUT" });
+    const option = new FakeLocator({ tagName: "LI" }, { count: 1 });
+    const root = new FakeLocator({ tagName: "DIV" }, { testId: "vs" });
+    root.descendant = input;
+    // Make nested .locator("ul.vs__dropdown-menu li[role='option']") return an option locator with count 1.
+    const original = root.locator.bind(root);
+    root.locator = (selector: string) => {
+      if (selector.includes("vs__dropdown-menu")) return option;
+      return original(selector);
+    };
+    fakePage.locator = () => root;
+    await page.selectVSelect("vs", "Acme", 0, "note", "vs field");
+    expect(input.clicks).toBeGreaterThanOrEqual(1);
+    expect(option.clicks).toBe(1);
+  });
+
+  it("selects a vue-select option when no dropdown option is present", async () => {
+    const fakePage = new FakePage();
+    const page = new ExposedBasePage(fakePage);
+    const input = new FakeLocator({ tagName: "INPUT" });
+    const option = new FakeLocator({ tagName: "LI" }, { count: 0 });
+    const root = new FakeLocator({ tagName: "DIV" }, { testId: "vs" });
+    root.descendant = input;
+    const original = root.locator.bind(root);
+    root.locator = (selector: string) => {
+      if (selector.includes("vs__dropdown-menu")) return option;
+      return original(selector);
+    };
+    fakePage.locator = () => root;
+    await page.selectVSelect("vs", "Acme", 0, "note");
+    expect(input.clicks).toBeGreaterThanOrEqual(1);
+    expect(option.clicks).toBe(0);
+  });
+
+  it("clicks by aria label", async () => {
+    const fakePage = new FakePage();
+    const target = new FakeLocator({ tagName: "BUTTON" });
+    fakePage.locator = (selector: string) =>
+      selector.includes("aria-label") ? target : new FakeLocator({ tagName: "DIV" }, { selector });
+    const page = new ExposedBasePage(fakePage);
+    await page.clickAria("Close", "note");
+    expect(target.clicks).toBe(1);
+  });
+
+  it("types into an element by test id", async () => {
+    const fakePage = new FakePage();
+    const page = new ExposedBasePage(fakePage);
+    const input = new FakeLocator({ tagName: "INPUT" }, { testId: "name" });
+    fakePage.locator = () => input;
+    await page.typeTestId("name", "Acme");
+    expect(input.clicks).toBeGreaterThanOrEqual(1);
+    const enteredViaKeyboard = fakePage.keyboard.typed.some((t) => t.text === "Acme");
+    const enteredViaFill = input.fills.includes("Acme");
+    expect(enteredViaKeyboard || enteredViaFill).toBe(true);
+  });
+
+  it("checks visibility, text, wait, hover, and select by test id", async () => {
+    const fakePage = new FakePage();
+    fakePage.isVisibleResult = false;
+    fakePage.textContentResult = "hello";
+    const page = new ExposedBasePage(fakePage);
+    const input = new FakeLocator({ tagName: "SELECT" }, { testId: "sel" });
+    fakePage.locator = () => input;
+    expect(await page.visibleTestId("x")).toBe(false);
+    expect(await page.textTestId("x")).toBe("hello");
+    await page.waitTestId("x", { timeout: 500 });
+    expect(fakePage.waitForSelectorCalls[0]).toEqual({ selector: '[data-testid="x"]', options: { timeout: 500 } });
+    await page.hoverTestId("x");
+    expect(fakePage.hoverCalls).toContain('[data-testid="x"]');
+    await page.selectTestId("x", "opt");
+    expect(fakePage.selectOptionCalls[0]).toEqual({ selector: '[data-testid="x"]', value: "opt" });
+  });
+});
+
+describe("BasePage fluent proxy", () => {
+  class Child {
+    public constructor(public value: number) {}
+    public name = "child";
+    public async getObjectId() {
+      return new ObjectId("7");
+    }
+    public async getObjectIdAsInt() {
+      return 7;
+    }
+    public async increment() {
+      return this.value + 1;
+    }
+    public async nested(): Promise<Child> {
+      return new Child(this.value + 10);
+    }
+  }
+
+  function makePage() {
+    const fakePage = new FakePage();
+    return new ExposedBasePage(fakePage);
+  }
+
+  it("awaits to the underlying object", async () => {
+    const page = makePage();
+    const fluent = page.makeFluent(async () => new Child(1));
+    const child = await fluent;
+    expect(child).toBeInstanceOf(Child);
+    expect(child.value).toBe(1);
+  });
+
+  it("chains non-value-returning methods back to the root and resolves siblings", async () => {
+    const page = makePage();
+    const fluent = page.makeFluent(async () => new Child(1));
+    const chained = fluent.increment().nested();
+    const root = await chained;
+    expect(root).toBeInstanceOf(Child);
+  });
+
+  it("returns a value proxy for getObjectId and getObjectIdAsInt", async () => {
+    const page = makePage();
+    const fluent = page.makeFluent(async () => new Child(1));
+    const id = await fluent.getObjectId();
+    expect(id.toString()).toBe("7");
+    const asInt = await fluent.getObjectIdAsInt();
+    expect(asInt).toBe(7);
+  });
+
+  it("reads a property member of a value proxy", async () => {
+    const page = makePage();
+    const fluent = page.makeFluent(async () => new Child(1));
+    // Calling a function member of the value proxy resolves to that member's result,
+    // with `this` bound to the underlying object (ObjectId.toString reads this.raw).
+    expect(await fluent.getObjectId().toString()).toBe("7");
+  });
+
+  it("throws when awaiting a missing member on the root proxy", async () => {
+    const page = makePage();
+    const fluent = page.makeFluent(async () => new Child(1));
+    await expect(dynamicMembers(fluent).missing.then((v) => v)).rejects.toThrow("does not exist");
+  });
+
+  it("throws when awaiting a missing nested member of a value proxy", async () => {
+    const page = makePage();
+    const fluent = page.makeFluent(async () => new Child(1));
+    const valueProxy = fluent.getObjectId();
+    await expect(dynamicMembers(valueProxy).nope.then((v) => v)).rejects.toThrow("does not exist");
+  });
+
+  it("throws when calling a non-function nested member of a value proxy", async () => {
+    const page = makePage();
+    const fluent = page.makeFluent(async () => new Child(1));
+    // `raw` is a non-function (string) member of ObjectId; calling it through the
+    // value-member proxy rejects with "is not a function". Driving the rejection
+    // through `.then` yields a real Promise (the proxy is a thenable function, not
+    // a Promise instance) so `expect(...).rejects` can observe it.
+    const valueProxy = fluent.getObjectId();
+    await expect(dynamicMembers(valueProxy).raw().then((v) => v)).rejects.toThrow("is not a function");
+  });
+});

--- a/tests/broad/compiler-metadata-utils-ts.test.ts
+++ b/tests/broad/compiler-metadata-utils-ts.test.ts
@@ -1,0 +1,520 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import {
+  type AttributeNode,
+  type CommentNode,
+  type DirectiveNode,
+  type ElementNode,
+  type InterpolationNode,
+  type SimpleExpressionNode,
+  type SourceLocation,
+  NodeTypes,
+} from "@vue/compiler-core";
+import { PatchFlags } from "@vue/shared";
+
+import {
+  findDataTestIdProp,
+  getTestIdFromProp,
+  parseDynamicProps,
+  tryCreateElementMetadata,
+} from "../../compiler-metadata-utils";
+import {
+  makeAttributeNode,
+  makeDirectiveNode,
+  makeElementNode,
+  makeSimpleExpression,
+  makeTextNode,
+  makeVNodeCall,
+} from "../helpers/typed-mocks";
+
+function loc(): SourceLocation {
+  return {
+    start: { offset: 0, line: 1, column: 1 },
+    end: { offset: 0, line: 1, column: 1 },
+    source: "",
+  };
+}
+
+function expr(content: string): SimpleExpressionNode {
+  return makeSimpleExpression(content);
+}
+
+function makeInterpolationNode(): InterpolationNode {
+  return { type: NodeTypes.INTERPOLATION, content: makeSimpleExpression(""), loc: loc() };
+}
+
+function makeCommentNode(): CommentNode {
+  return { type: NodeTypes.COMMENT, content: "", loc: loc() };
+}
+
+function makeElement(overrides: Partial<ElementNode> = {}): ElementNode {
+  const el = makeElementNode({
+    ...(overrides.tag !== undefined ? { tag: overrides.tag } : {}),
+    ...(overrides.tagType !== undefined ? { tagType: overrides.tagType } : {}),
+    ...(overrides.props !== undefined ? { props: overrides.props } : {}),
+    ...(overrides.children !== undefined ? { children: overrides.children } : {}),
+  });
+  const result = { ...el, ...overrides } as ElementNode;
+  if (!overrides.loc) {
+    result.loc = {
+      start: { offset: 0, line: 7, column: 3 },
+      end: { offset: 0, line: 7, column: 3 },
+      source: "",
+    };
+  }
+  return result;
+}
+
+describe("compiler-metadata-utils.ts getTestIdFromProp", () => {
+  it("returns null when prop is undefined", () => {
+    expect(getTestIdFromProp(undefined)).toBeNull();
+  });
+
+  it("returns the content of a static attribute with a value", () => {
+    expect(
+      getTestIdFromProp(makeAttributeNode("data-testid", "abc")),
+    ).toBe("abc");
+  });
+
+  it("returns null for a static attribute with no value", () => {
+    expect(
+      getTestIdFromProp(makeAttributeNode("data-testid")),
+    ).toBeNull();
+  });
+
+  it("returns the expression content of a bind directive with a simple expression", () => {
+    expect(
+      getTestIdFromProp(makeDirectiveNode("bind", { arg: expr("data-testid"), exp: expr("someId") })),
+    ).toBe("someId");
+  });
+
+  it("returns null for a bind directive whose exp is not a simple expression", () => {
+    expect(
+      getTestIdFromProp(makeDirectiveNode("bind", { arg: expr("data-testid") })),
+    ).toBeNull();
+  });
+
+  it("returns null for a prop that is neither attribute nor directive", () => {
+    const prop = makeInterpolationNode();
+    // @ts-expect-error intentionally passing a non-attribute/directive node to exercise the null-return path
+    expect(getTestIdFromProp(prop)).toBeNull();
+  });
+});
+
+describe("compiler-metadata-utils.ts findDataTestIdProp", () => {
+  it("finds a static attribute by default name", () => {
+    const el = makeElement({
+      props: [makeAttributeNode("data-testid", "x")],
+    });
+    expect(findDataTestIdProp(el)?.type).toBe(NodeTypes.ATTRIBUTE);
+  });
+
+  it("finds a bind directive by custom attribute name", () => {
+    const el = makeElement({
+      props: [makeDirectiveNode("bind", { arg: expr("data-qa"), exp: expr("y") })],
+    });
+    const prop = findDataTestIdProp(el, "data-qa");
+    expect(prop?.type).toBe(NodeTypes.DIRECTIVE);
+  });
+
+  it("returns undefined when no matching prop exists", () => {
+    expect(findDataTestIdProp(makeElement())).toBeUndefined();
+  });
+});
+
+describe("compiler-metadata-utils.ts parseDynamicProps", () => {
+  it("returns undefined for falsy input", () => {
+    expect(parseDynamicProps(undefined)).toBeUndefined();
+    expect(parseDynamicProps("")).toBeUndefined();
+  });
+
+  it("parses a comma-delimited string, trimming and dropping empty tokens", () => {
+    expect(parseDynamicProps("a, b ,c")).toEqual(["a", "b", "c"]);
+    // Empty middle token (token.length === 0 branch) and empty last token (last.length === 0 branch).
+    expect(parseDynamicProps("a,,b,")).toEqual(["a", "b"]);
+    // Empty leading token.
+    expect(parseDynamicProps(",a")).toEqual(["a"]);
+  });
+
+  it("parses a JSON array simple expression", () => {
+    expect(parseDynamicProps(expr('["class", "style"]'))).toEqual(["class", "style"]);
+  });
+
+  it("returns undefined when JSON array parsing fails (catch branch)", () => {
+    expect(parseDynamicProps(expr("[not valid json]"))).toBeUndefined();
+  });
+
+  it("wraps a non-array simple expression in a single-element array", () => {
+    expect(parseDynamicProps(expr("class"))).toEqual(["class"]);
+  });
+
+  it("returns undefined for an unrecognized input type", () => {
+    // @ts-expect-error intentionally passing an unrecognized input type to exercise the undefined-return path
+    expect(parseDynamicProps({ random: true })).toBeUndefined();
+  });
+});
+
+describe("compiler-metadata-utils.ts tryCreateElementMetadata", () => {
+  const semanticNameMap = new Map<string, string>([["my-btn", "create"]]);
+
+  function makeTestIdEl(opts: {
+    testId?: string;
+    bindTestId?: string;
+    codegenNode?: ElementNode["codegenNode"];
+    props?: Array<AttributeNode | DirectiveNode>;
+    children?: ElementNode["children"];
+    tag?: string;
+  }): ElementNode {
+    const testId = opts.testId;
+    const bindTestId = opts.bindTestId;
+    const props: Array<AttributeNode | DirectiveNode> = opts.props ?? [];
+    if (testId !== undefined) {
+      props.unshift(makeAttributeNode("data-testid", testId));
+    }
+    else if (bindTestId !== undefined) {
+      props.unshift(makeDirectiveNode("bind", { arg: expr("data-testid"), exp: expr(bindTestId) }));
+    }
+    return makeElement({
+      tag: opts.tag ?? "button",
+      props,
+      children: opts.children ?? [],
+      codegenNode: opts.codegenNode,
+    });
+  }
+
+  it("returns null when there is no test id prop", () => {
+    const el = makeElement({ codegenNode: makeVNodeCall() });
+    expect(tryCreateElementMetadata({
+      element: el,
+      semanticNameMap,
+      debug: false,
+      debugPrefix: "[t]",
+      preferJsonParseFailureAsContentArray: false,
+    })).toBeNull();
+  });
+
+  it("returns null when the test id has no value (empty static attribute)", () => {
+    const el = makeElement({
+      props: [makeAttributeNode("data-testid")],
+      codegenNode: makeVNodeCall(),
+    });
+    expect(tryCreateElementMetadata({
+      element: el,
+      semanticNameMap,
+      debug: false,
+      debugPrefix: "[t]",
+      preferJsonParseFailureAsContentArray: false,
+    })).toBeNull();
+  });
+
+  it("returns null when codegenNode is missing or not a VNODE_CALL", () => {
+    const el = makeTestIdEl({ testId: "my-btn", codegenNode: undefined });
+    expect(tryCreateElementMetadata({
+      element: el,
+      semanticNameMap,
+      debug: false,
+      debugPrefix: "[t]",
+      preferJsonParseFailureAsContentArray: false,
+    })).toBeNull();
+
+    const el2 = makeTestIdEl({ testId: "my-btn", codegenNode: makeSimpleExpression("x") });
+    expect(tryCreateElementMetadata({
+      element: el2,
+      semanticNameMap,
+      debug: false,
+      debugPrefix: "[t]",
+      preferJsonParseFailureAsContentArray: false,
+    })).toBeNull();
+  });
+
+  it("collects static attributes (aria-label, role, title) and text content from nested children", () => {
+    const el = makeTestIdEl({
+      testId: "my-btn",
+      tag: "button",
+      codegenNode: makeVNodeCall({}),
+      props: [
+        makeAttributeNode("aria-label", "Save"),
+        makeAttributeNode("role", "button"),
+        makeAttributeNode("title", "Save now"),
+      ],
+      children: [
+        makeTextNode("Hello"),
+        makeElementNode({
+          tag: "span",
+          children: [makeTextNode("world")],
+        }),
+      ],
+    });
+
+    const meta = tryCreateElementMetadata({
+      element: el,
+      semanticNameMap,
+      debug: false,
+      debugPrefix: "[t]",
+      preferJsonParseFailureAsContentArray: false,
+    })!;
+
+    expect(meta).not.toBeNull();
+    expect(meta.testId).toBe("my-btn");
+    expect(meta.semanticName).toBe("create");
+    expect(meta.staticAriaLabel).toBe("Save");
+    expect(meta.staticRole).toBe("button");
+    expect(meta.staticTitle).toBe("Save now");
+    expect(meta.staticTextContent).toBe("Hello world");
+    expect(meta.sourceLine).toBe(7);
+    expect(meta.sourceColumn).toBe(3);
+  });
+
+  it("decodes patch flags and dynamic props from a JSON array dynamicProps", () => {
+    const el = makeTestIdEl({
+      testId: "my-btn",
+      codegenNode: makeVNodeCall({
+        patchFlag: PatchFlags.TEXT | PatchFlags.CLASS | PatchFlags.STYLE | PatchFlags.NEED_HYDRATION, // 1 | 2 | 4 | 32 = 39
+        dynamicProps: expr('["class", "style", "text"]'),
+      }),
+    });
+
+    const meta = tryCreateElementMetadata({
+      element: el,
+      semanticNameMap,
+      debug: false,
+      debugPrefix: "[t]",
+      preferJsonParseFailureAsContentArray: false,
+    })!;
+
+    expect(meta.patchFlag).toBe(39);
+    expect(meta.dynamicProps).toEqual(["class", "style", "text"]);
+    expect(meta.hasClickHandler).toBe(true);
+    expect(meta.hasDynamicClass).toBe(true);
+    expect(meta.hasDynamicStyle).toBe(true);
+    expect(meta.hasDynamicText).toBe(true);
+  });
+
+  it("falls back to [] for an unparseable JSON-array dynamicProps (preferJsonParseFailureAsContentArray=false)", () => {
+    const el = makeTestIdEl({
+      testId: "my-btn",
+      codegenNode: makeVNodeCall({
+        patchFlag: 2,
+        dynamicProps: expr("[bad json]"),
+      }),
+    });
+
+    const meta = tryCreateElementMetadata({
+      element: el,
+      semanticNameMap,
+      debug: false,
+      debugPrefix: "[t]",
+      preferJsonParseFailureAsContentArray: false,
+    })!;
+
+    expect(meta.dynamicProps).toEqual([]);
+  });
+
+  it("falls back to [content] for an unparseable JSON-array dynamicProps when preferJsonParseFailureAsContentArray=true", () => {
+    const el = makeTestIdEl({
+      testId: "my-btn",
+      codegenNode: makeVNodeCall({
+        patchFlag: 2,
+        dynamicProps: expr("[bad json]"),
+      }),
+    });
+
+    const meta = tryCreateElementMetadata({
+      element: el,
+      semanticNameMap,
+      debug: false,
+      debugPrefix: "[t]",
+      preferJsonParseFailureAsContentArray: true,
+    })!;
+
+    expect(meta.dynamicProps).toEqual(["[bad json]"]);
+  });
+
+  it("normalizes a whitespace-only testIdAttribute to the default", () => {
+    const el = makeTestIdEl({ testId: "my-btn", codegenNode: makeVNodeCall({}) });
+    const meta = tryCreateElementMetadata({
+      element: el,
+      semanticNameMap,
+      debug: false,
+      debugPrefix: "[t]",
+      preferJsonParseFailureAsContentArray: false,
+      testIdAttribute: "   ",
+    })!;
+    expect(meta.testId).toBe("my-btn");
+  });
+
+  it("respects a custom testIdAttribute that is trimmed", () => {
+    const el = makeTestIdEl({
+      bindTestId: "qa-thing",
+      codegenNode: makeVNodeCall({}),
+    });
+    // Replace the default data-testid directive arg name with the custom one.
+    const testIdProp = el.props[0];
+    if (testIdProp.type === NodeTypes.DIRECTIVE) {
+      testIdProp.arg = expr("data-qa");
+    }
+
+    const meta = tryCreateElementMetadata({
+      element: el,
+      semanticNameMap,
+      debug: false,
+      debugPrefix: "[t]",
+      preferJsonParseFailureAsContentArray: false,
+      testIdAttribute: "  data-qa  ",
+    })!;
+    expect(meta.testId).toBe("qa-thing");
+  });
+
+  it("emits debug logs when debug is enabled", () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => { logs.push(args.join(" ")); };
+    try {
+      const el = makeTestIdEl({
+        testId: "my-btn",
+        codegenNode: makeVNodeCall({
+          patchFlag: 2,
+          dynamicProps: expr("class"),
+        }),
+      });
+
+      const meta = tryCreateElementMetadata({
+        element: el,
+        semanticNameMap,
+        debug: true,
+        debugPrefix: "[t]",
+        preferJsonParseFailureAsContentArray: false,
+      })!;
+
+      expect(meta).not.toBeNull();
+      expect(logs.some((l) => l.includes("testId=\"my-btn\""))).toBe(true);
+      expect(logs.some((l) => l.includes("patchFlag: 2"))).toBe(true);
+      expect(logs.some((l) => l.includes("dynamicProps: class"))).toBe(true);
+    }
+    finally {
+      console.log = originalLog;
+    }
+  });
+});
+
+describe("compiler-metadata-utils.ts branch coverage", () => {
+  const semanticNameMap = new Map<string, string>();
+
+  function makeTestIdEl(opts: {
+    testId?: string;
+    codegenNode?: ElementNode["codegenNode"];
+    props?: Array<AttributeNode | DirectiveNode>;
+    children?: ElementNode["children"];
+    tag?: string;
+  }): ElementNode {
+    const props: Array<AttributeNode | DirectiveNode> = opts.props ?? [];
+    if (opts.testId !== undefined) {
+      props.unshift(makeAttributeNode("data-testid", opts.testId));
+    }
+    return makeElement({
+      tag: opts.tag ?? "button",
+      props,
+      children: opts.children ?? [],
+      codegenNode: opts.codegenNode,
+    });
+  }
+
+  it("skips TEXT children that collapse to empty whitespace (line 106 false branch)", () => {
+    const el = makeTestIdEl({
+      testId: "my-btn",
+      codegenNode: makeVNodeCall({}),
+      children: [
+        // A whitespace-only text node collapses to "" -> falsy -> not pushed.
+        makeTextNode("   "),
+        // A meaningful text node alongside it.
+        makeTextNode("Hello"),
+      ],
+    });
+
+    const meta = tryCreateElementMetadata({
+      element: el,
+      semanticNameMap,
+      debug: false,
+      debugPrefix: "[t]",
+      preferJsonParseFailureAsContentArray: false,
+    })!;
+
+    // Only the non-empty text node contributes.
+    expect(meta.staticTextContent).toBe("Hello");
+  });
+
+  it("ignores child nodes that are neither TEXT nor ELEMENT (line 112 false branch)", () => {
+    const el = makeTestIdEl({
+      testId: "my-btn",
+      codegenNode: makeVNodeCall({}),
+      children: [
+        makeTextNode("Keep"),
+        // An interpolation/comment node is neither TEXT nor ELEMENT -> ignored by visit.
+        makeInterpolationNode(),
+        makeCommentNode(),
+      ],
+    });
+
+    const meta = tryCreateElementMetadata({
+      element: el,
+      semanticNameMap,
+      debug: false,
+      debugPrefix: "[t]",
+      preferJsonParseFailureAsContentArray: false,
+    })!;
+
+    expect(meta.staticTextContent).toBe("Keep");
+  });
+
+  it("does not enter the JSON-array fallback branch for a non-array simple expression dynamicProps (line 159 false branch)", () => {
+    const el = makeTestIdEl({
+      testId: "my-btn",
+      codegenNode: makeVNodeCall({
+        patchFlag: 2,
+        // A non-array simple expression: parseDynamicProps wraps it as ["class"],
+        // and the fallback `if (content.startsWith("[")...)` is false.
+        dynamicProps: expr("class"),
+      }),
+    });
+
+    const meta = tryCreateElementMetadata({
+      element: el,
+      semanticNameMap,
+      debug: false,
+      debugPrefix: "[t]",
+      preferJsonParseFailureAsContentArray: false,
+    })!;
+
+    expect(meta.dynamicProps).toEqual(["class"]);
+  });
+
+  it("logs 'none' for dynamicProps in debug mode when dynamicPropsList is empty (line 187 || none branch)", () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => { logs.push(args.join(" ")); };
+    try {
+      const el = makeTestIdEl({
+        testId: "my-btn",
+        codegenNode: makeVNodeCall({
+          // An unparseable JSON-array expression with preferJsonParseFailureAsContentArray=false
+          // yields dynamicPropsList = [] -> [].join() is "" -> logs "none".
+          dynamicProps: expr("[bad json]"),
+        }),
+      });
+
+      tryCreateElementMetadata({
+        element: el,
+        semanticNameMap,
+        debug: true,
+        debugPrefix: "[t]",
+        preferJsonParseFailureAsContentArray: false,
+      })!;
+
+      expect(logs.some((l) => l.includes("dynamicProps: none"))).toBe(true);
+    }
+    finally {
+      console.log = originalLog;
+    }
+  });
+});

--- a/tests/broad/manifest-generator-ts.test.ts
+++ b/tests/broad/manifest-generator-ts.test.ts
@@ -1,0 +1,517 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { createPomStringPattern } from "../../pom-patterns";
+import {
+  generatePomManifestModule,
+  generateTestIdsModule,
+} from "../../manifest-generator";
+import type { IComponentDependencies, IDataTestId, PomExtraClickMethodSpec, PomPrimarySpec } from "../../utils";
+import type { ElementMetadata } from "../../metadata-collector";
+
+function pom(
+  overrides: Partial<PomPrimarySpec> = {},
+): PomPrimarySpec {
+  return {
+    nativeRole: "button",
+    methodName: "Save",
+    selector: createPomStringPattern("save", "static", []),
+    parameters: [],
+    generatedActionName: "clickSave",
+    generatedPropertyName: "SaveButton",
+    ...overrides,
+  };
+}
+
+function entry(overrides: Partial<IDataTestId> = {}): IDataTestId {
+  return {
+    selectorValue: createPomStringPattern("save", "static", []),
+    pom: pom(),
+    ...overrides,
+  };
+}
+
+function deps(
+  dataTestIdSet: Set<IDataTestId>,
+  overrides: Partial<IComponentDependencies> = {},
+): IComponentDependencies {
+  return {
+    filePath: "/repo/src/Foo.vue",
+    childrenComponentSet: new Set<string>(),
+    usedComponentSet: new Set<string>(),
+    dataTestIdSet,
+    isView: false,
+    ...overrides,
+  };
+}
+
+describe("manifest-generator.ts generateTestIdsModule / generatePomManifestModule", () => {
+  it("emits both manifests with entries, accessibility, generated names, and metadata fields", () => {
+    const primarySelector = createPomStringPattern("save-button", "static", []);
+    const primaryPom = pom({
+      methodName: "SaveButton",
+      selector: primarySelector,
+      generatedActionName: "clickSaveButton",
+      generatedPropertyName: "SaveButton",
+    });
+
+    // An extra click method whose selector matches the primary selector (testId kind, same formatted + patternKind).
+    const matchingExtra: PomExtraClickMethodSpec = {
+      kind: "click",
+      name: "clickSaveButtonAlt",
+      selector: { kind: "testId", testId: primarySelector },
+      parameters: [],
+    };
+    // An extra click method whose selector does NOT match (different testId formatted).
+    const nonMatchingExtra: PomExtraClickMethodSpec = {
+      kind: "click",
+      name: "clickOther",
+      selector: { kind: "testId", testId: createPomStringPattern("other", "static", []) },
+      parameters: [],
+    };
+
+    const dataTestIdSet = new Set<IDataTestId>([
+      {
+        selectorValue: primarySelector,
+        pom: primaryPom,
+        targetPageObjectModelClass: "DetailsPage",
+      },
+    ]);
+
+    const componentHierarchyMap = new Map<string, IComponentDependencies>([
+      ["SaveView", deps(dataTestIdSet, {
+        filePath: "/repo/src/views/Save.vue",
+        isView: true,
+        pomExtraMethods: [matchingExtra, nonMatchingExtra],
+      })],
+    ]);
+
+    const elementMetadata = new Map<string, Map<string, ElementMetadata>>([
+      ["SaveView", new Map<string, ElementMetadata>([
+        ["save-button", {
+          testId: "save-button",
+          semanticName: "save form",
+          tag: "button",
+          tagType: 0,
+          patchFlag: 39,
+          dynamicProps: ["class", "style"],
+          hasClickHandler: true,
+          hasDynamicClass: true,
+          hasDynamicStyle: true,
+          hasDynamicText: true,
+          staticAriaLabel: "Save",
+          staticRole: "button",
+          staticTextContent: "Save",
+          sourceLine: 5,
+          sourceColumn: 2,
+        }],
+      ])],
+    ]);
+
+    const code = generateTestIdsModule(componentHierarchyMap, elementMetadata);
+
+    // Both manifests present.
+    expect(code).toContain("export const testIdManifest");
+    expect(code).toContain("export const pomManifest");
+
+    // The matching extra action name is included; the non-matching one is excluded.
+    // generatedActionNames dedupes: [clickSaveButton, clickSaveButtonAlt] (sorted).
+    expect(code).toContain("\"clickSaveButton\"");
+    expect(code).toContain("\"clickSaveButtonAlt\"");
+    expect(code).not.toContain("\"clickOther\"");
+
+    // Accessibility audit fields derived from metadata + role.
+    expect(code).toContain("\"accessibleNameSource\": \"aria-label\"");
+    expect(code).toContain("\"needsReview\": false");
+    expect(code).toContain("\"staticAriaLabel\": \"Save\"");
+
+    // semanticName comes from metadata when present.
+    expect(code).toContain("\"semanticName\": \"save form\"");
+    // locatorDescription built from pom.
+    expect(code).toContain("\"locatorDescription\":");
+    // inferredRole from pom.nativeRole.
+    expect(code).toContain("\"inferredRole\": \"button\"");
+    // generatedPropertyName from pom.
+    expect(code).toContain("\"generatedPropertyName\": \"SaveButton\"");
+    // emitPrimary defaults to true.
+    expect(code).toContain("\"emitPrimary\": true");
+    // targetPageObjectModelClass propagated from entry.
+    expect(code).toContain("\"targetPageObjectModelClass\": \"DetailsPage\"");
+
+    // Metadata-sourced fields propagated.
+    expect(code).toContain("\"sourceTag\": \"button\"");
+    expect(code).toContain("\"sourceTagType\": 0");
+    expect(code).toContain("\"sourceLine\": 5");
+    expect(code).toContain("\"sourceColumn\": 2");
+    expect(code).toContain("\"patchFlag\": 39");
+    expect(code).toContain("\"dynamicProps\":");
+    expect(code).toContain("\"hasClickHandler\": true");
+    expect(code).toContain("\"hasDynamicClass\": true");
+    expect(code).toContain("\"hasDynamicStyle\": true");
+    expect(code).toContain("\"hasDynamicText\": true");
+
+    // Component kind derived from isView.
+    expect(code).toContain("\"kind\": \"view\"");
+    expect(code).toContain("\"sourceFile\": \"/repo/src/views/Save.vue\"");
+  });
+
+  it("falls back to humanized method name for semanticName and uses buildPomLocatorDescription for locatorDescription when metadata is absent but pom present", () => {
+    const dataTestIdSet = new Set<IDataTestId>([
+      entry({
+        selectorValue: createPomStringPattern("submit-thing", "static", []),
+        pom: pom({
+          methodName: "SubmitThing",
+          selector: createPomStringPattern("submit-thing", "static", []),
+          generatedActionName: "clickSubmitThing",
+          generatedPropertyName: "SubmitThingButton",
+        }),
+      }),
+    ]);
+
+    const componentHierarchyMap = new Map<string, IComponentDependencies>([
+      ["MyComp", deps(dataTestIdSet)],
+    ]);
+
+    // No elementMetadata for this component -> metadata is undefined.
+    const code = generateTestIdsModule(componentHierarchyMap, new Map());
+    // semanticName falls back to humanizePomMethodName("SubmitThing").
+    expect(code).toContain("\"semanticName\": \"submit thing\"");
+    // locatorDescription is built from pom via buildPomLocatorDescription (componentName + method + role).
+    expect(code).toContain("\"locatorDescription\": \"My comp submit thing button\"");
+    // inferredRole present; accessibility undefined when metadata undefined (no accessibility field).
+    expect(code).toContain("\"inferredRole\": \"button\"");
+    expect(code).not.toContain("\"accessibility\"");
+    // generatedActionName present.
+    expect(code).toContain("\"generatedActionName\": \"clickSubmitThing\"");
+  });
+
+  it("uses testId as semanticName and componentName as locatorDescription when pom is absent", () => {
+    const dataTestIdSet = new Set<IDataTestId>([
+      { selectorValue: createPomStringPattern("raw-id", "static", []) },
+    ]);
+
+    const componentHierarchyMap = new Map<string, IComponentDependencies>([
+      ["Plain", deps(dataTestIdSet)],
+    ]);
+
+    const code = generateTestIdsModule(componentHierarchyMap, new Map());
+    // pom null -> semanticName = testId, locatorDescription = componentName.
+    expect(code).toContain("\"semanticName\": \"raw-id\"");
+    expect(code).toContain("\"locatorDescription\": \"Plain\"");
+    // inferredRole null, generatedPropertyName null, generatedActionName null.
+    expect(code).toContain("\"inferredRole\": null");
+    expect(code).toContain("\"generatedPropertyName\": null");
+    expect(code).toContain("\"generatedActionName\": null");
+    // generatedActionNames empty array.
+    expect(code).toContain("\"generatedActionNames\": []");
+    // emitPrimary true (pom?.emitPrimary !== false -> true when pom undefined).
+    expect(code).toContain("\"emitPrimary\": true");
+  });
+
+  it("suppresses standalone wrapper fallback surfaces from the pom manifest but keeps them in testIdManifest", () => {
+    // A wrapper whose only entry is a generic button fallback named after the component class.
+    const wrapperSelector = createPomStringPattern("WrapperButton-Click-button", "static", []);
+    const dataTestIdSet = new Set<IDataTestId>([
+      {
+        selectorValue: wrapperSelector,
+        pom: pom({
+          nativeRole: "button",
+          methodName: "WrapperButton",
+          selector: wrapperSelector,
+          generatedActionName: "clickWrapperButton",
+          generatedPropertyName: "WrapperButton",
+        }),
+      },
+    ]);
+
+    const componentHierarchyMap = new Map<string, IComponentDependencies>([
+      ["WrapperButton", deps(dataTestIdSet, { filePath: "/repo/src/components/WrapperButton.vue" })],
+      // A view component that should remain in the pom manifest (views are never suppressed).
+      ["NormalView", deps(new Set<IDataTestId>([entry({
+        selectorValue: createPomStringPattern("normal", "static", []),
+        pom: pom({
+          methodName: "NormalView",
+          selector: createPomStringPattern("normal", "static", []),
+          generatedActionName: "clickNormalView",
+          generatedPropertyName: "NormalViewButton",
+        }),
+      })]), { filePath: "/repo/src/views/Normal.vue", isView: true })],
+    ]);
+
+    const code = generateTestIdsModule(componentHierarchyMap, new Map());
+
+    const testIdSection = code.slice(
+      code.indexOf("export const testIdManifest"),
+      code.indexOf("export const pomManifest"),
+    );
+    const pomSection = code.slice(code.indexOf("export const pomManifest"));
+
+    // WrapperButton present in testIdManifest, suppressed in pomManifest.
+    expect(testIdSection).toContain("\"WrapperButton\"");
+    expect(pomSection).not.toContain("\"WrapperButton\":");
+    // NormalView present in both.
+    expect(testIdSection).toContain("\"NormalView\"");
+    expect(pomSection).toContain("\"NormalView\"");
+  });
+
+  it("excludes components with no data-testid entries from both manifests (lines 124-125, 150-151)", () => {
+    const componentHierarchyMap = new Map<string, IComponentDependencies>([
+      ["Empty", deps(new Set<IDataTestId>())],
+      ["HasEntries", deps(new Set<IDataTestId>([entry({
+        selectorValue: createPomStringPattern("has", "static", []),
+        pom: pom({
+          methodName: "Has",
+          selector: createPomStringPattern("has", "static", []),
+          generatedActionName: "clickHas",
+          generatedPropertyName: "HasButton",
+        }),
+      })]))],
+    ]);
+
+    const code = generateTestIdsModule(componentHierarchyMap, new Map());
+    expect(code).not.toContain("\"Empty\"");
+    expect(code).toContain("\"HasEntries\"");
+  });
+
+  it("emits a parameterized selector pattern kind and dedupes testIds", () => {
+    const paramSelector = createPomStringPattern("item-${key}", "parameterized", ["key"]);
+    const dataTestIdSet = new Set<IDataTestId>([
+      entry({
+        selectorValue: paramSelector,
+        pom: pom({
+          methodName: "ItemByKey",
+          selector: paramSelector,
+          generatedActionName: "clickItemByKey",
+          generatedPropertyName: "ItemButton",
+        }),
+      }),
+    ]);
+
+    const componentHierarchyMap = new Map<string, IComponentDependencies>([
+      ["Items", deps(dataTestIdSet)],
+    ]);
+
+    const code = generateTestIdsModule(componentHierarchyMap, new Map());
+    expect(code).toContain("\"selectorPatternKind\": \"parameterized\"");
+  });
+
+  it("generatePomManifestModule emits only the pom manifest and type aliases", () => {
+    const dataTestIdSet = new Set<IDataTestId>([entry()]);
+    const componentHierarchyMap = new Map<string, IComponentDependencies>([
+      ["Solo", deps(dataTestIdSet)],
+    ]);
+
+    const code = generatePomManifestModule(componentHierarchyMap, new Map());
+    expect(code).toContain("export const pomManifest");
+    expect(code).not.toContain("export const testIdManifest");
+    expect(code).toContain("export type PomManifestComponentName");
+    expect(code).toContain("\"Solo\"");
+  });
+
+  it("sorts components and testIds deterministically (line 118 sort)", () => {
+    const componentHierarchyMap = new Map<string, IComponentDependencies>([
+      ["Zeta", deps(new Set<IDataTestId>([entry({
+        selectorValue: createPomStringPattern("z", "static", []),
+        pom: pom({ methodName: "Z", selector: createPomStringPattern("z", "static", []), generatedActionName: "clickZ", generatedPropertyName: "ZButton" }),
+      })]))],
+      ["Alpha", deps(new Set<IDataTestId>([entry({
+        selectorValue: createPomStringPattern("a", "static", []),
+        pom: pom({ methodName: "A", selector: createPomStringPattern("a", "static", []), generatedActionName: "clickA", generatedPropertyName: "AButton" }),
+      })]))],
+    ]);
+
+    const code = generateTestIdsModule(componentHierarchyMap, new Map());
+    const alphaIdx = code.indexOf("\"Alpha\"");
+    const zetaIdx = code.indexOf("\"Zeta\"");
+    expect(alphaIdx).toBeGreaterThan(-1);
+    expect(zetaIdx).toBeGreaterThan(-1);
+    expect(alphaIdx).toBeLessThan(zetaIdx);
+  });
+
+  it("matchesPrimarySelector returns false for a non-testId selector kind (line 50-51 branch)", () => {
+    // An extra method with withinTestIdByLabel selector should NOT be matched as a primary action name.
+    const primarySelector = createPomStringPattern("root", "static", []);
+    const labelExtra: PomExtraClickMethodSpec = {
+      kind: "click",
+      name: "clickByLabel",
+      selector: {
+        kind: "withinTestIdByLabel",
+        rootTestId: primarySelector,
+        label: createPomStringPattern("Go", "static", []),
+      },
+      parameters: [],
+    };
+
+    const dataTestIdSet = new Set<IDataTestId>([
+      entry({
+        selectorValue: primarySelector,
+        pom: pom({
+          methodName: "Root",
+          selector: primarySelector,
+          generatedActionName: "clickRoot",
+          generatedPropertyName: "RootButton",
+        }),
+      }),
+    ]);
+
+    const componentHierarchyMap = new Map<string, IComponentDependencies>([
+      ["Lbl", deps(dataTestIdSet, { pomExtraMethods: [labelExtra] })],
+    ]);
+
+    const code = generateTestIdsModule(componentHierarchyMap, new Map());
+    // The label-based extra method is excluded because its selector kind is not "testId".
+    expect(code).toContain("\"clickRoot\"");
+    expect(code).not.toContain("\"clickByLabel\"");
+  });
+
+  it("matchesPrimarySelector returns false when testId formatted differs (mismatch branch)", () => {
+    const primarySelector = createPomStringPattern("primary", "static", []);
+    const dataTestIdSet = new Set<IDataTestId>([
+      entry({
+        selectorValue: primarySelector,
+        pom: pom({
+          methodName: "Primary",
+          selector: primarySelector,
+          generatedActionName: "clickPrimary",
+          generatedPropertyName: "PrimaryButton",
+        }),
+      }),
+    ]);
+
+    // Extra method with testId kind but different formatted value AND different patternKind.
+    const mismatchExtra: PomExtraClickMethodSpec = {
+      kind: "click",
+      name: "clickMismatch",
+      selector: { kind: "testId", testId: createPomStringPattern("other-${key}", "parameterized", ["key"]) },
+      parameters: [],
+    };
+
+    const componentHierarchyMap = new Map<string, IComponentDependencies>([
+      ["M", deps(dataTestIdSet, { pomExtraMethods: [mismatchExtra] })],
+    ]);
+
+    const code = generateTestIdsModule(componentHierarchyMap, new Map());
+    expect(code).toContain("\"clickPrimary\"");
+    expect(code).not.toContain("\"clickMismatch\"");
+  });
+
+  it("dedupes generatedActionNames when an extra method name equals the primary action name", () => {
+    const primarySelector = createPomStringPattern("dup", "static", []);
+    const dataTestIdSet = new Set<IDataTestId>([
+      entry({
+        selectorValue: primarySelector,
+        pom: pom({
+          methodName: "Dup",
+          selector: primarySelector,
+          generatedActionName: "clickDup",
+          generatedPropertyName: "DupButton",
+        }),
+      }),
+    ]);
+    // Extra method with the SAME name as the primary -> should be deduped out of generatedActionNames.
+    const dupExtra: PomExtraClickMethodSpec = {
+      kind: "click",
+      name: "clickDup",
+      selector: { kind: "testId", testId: primarySelector },
+      parameters: [],
+    };
+
+    const componentHierarchyMap = new Map<string, IComponentDependencies>([
+      ["DupView", deps(dataTestIdSet, { pomExtraMethods: [dupExtra], isView: true })],
+    ]);
+
+    const code = generateTestIdsModule(componentHierarchyMap, new Map());
+
+    // Parse the generated pomManifest object to inspect generatedActionNames precisely.
+    const match = code.match(/export const pomManifest = (\{[\s\S]*?\}) as const/);
+    expect(match).not.toBeNull();
+    const pomManifest = JSON.parse(match![1]);
+    const entries = pomManifest.DupView.entries;
+    expect(entries).toHaveLength(1);
+    // generatedActionName field retains the primary name; generatedActionNames array dedupes to a single entry.
+    expect(entries[0].generatedActionName).toBe("clickDup");
+    expect(entries[0].generatedActionNames).toEqual(["clickDup"]);
+  });
+
+  it("emitPrimary is false when pom.emitPrimary is false", () => {
+    const primarySelector = createPomStringPattern("hidden", "static", []);
+    const dataTestIdSet = new Set<IDataTestId>([
+      entry({
+        selectorValue: primarySelector,
+        pom: pom({
+          methodName: "Hidden",
+          selector: primarySelector,
+          generatedActionName: "clickHidden",
+          generatedPropertyName: "HiddenButton",
+          emitPrimary: false,
+        }),
+      }),
+    ]);
+
+    const componentHierarchyMap = new Map<string, IComponentDependencies>([
+      ["Hidden", deps(dataTestIdSet, { isView: true })],
+    ]);
+
+    const code = generateTestIdsModule(componentHierarchyMap, new Map());
+    expect(code).toContain("\"emitPrimary\": false");
+  });
+
+  it("sorts multiple matching extra action names alphabetically (line 72 sort comparator)", () => {
+    const primarySelector = createPomStringPattern("multi", "static", []);
+    const dataTestIdSet = new Set<IDataTestId>([
+      entry({
+        selectorValue: primarySelector,
+        pom: pom({
+          methodName: "Multi",
+          selector: primarySelector,
+          generatedActionName: "clickMulti",
+          generatedPropertyName: "MultiButton",
+        }),
+      }),
+    ]);
+    // Two extra methods both matching the primary selector -> sort comparator runs.
+    const extras: PomExtraClickMethodSpec[] = [
+      { kind: "click", name: "zetaExtra", selector: { kind: "testId", testId: primarySelector }, parameters: [] },
+      { kind: "click", name: "alphaExtra", selector: { kind: "testId", testId: primarySelector }, parameters: [] },
+    ];
+
+    const componentHierarchyMap = new Map<string, IComponentDependencies>([
+      ["MultiView", deps(dataTestIdSet, { pomExtraMethods: extras, isView: true })],
+    ]);
+
+    const code = generateTestIdsModule(componentHierarchyMap, new Map());
+    const match = code.match(/export const pomManifest = (\{[\s\S]*?\}) as const/);
+    expect(match).not.toBeNull();
+    const pomManifest = JSON.parse(match![1]);
+    const names = pomManifest.MultiView.entries[0].generatedActionNames;
+    // Primary action first, then sorted matching extras (deduped against the primary).
+    expect(names).toEqual(["clickMulti", "alphaExtra", "zetaExtra"]);
+  });
+
+  it("sorts multiple testIds within a component alphabetically (line 121 sort comparator)", () => {
+    const zetaSelector = createPomStringPattern("zeta-id", "static", []);
+    const alphaSelector = createPomStringPattern("alpha-id", "static", []);
+    const dataTestIdSet = new Set<IDataTestId>([
+      entry({
+        selectorValue: zetaSelector,
+        pom: pom({ methodName: "ZetaId", selector: zetaSelector, generatedActionName: "clickZetaId", generatedPropertyName: "ZetaIdButton" }),
+      }),
+      entry({
+        selectorValue: alphaSelector,
+        pom: pom({ methodName: "AlphaId", selector: alphaSelector, generatedActionName: "clickAlphaId", generatedPropertyName: "AlphaIdButton" }),
+      }),
+    ]);
+
+    const componentHierarchyMap = new Map<string, IComponentDependencies>([
+      ["MultiIds", deps(dataTestIdSet, { isView: true })],
+    ]);
+
+    const code = generateTestIdsModule(componentHierarchyMap, new Map());
+    const match = code.match(/export const pomManifest = (\{[\s\S]*?\}) as const/);
+    expect(match).not.toBeNull();
+    const pomManifest = JSON.parse(match![1]);
+    const entries = pomManifest.MultiIds.entries;
+    // Entries sorted by testId formatted: alpha-id before zeta-id.
+    expect(entries.map((e: { testId: string }) => e.testId)).toEqual(["alpha-id", "zeta-id"]);
+  });
+});

--- a/tests/broad/metadata-collector-ts.test.ts
+++ b/tests/broad/metadata-collector-ts.test.ts
@@ -1,0 +1,275 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { type ElementNode, ElementTypes } from "@vue/compiler-core";
+
+import { createMetadataCollectorTransform, type ElementMetadata } from "../../metadata-collector";
+import {
+  makeAttributeNode,
+  makeElementNode as makeTypedElementNode,
+  makeSimpleExpression,
+  makeTextNode,
+  makeTransformContext,
+  makeVNodeCall,
+} from "../helpers/typed-mocks";
+
+function makeElementNode(overrides: Partial<ElementNode> = {}): ElementNode {
+  return {
+    ...makeTypedElementNode({
+      tag: "button",
+      tagType: ElementTypes.ELEMENT,
+      props: [makeAttributeNode("data-testid", "submit-button")],
+      children: [],
+      codegenNode: makeVNodeCall({
+        patchFlag: 2,
+        dynamicProps: makeSimpleExpression('["class"]'),
+      }),
+    }),
+    ...overrides,
+  } as ElementNode;
+}
+
+describe("metadata-collector.ts createMetadataCollectorTransform", () => {
+  it("normalizes a null/whitespace testIdAttribute to the default (line 50)", () => {
+    const metadataMap = new Map<string, Map<string, ElementMetadata>>();
+    const semanticNameMap = new Map<string, string>();
+
+    // null/undefined testIdAttribute falls back to default after trim/empty-coalesce.
+    const transformNull = createMetadataCollectorTransform(
+      "Comp",
+      metadataMap,
+      semanticNameMap,
+      false,
+      // @ts-expect-error intentionally null testIdAttribute to exercise the default-fallback path (line 50)
+      null,
+    );
+    const el = makeElementNode();
+    const onExit = transformNull(el, makeTransformContext());
+    if (typeof onExit === "function")
+      onExit();
+    expect(metadataMap.get("Comp")?.get("submit-button")).toBeTruthy();
+
+    // whitespace-only testIdAttribute normalizes to default.
+    const metadataMap2 = new Map<string, Map<string, ElementMetadata>>();
+    const transformWs = createMetadataCollectorTransform(
+      "Comp",
+      metadataMap2,
+      semanticNameMap,
+      false,
+      "   ",
+    );
+    const onExit2 = transformWs(makeElementNode(), makeTransformContext());
+    if (typeof onExit2 === "function")
+      onExit2();
+    expect(metadataMap2.get("Comp")?.get("submit-button")).toBeTruthy();
+  });
+
+  it("uses the default testIdAttribute when the argument is omitted (line 50 default param)", () => {
+    const metadataMap = new Map<string, Map<string, ElementMetadata>>();
+    const semanticNameMap = new Map<string, string>();
+    // Omit the 5th argument entirely to exercise the default parameter value.
+    const transform = createMetadataCollectorTransform(
+      "Comp",
+      metadataMap,
+      semanticNameMap,
+      false,
+    );
+    const onExit = transform(makeElementNode(), makeTransformContext());
+    if (typeof onExit === "function")
+      onExit();
+    expect(metadataMap.get("Comp")?.get("submit-button")).toBeTruthy();
+  });
+
+  it("returns an exit function that returns early for non-element nodes (lines 56-57)", () => {
+    const metadataMap = new Map<string, Map<string, ElementMetadata>>();
+    const semanticNameMap = new Map<string, string>();
+    const transform = createMetadataCollectorTransform(
+      "Comp",
+      metadataMap,
+      semanticNameMap,
+      false,
+    );
+
+    const interpolationNode = makeTextNode("x");
+    const onExit = transform(interpolationNode, makeTransformContext());
+    expect(typeof onExit).toBe("function");
+    if (typeof onExit === "function")
+      onExit();
+    // Nothing should have been collected.
+    expect(metadataMap.size).toBe(0);
+  });
+
+  it("emits debug logs when debug is enabled (lines 63-69)", () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.join(" "));
+    };
+    try {
+      const metadataMap = new Map<string, Map<string, ElementMetadata>>();
+      const semanticNameMap = new Map<string, string>();
+      const transform = createMetadataCollectorTransform(
+        "Comp",
+        metadataMap,
+        semanticNameMap,
+        true,
+      );
+
+      const el = makeElementNode();
+      const onExit = transform(el, makeTransformContext());
+      if (typeof onExit === "function")
+        onExit();
+
+      // Debug logs from metadata-collector exit function.
+      expect(logs.some((l) => l.includes("[metadata] Checking <button>"))).toBe(true);
+      expect(logs.some((l) => l.includes("codegenNode exists: true"))).toBe(true);
+      expect(logs.some((l) => l.includes("codegenNode.type:"))).toBe(true);
+      expect(logs.some((l) => l.includes("tagType="))).toBe(true);
+      expect(logs.some((l) => l.includes("testId=\"submit-button\""))).toBe(true);
+    }
+    finally {
+      console.log = originalLog;
+    }
+  });
+
+  it("logs an empty testId string when no testId prop exists in debug mode (line 65 null branch)", () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.join(" "));
+    };
+    try {
+      const metadataMap = new Map<string, Map<string, ElementMetadata>>();
+      const semanticNameMap = new Map<string, string>();
+      const transform = createMetadataCollectorTransform(
+        "Comp",
+        metadataMap,
+        semanticNameMap,
+        true,
+      );
+
+      // Element with no data-testid prop -> getTestIdFromProp returns null -> debugTestId ?? "" yields "".
+      const el = makeElementNode({ props: [] });
+      const onExit = transform(el, makeTransformContext());
+      if (typeof onExit === "function")
+        onExit();
+
+      expect(logs.some((l) => l.includes('testId=""'))).toBe(true);
+      expect(metadataMap.size).toBe(0);
+    }
+    finally {
+      console.log = originalLog;
+    }
+  });
+
+  it("logs codegenNode exists: false in debug mode when codegenNode is missing", () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.join(" "));
+    };
+    try {
+      const metadataMap = new Map<string, Map<string, ElementMetadata>>();
+      const semanticNameMap = new Map<string, string>();
+      const transform = createMetadataCollectorTransform(
+        "Comp",
+        metadataMap,
+        semanticNameMap,
+        true,
+      );
+
+      const el = makeElementNode({ codegenNode: undefined });
+      const onExit = transform(el, makeTransformContext());
+      if (typeof onExit === "function")
+        onExit();
+
+      expect(logs.some((l) => l.includes("codegenNode exists: false"))).toBe(true);
+      // No codegenNode.type log line because codegenNode is falsy.
+      expect(logs.some((l) => l.includes("codegenNode.type:"))).toBe(false);
+    }
+    finally {
+      console.log = originalLog;
+    }
+  });
+
+  it("returns early when metadata cannot be created (lines 82-83)", () => {
+    const metadataMap = new Map<string, Map<string, ElementMetadata>>();
+    const semanticNameMap = new Map<string, string>();
+    const transform = createMetadataCollectorTransform(
+      "Comp",
+      metadataMap,
+      semanticNameMap,
+      false,
+    );
+
+    // Element has no data-testid prop, so tryCreateElementMetadata returns null.
+    const el = makeElementNode({ props: [] });
+    const onExit = transform(el, makeTransformContext());
+    if (typeof onExit === "function")
+      onExit();
+
+    expect(metadataMap.size).toBe(0);
+  });
+
+  it("returns early when codegenNode is missing so metadata is null (lines 82-83)", () => {
+    const metadataMap = new Map<string, Map<string, ElementMetadata>>();
+    const semanticNameMap = new Map<string, string>();
+    const transform = createMetadataCollectorTransform(
+      "Comp",
+      metadataMap,
+      semanticNameMap,
+      false,
+    );
+
+    const el = makeElementNode({ codegenNode: undefined });
+    const onExit = transform(el, makeTransformContext());
+    if (typeof onExit === "function")
+      onExit();
+
+    expect(metadataMap.size).toBe(0);
+  });
+
+  it("creates and stores a new component map when none exists yet (line 86)", () => {
+    const metadataMap = new Map<string, Map<string, ElementMetadata>>();
+    const semanticNameMap = new Map<string, string>([["submit-button", "submit"]]);
+    const transform = createMetadataCollectorTransform(
+      "FreshComp",
+      metadataMap,
+      semanticNameMap,
+      false,
+    );
+
+    const onExit = transform(makeElementNode(), makeTransformContext());
+    if (typeof onExit === "function")
+      onExit();
+
+    // The component map did not exist before; it should be created now.
+    expect(metadataMap.has("FreshComp")).toBe(true);
+    const entry = metadataMap.get("FreshComp")?.get("submit-button");
+    expect(entry).toBeTruthy();
+    expect(entry!.semanticName).toBe("submit");
+  });
+
+  it("reuses an existing component map when it already exists (line 86 reuse + line 90 set)", () => {
+    const existing = new Map<string, ElementMetadata>([
+      ["existing-id", { testId: "existing-id", tag: "button", tagType: ElementTypes.ELEMENT }],
+    ]);
+    const metadataMap = new Map<string, Map<string, ElementMetadata>>([["Comp", existing]]);
+    const semanticNameMap = new Map<string, string>();
+    const transform = createMetadataCollectorTransform(
+      "Comp",
+      metadataMap,
+      semanticNameMap,
+      false,
+    );
+
+    const onExit = transform(makeElementNode(), makeTransformContext());
+    if (typeof onExit === "function")
+      onExit();
+
+    // Same map instance reused, now containing both entries.
+    expect(metadataMap.get("Comp")).toBe(existing);
+    expect(existing.get("existing-id")).toBeTruthy();
+    expect(existing.get("submit-button")).toBeTruthy();
+  });
+});

--- a/tests/broad/plugin-logger-ts.test.ts
+++ b/tests/broad/plugin-logger-ts.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment node
+import type { Logger } from "vite";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { VUE_POM_GENERATOR_LOG_PREFIX, createLogger } from "../../plugin/logger";
+
+/** Builds a complete Vite `Logger` double so `createLogger`'s `viteLogger` slot
+ * is satisfied without a type-bypass cast. Methods default to no-op `vi.fn()`
+ * spies; pass the ones you want to assert on via `overrides`. */
+function makeViteLogger(overrides: Partial<Logger> = {}): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    warnOnce: vi.fn(),
+    error: vi.fn(),
+    clearScreen: vi.fn(),
+    hasErrorLogged: () => false,
+    hasWarned: false,
+    ...overrides,
+  };
+}
+
+describe("createLogger", () => {
+  describe("normalize (via viteLogger capture)", () => {
+    it("prefixes a plain message", () => {
+      const info = vi.fn();
+      const logger = createLogger({ verbosity: "info", viteLogger: makeViteLogger({ info }) });
+      logger.info("hello");
+      expect(info).toHaveBeenCalledWith(`${VUE_POM_GENERATOR_LOG_PREFIX} hello`);
+    });
+
+    it("returns only the prefix when the message trims to empty", () => {
+      const info = vi.fn();
+      const logger = createLogger({ verbosity: "info", viteLogger: makeViteLogger({ info }) });
+      logger.info("   ");
+      expect(info).toHaveBeenCalledWith(VUE_POM_GENERATOR_LOG_PREFIX);
+    });
+
+    it("does not double-prefix a message that already starts with the prefix", () => {
+      const info = vi.fn();
+      const logger = createLogger({ verbosity: "info", viteLogger: makeViteLogger({ info }) });
+      logger.info(`${VUE_POM_GENERATOR_LOG_PREFIX} already`);
+      expect(info).toHaveBeenCalledWith(`${VUE_POM_GENERATOR_LOG_PREFIX} already`);
+    });
+
+    it("treats null/undefined message as empty", () => {
+      const info = vi.fn();
+      const logger = createLogger({ verbosity: "info", viteLogger: makeViteLogger({ info }) });
+      // @ts-expect-error exercising nullish input
+      logger.info(undefined);
+      // @ts-expect-error exercising null input
+      logger.info(null);
+      expect(info).toHaveBeenNthCalledWith(1, VUE_POM_GENERATOR_LOG_PREFIX);
+      expect(info).toHaveBeenNthCalledWith(2, VUE_POM_GENERATOR_LOG_PREFIX);
+    });
+  });
+
+  describe("sink routing with viteLogger", () => {
+    it("routes info to viteLogger.info", () => {
+      const info = vi.fn();
+      const warn = vi.fn();
+      const logger = createLogger({ verbosity: "debug", viteLogger: makeViteLogger({ info, warn }) });
+      logger.info("a");
+      expect(info).toHaveBeenCalled();
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("routes warn to viteLogger.warn", () => {
+      const info = vi.fn();
+      const warn = vi.fn();
+      const logger = createLogger({ verbosity: "debug", viteLogger: makeViteLogger({ info, warn }) });
+      logger.warn("b");
+      expect(warn).toHaveBeenCalled();
+      expect(info).not.toHaveBeenCalled();
+    });
+
+    it("routes debug to viteLogger.info (no dedicated debug channel)", () => {
+      const info = vi.fn();
+      const logger = createLogger({ verbosity: "debug", viteLogger: makeViteLogger({ info }) });
+      logger.debug("c");
+      expect(info).toHaveBeenCalledWith(expect.stringContaining("c"));
+    });
+  });
+
+  describe("sink routing without viteLogger (console fallback)", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("routes info to console.log when no viteLogger", () => {
+      const log = vi.spyOn(console, "log").mockImplementation(() => {});
+      const logger = createLogger({ verbosity: "info" });
+      logger.info("plain");
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("plain"));
+    });
+
+    it("routes warn to console.warn when no viteLogger", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const logger = createLogger({ verbosity: "warn" });
+      logger.warn("danger");
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("danger"));
+    });
+
+    it("routes debug to console.log when no viteLogger", () => {
+      const log = vi.spyOn(console, "log").mockImplementation(() => {});
+      const logger = createLogger({ verbosity: "debug" });
+      logger.debug("dbg");
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("dbg"));
+    });
+  });
+
+  describe("verbosity gating", () => {
+    it("silent suppresses info, warn, and debug", () => {
+      const info = vi.fn();
+      const warn = vi.fn();
+      const logger = createLogger({ verbosity: "silent", viteLogger: makeViteLogger({ info, warn }) });
+      logger.info("i");
+      logger.debug("d");
+      logger.warn("w");
+      expect(info).not.toHaveBeenCalled();
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("warn suppresses info and debug but allows warn", () => {
+      const info = vi.fn();
+      const warn = vi.fn();
+      const logger = createLogger({ verbosity: "warn", viteLogger: makeViteLogger({ info, warn }) });
+      logger.info("i");
+      logger.debug("d");
+      logger.warn("w");
+      expect(info).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it("info allows info and warn but suppresses debug", () => {
+      const info = vi.fn();
+      const warn = vi.fn();
+      const logger = createLogger({ verbosity: "info", viteLogger: makeViteLogger({ info, warn }) });
+      logger.info("i");
+      logger.debug("d");
+      logger.warn("w");
+      expect(info).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it("debug allows info, debug, and warn", () => {
+      const info = vi.fn();
+      const warn = vi.fn();
+      const logger = createLogger({ verbosity: "debug", viteLogger: makeViteLogger({ info, warn }) });
+      logger.info("i");
+      logger.debug("d");
+      logger.warn("w");
+      expect(info).toHaveBeenCalledTimes(2); // info + debug both go to info
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/broad/plugin-resolved-generation-options-ts.test.ts
+++ b/tests/broad/plugin-resolved-generation-options-ts.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { resolveGenerationSupportOptions } from "../../plugin/resolved-generation-options";
+
+describe("resolveGenerationSupportOptions", () => {
+  it("uses default outDir when not provided", () => {
+    expect(resolveGenerationSupportOptions({}).outDir).toBe("tests/playwright/__generated__");
+  });
+
+  it("trims a provided outDir", () => {
+    expect(resolveGenerationSupportOptions({ outDir: "  out/dir  " }).outDir).toBe("out/dir");
+  });
+
+  it("falls back to default testIdAttribute when the provided one trims to empty", () => {
+    expect(resolveGenerationSupportOptions({ testIdAttribute: "   " }).testIdAttribute).toBe("data-testid");
+  });
+
+  it("trims a provided non-empty testIdAttribute", () => {
+    expect(resolveGenerationSupportOptions({ testIdAttribute: "  data-qa  " }).testIdAttribute).toBe("data-qa");
+  });
+
+  it("defaults emitLanguages to ['ts']", () => {
+    expect(resolveGenerationSupportOptions({}).emitLanguages).toEqual(["ts"]);
+  });
+
+  it("uses provided emitLanguages when non-empty", () => {
+    expect(resolveGenerationSupportOptions({ emitLanguages: ["ts", "csharp"] }).emitLanguages).toEqual(["ts", "csharp"]);
+  });
+});

--- a/tests/broad/plugin-runtime-annotator-format-ts.test.ts
+++ b/tests/broad/plugin-runtime-annotator-format-ts.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+
+import { formatAnnotations, formatSingleAnnotationPreview, type FormattedAnnotation } from "../../plugin/runtime/annotator/format";
+
+const baseAnnotation: FormattedAnnotation = {
+  comment: "  broken   link  ",
+  targetLabel: "SubmitButton",
+  source: "src/widgets/Submit.vue",
+  component: "SubmitButton",
+  uiText: "  submit  ",
+  locator: "near `[data-testid=\"submit\"]`",
+  domHint: "div > button#submit",
+};
+
+describe("formatAnnotations", () => {
+  it("strips the URL scheme and renders header + url + viewport in forensic mode", () => {
+    const out = formatAnnotations([baseAnnotation], "forensic", "https://app.example.com/page");
+    expect(out).toContain("## Feedback — app.example.com/page");
+    expect(out).toContain("- **URL:** https://app.example.com/page");
+    // jsdom defines window, so the viewport line is present in forensic mode.
+    expect(out).toMatch(/- \*\*Viewport:\*\* \d+x\d+/);
+  });
+
+  it("omits the viewport line in standard mode", () => {
+    const out = formatAnnotations([baseAnnotation], "standard", "http://app.example.com/page");
+    expect(out).not.toContain("Viewport");
+    expect(out).toContain("## Feedback — app.example.com/page");
+  });
+
+  it("renders component, normalized UI text, locator, and forensic DOM hint", () => {
+    const out = formatAnnotations([baseAnnotation], "forensic", "https://app.example.com");
+    expect(out).toContain("### 1. broken link");
+    expect(out).toContain("- **Source:** src/widgets/Submit.vue");
+    expect(out).toContain("- **Component:** SubmitButton");
+    expect(out).toContain("- **Target:** `SubmitButton`");
+    expect(out).toContain("- **UI text:** `submit`");
+    expect(out).toContain("- **Locator:** near `[data-testid=\"submit\"]`");
+    expect(out).toContain("- **DOM hint:** `div > button#submit`");
+  });
+
+  it("falls back to targetLabel for the title when the comment is blank", () => {
+    const out = formatAnnotations(
+      [{ ...baseAnnotation, comment: "   " }],
+      "standard",
+      "https://app.example.com",
+    );
+    expect(out).toContain("### 1. SubmitButton");
+  });
+
+  it("falls back to a default source message when source is missing", () => {
+    const out = formatAnnotations(
+      [{ ...baseAnnotation, source: undefined }],
+      "standard",
+      "https://app.example.com",
+    );
+    expect(out).toContain("- **Source:** Unable to find component file path.");
+  });
+
+  it("omits component, UI text, locator, and DOM hint lines when those fields are absent/blank", () => {
+    const out = formatAnnotations(
+      [{
+        comment: "note",
+        targetLabel: "Thing",
+        component: undefined,
+        uiText: "   ",
+        locator: "",
+        domHint: "  ",
+      }],
+      "forensic",
+      "https://app.example.com",
+    );
+    expect(out).not.toContain("**Component:**");
+    expect(out).not.toContain("**UI text:**");
+    expect(out).not.toContain("**Locator:**");
+    expect(out).not.toContain("**DOM hint:**");
+  });
+
+  it("numbers multiple annotations sequentially", () => {
+    const out = formatAnnotations(
+      [baseAnnotation, { ...baseAnnotation, comment: "second" }],
+      "standard",
+      "https://app.example.com",
+    );
+    expect(out).toContain("### 1. broken link");
+    expect(out).toContain("### 2. second");
+  });
+});
+
+describe("formatSingleAnnotationPreview", () => {
+  it("slices from the first heading and trims", () => {
+    const preview = formatSingleAnnotationPreview(baseAnnotation, "standard", "https://app.example.com");
+    expect(preview.startsWith("### 1.")).toBe(true);
+    expect(preview).not.toContain("## Feedback");
+  });
+});

--- a/tests/broad/typescript-codegen-ts.test.ts
+++ b/tests/broad/typescript-codegen-ts.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import {
+  addExportAll,
+  addNamedImport,
+  buildCommentBlock,
+  buildFilePrefix,
+  createClassConstructor,
+  createClassGetter,
+  createClassMethod,
+  createClassProperty,
+  createTypeScriptWriter,
+  renderClassMembers,
+  renderSourceFile,
+  renderTypeScript,
+  renderTypeScriptLines,
+  type TypeScriptClassMember,
+  writeCommentBlock,
+} from "../../typescript-codegen";
+
+describe("typescript-codegen.ts", () => {
+  it("ensureTrailingNewline adds a newline when missing (via renderTypeScript)", () => {
+    // A single write() with no trailing newline exercises the missing-newline branch.
+    const out = renderTypeScript((writer) => {
+      writer.write("no-newline");
+    });
+    expect(out.endsWith("\n")).toBe(true);
+    expect(out).toBe("no-newline\n");
+  });
+
+  it("does not double-add a trailing newline (via renderTypeScriptLines)", () => {
+    const out = renderTypeScriptLines(["a", "b"]);
+    expect(out).toBe("a\nb\n");
+  });
+
+  it("createTypeScriptWriter produces a usable writer", () => {
+    const writer = createTypeScriptWriter();
+    writer.writeLine("hello");
+    expect(writer.toString()).toContain("hello");
+  });
+
+  it("buildFilePrefix emits reference lib, eslint-disable, and comment block", () => {
+    const prefix = buildFilePrefix({
+      referenceLib: "dom",
+      eslintDisableSortImports: true,
+      commentLines: ["Generated file", "Do not edit"],
+    });
+    expect(prefix).toContain('/// <reference lib="dom" />');
+    expect(prefix).toContain("/* eslint-disable perfectionist/sort-imports */");
+    expect(prefix).toContain("Generated file");
+    expect(prefix).toContain("Do not edit");
+  });
+
+  it("buildFilePrefix returns empty string for no options", () => {
+    expect(buildFilePrefix()).toBe("");
+  });
+
+  it("buildCommentBlock renders a multi-line doc comment", () => {
+    const block = buildCommentBlock(["One", "Two"]);
+    expect(block).toContain("/**");
+    expect(block).toContain(" * One");
+    expect(block).toContain(" * Two");
+    expect(block).toContain(" */");
+  });
+
+  it("writeCommentBlock writes a comment block onto a writer", () => {
+    const writer = createTypeScriptWriter();
+    writeCommentBlock(writer, ["Header"]);
+    expect(writer.toString()).toContain("Header");
+  });
+
+  it("renderSourceFile builds statements and applies a prefix", () => {
+    const content = renderSourceFile(
+      "test.ts",
+      (sf) => {
+        sf.addStatements('const x = 1;');
+      },
+      { prefixText: "// prefix\n" },
+    );
+    expect(content.startsWith("// prefix\n")).toBe(true);
+    expect(content).toContain("const x = 1");
+    expect(content.endsWith("\n")).toBe(true);
+  });
+
+  it("renderSourceFile without prefix does not prepend anything", () => {
+    const content = renderSourceFile("test.ts", (sf) => {
+      sf.addStatements('const y = 2;');
+    });
+    expect(content).toContain("const y = 2");
+    expect(content.startsWith("//")).toBe(false);
+  });
+
+  it("addNamedImport and addExportAll modify the source file", () => {
+    const content = renderSourceFile("test.ts", (sf) => {
+      addNamedImport(sf, { moduleSpecifier: "vue", namedImports: [{ name: "ref", alias: "r" }], isTypeOnly: true });
+      addExportAll(sf, "./other");
+    });
+    expect(content).toContain('from "vue"');
+    expect(content).toContain("ref as r");
+    expect(content).toContain('export * from "./other"');
+  });
+
+  it("renderClassMembers renders each member kind (constructor, getter, method, property)", () => {
+    const members = [
+      createClassConstructor({ parameters: [], statements: ["this.x = 1;"] }),
+      createClassGetter({ name: "value", returnType: "number", statements: ["return 2;"] }),
+      createClassMethod({ name: "doThing", parameters: [{ name: "n", type: "string" }], returnType: "void", statements: ["console.log(n);"] }),
+      createClassProperty({ name: "flag", type: "boolean", initializer: "false" }),
+    ];
+
+    const rendered = renderClassMembers(members);
+    expect(rendered).toContain("constructor");
+    expect(rendered).toContain("get value()");
+    expect(rendered).toContain("doThing(");
+    expect(rendered).toContain("flag");
+    expect(rendered).toContain("boolean");
+  });
+
+  it("renderClassMembers returns empty text when there are no members (empty-members branch)", () => {
+    expect(renderClassMembers([])).toBe("");
+  });
+
+  it("renderClassMembers throws for an unsupported member kind", () => {
+    // @ts-expect-error intentionally invalid member kind (9999 is not a supported StructureKind) to exercise the unsupported-kind error path
+    const bad: TypeScriptClassMember = { kind: 9999 };
+    expect(() => renderClassMembers([bad])).toThrow(/Unsupported class member kind/);
+  });
+});


### PR DESCRIPTION
New standalone test files (in `tests/broad/`) exercising previously uncovered modules against the real source, plus a focused annotator-runtime helper test. Stacks on `refactor/eliminate-template-vars-tighten-any` (#46).

- `class-generation-base-page-ts`, `typescript-codegen-ts`, `manifest-generator-ts`
- `compiler-metadata-utils-ts`, `metadata-collector-ts`, `plugin-logger-ts`
- `plugin-resolved-generation-options-ts`, `plugin-runtime-annotator-format-ts`
- `accessibility-audit-ts`
- `tests/annotator-runtime-helpers.test.ts` (annotator pure helpers)

These build on the typed mock helpers (`tests/helpers/typed-mocks.ts`, `tests/broad/helpers/fake-runtime.ts`) and the `__internal` export surface added in the preceding refactor commits (#45, #46).

Builds green at this stack level: lint clean, typecheck clean, 369 tests pass across 34 files.

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>