### PR TITLE
feat(eslint): ban getByTestId and close computed-member bypass in no-raw-playwright-apis

### DIFF
--- a/eslint/no-raw-playwright-apis.ts
+++ b/eslint/no-raw-playwright-apis.ts
@@ -1,6 +1,10 @@
 import type { Rule } from "eslint";
+import type { MemberExpression } from "estree";
 
-const bannedPlaywrightApis = new Set(["locator", "getByRole", "getByText", "getByLabel"]);
+// Locator-filter methods available on Page/Locator/Frame etc. Banned regardless of
+// the receiver object. `getByTestId` is the generator's own test-id contract — specs
+// should reach it through a generated POM accessor, never a raw `*.getByTestId(...)`.
+const bannedPlaywrightApis = new Set(["locator", "getByRole", "getByText", "getByLabel", "getByTestId"]);
 
 const bannedPageApis = new Set([
 	"$eval",
@@ -16,6 +20,24 @@ const SPEC_FILE_SUFFIXES = [".spec.ts", ".spec.tsx", ".spec.js", ".spec.jsx"];
 
 function isSpecFile(filename: string): boolean {
 	return SPEC_FILE_SUFFIXES.some((suffix) => filename.endsWith(suffix));
+}
+
+/**
+ * Resolve the accessed property name from a MemberExpression callee, covering both
+ * the usual member access (`page.getByTestId(...)`) and the computed equivalent
+ * (`page["getByTestId"](...)`). A computed access whose key is a non-Literal
+ * (e.g. `obj[dynamicKey]()`) cannot be resolved to a name, so it returns
+ * `undefined` and is left alone — it could be anything at runtime.
+ */
+function resolveMemberPropertyName(callee: MemberExpression): string | undefined {
+	const { property, computed } = callee;
+	if (!computed && property.type === "Identifier") {
+		return property.name;
+	}
+	if (computed && property.type === "Literal" && typeof property.value === "string") {
+		return property.value;
+	}
+	return undefined;
 }
 
 export const noRawPlaywrightApisRule: Rule.RuleModule = {
@@ -55,16 +77,16 @@ export const noRawPlaywrightApisRule: Rule.RuleModule = {
 					return;
 				}
 
-				if (
-					node.callee.type !== "MemberExpression"
-					|| node.callee.computed
-					|| node.callee.property.type !== "Identifier"
-				) {
+				if (node.callee.type !== "MemberExpression") {
+					return;
+				}
+
+				const apiName = resolveMemberPropertyName(node.callee as MemberExpression);
+				if (apiName === undefined) {
 					return;
 				}
 
 				const objectText = sourceCode.getText(node.callee.object);
-				const apiName = node.callee.property.name;
 
 				if (
 					(objectText === "page" || objectText === "playwrightPage")

--- a/tests/eslint.test.ts
+++ b/tests/eslint.test.ts
@@ -200,4 +200,75 @@ describe("no-raw-playwright-apis", () => {
 			],
 		});
 	});
+
+	it("flags getByTestId in spec files", () => {
+		tester.run("no-raw-playwright-apis", noRawPlaywrightApisRule, {
+			valid: [],
+			invalid: [
+				{
+					code: "page.getByTestId('save-button');",
+					filename: "/tmp/example.spec.ts",
+					errors: [{ messageId: "rawPlaywrightApi" }],
+				},
+				{
+					// getByTestId is a locator-filter method (like getByRole/getByText),
+					// so it is banned regardless of the receiver object.
+					code: "someLocator.getByTestId('save-button');",
+					filename: "/tmp/example.spec.ts",
+					errors: [{ messageId: "rawPlaywrightApi" }],
+				},
+				{
+					// A template-literal arg is still a raw getByTestId call.
+					code: "page.getByTestId(`edit-person-btn-${id}`);",
+					filename: "/tmp/example.spec.ts",
+					errors: [{ messageId: "rawPlaywrightApi" }],
+				},
+			],
+		});
+	});
+
+	it("flags computed-member access to banned APIs", () => {
+		tester.run("no-raw-playwright-apis", noRawPlaywrightApisRule, {
+			valid: [],
+			invalid: [
+				{
+					// Computed string-literal access (`obj["name"]()`) previously slipped
+					// through the `!callee.computed` guard; the fix resolves the property
+					// name from a string Literal too.
+					code: "page['getByTestId']('save'); page['locator']('button'); page['getByRole']('button');",
+					filename: "/tmp/example.spec.ts",
+					errors: [
+						{ messageId: "rawPlaywrightApi" },
+						{ messageId: "rawPlaywrightApi" },
+						{ messageId: "rawPlaywrightApi" },
+					],
+				},
+				{
+					// Computed page-level APIs are reported with the page message.
+					code: "page['click']('#save');",
+					filename: "/tmp/example.spec.ts",
+					errors: [{ messageId: "rawPlaywrightPageApi" }],
+				},
+			],
+		});
+	});
+
+	it("allows computed access to non-banned APIs and dynamic keys", () => {
+		tester.run("no-raw-playwright-apis", noRawPlaywrightApisRule, {
+			valid: [
+				{
+					// A computed name that is not a banned API is fine.
+					code: "page['someCustomMethod']('x');",
+					filename: "/tmp/example.spec.ts",
+				},
+				{
+					// A dynamic (non-Literal) computed key is not resolvable to a name,
+					// so it is never reported — it could be anything at runtime.
+					code: "obj[dynamicKey]();",
+					filename: "/tmp/example.spec.ts",
+				},
+			],
+			invalid: [],
+		});
+	});
 });


### PR DESCRIPTION
## Summary

`no-raw-playwright-apis` had two gaps that let raw Playwright usage slip past it in spec files. This closes both.

### 1. `getByTestId` was not banned

It is the generator's own test-id contract — specs should reach it through a generated POM accessor, never a raw `*.getByTestId(...)` — so it belongs alongside `locator` / `getByRole` / `getByText` / `getByLabel` as a **banned locator-filter method**. Added object-agnostic (callable on `Page`, `Locator`, and `Frame`), matching the existing set's semantics.

This lets downstream consumers (e.g. immybot's `frontend/eslint-rules/no-data-testid-in-specs.js`) drop the `getByTestId`-call half of their custom rule in favor of the shared generator rule.

### 2. Computed-member access bypassed every ban

The `CallExpression` handler returned early on `callee.computed`, so the computed equivalent of any banned API slipped through:

```ts
page["getByTestId"]("save");   // bypassed — computed
page["locator"]("button");     // bypassed — computed
page["click"]("#save");        // bypassed — computed
```

Replaced the early return with `resolveMemberPropertyName`, which resolves the accessed name from both the `Identifier` form (`page.getByTestId`) and a computed string-`Literal` form (`page["getByTestId"]`). A non-Literal computed key (`obj[dynamicKey]()`) is unresolvable and left alone — it could be anything at runtime.

## Test plan

RuleTester cases added to `tests/eslint.test.ts`:

- `getByTestId` — plain `page.getByTestId('save-button')`, on a locator (`someLocator.getByTestId(...)`), and with a template-literal arg
- computed access to banned playwright APIs (`page['getByTestId']`, `page['locator']`, `page['getByRole']`) → `rawPlaywrightApi`
- computed access to a banned page API (`page['click']`) → `rawPlaywrightPageApi`
- negative: computed non-banned API (`page['someCustomMethod']`) and dynamic key (`obj[dynamicKey]()`) stay valid

```
tests/eslint.test.ts: 10 passed (10)
tsc --noEmit: clean
eslint .: clean
```

The three pre-existing DOM-environment suite failures (`base-page`, `pointer`, `broad/class-generation-base-page-ts`) are unrelated to this change — they fail identically on clean `main` on this machine (jsdom env resolution under local vitest) and are environmental, not assertion failures.

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>