### PR TITLE
feat: emit parametrized goTo(params) for routes with declared params

### DIFF
--- a/class-generation/index.ts
+++ b/class-generation/index.ts
@@ -28,7 +28,7 @@ import {
   type PomStringPattern,
 } from "../pom-patterns";
 import { buildPomLocatorDescription, stripPomActionPrefix } from "../pom-discoverability";
-import { introspectNuxtPages, parseRouterFileFromCwd } from "../router-introspection";
+import { getParamToken, introspectNuxtPages, parseRouterFileFromCwd } from "../router-introspection";
 import {
   addExportAll,
   addNamedImport,
@@ -108,8 +108,23 @@ function resolveRouterEntry(projectRoot?: string, routerEntry?: string) {
   return path.isAbsolute(routerEntry) ? routerEntry : path.resolve(root, routerEntry);
 }
 
-interface RouteMeta {
+interface RouteParamMeta {
+  name: string;
+  optional: boolean;
+}
+
+interface RouteEntry {
+  /** Vue Router route `name`, when declared. Enables runtime `router.push({ name, params })`. */
+  name: string | null;
   template: string;
+  params: RouteParamMeta[];
+}
+
+interface RouteMeta {
+  /** Shortest route template — used for the static `route` property. */
+  template: string;
+  /** Every route that renders this component (name + template + declared params). */
+  routes: RouteEntry[];
 }
 
 type CustomPomMethodSignatureMap = Map<string, PomMethodSignature>;
@@ -277,27 +292,40 @@ async function getRouteMetaByComponent(
       },
     });
 
-  const map = new Map<string, RouteMeta[]>();
+  const map = new Map<string, RouteEntry[]>();
   for (const entry of routeMetaEntries) {
     const list = map.get(entry.componentName) ?? [];
-    list.push({ template: entry.pathTemplate });
+    list.push({ name: entry.name, template: entry.pathTemplate, params: entry.params });
     map.set(entry.componentName, list);
   }
 
-  const chooseRouteMeta = (entries: RouteMeta[]): RouteMeta | null => {
+  const dedupeRoutes = (entries: RouteEntry[]): RouteEntry[] => {
+    const seen = new Set<string>();
+    const unique: RouteEntry[] = [];
+    for (const entry of entries) {
+      if (seen.has(entry.template))
+        continue;
+      seen.add(entry.template);
+      unique.push(entry);
+    }
+    return unique;
+  };
+
+  const choosePrimaryTemplate = (entries: RouteEntry[]): string | null => {
     if (!entries.length)
       return null;
     return entries
       .slice()
-      .sort((a, b) => a.template.length - b.template.length || a.template.localeCompare(b.template))[0];
+      .sort((a, b) => a.template.length - b.template.length || a.template.localeCompare(b.template))[0].template;
   };
 
   const sorted = Array.from(map.entries()).sort((a, b) => a[0].localeCompare(b[0]));
   return Object.fromEntries(
     sorted
-      .map(([componentName, entries]) => {
-        const chosen = chooseRouteMeta(entries);
-        return chosen ? [componentName, chosen] : null;
+      .map(([componentName, rawEntries]) => {
+        const routes = dedupeRoutes(rawEntries);
+        const primaryTemplate = choosePrimaryTemplate(routes);
+        return primaryTemplate ? [componentName, { template: primaryTemplate, routes }] : null;
       })
       .filter((entry): entry is [string, RouteMeta] => !!entry),
   );
@@ -317,28 +345,208 @@ function generateRouteProperty(routeMeta: RouteMeta | null): TypeScriptClassMemb
   ];
 }
 
-function generateGoToSelfMethod(componentName: string): TypeScriptClassMember[] {
+function buildParamTypeString(params: RouteParamMeta[]): string {
+  return `{ ${params.map(p => `${p.name}${p.optional ? "?" : ""}: string | number`).join("; ")} }`;
+}
+
+function chooseParamlessRoute(routes: RouteEntry[]): RouteEntry | null {
+  const paramless = routes.filter(r => r.params.length === 0);
+  if (!paramless.length)
+    return null;
+  return paramless
+    .slice()
+    .sort((a, b) => a.template.length - b.template.length || a.template.localeCompare(b.template))[0];
+}
+
+function chooseParametrizedRoute(routes: RouteEntry[]): RouteEntry | null {
+  const parametrized = routes.filter(r => r.params.length > 0);
+  if (!parametrized.length)
+    return null;
+  return parametrized
+    .slice()
+    .sort((a, b) => a.params.length - b.params.length || a.template.length - b.template.length || a.template.localeCompare(b.template))[0];
+}
+
+const GOTO_RUNTIME_LINES = [
+  "const runtimeEnv = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env;",
+  "const runtimeBaseUrl = runtimeEnv?.PLAYWRIGHT_RUNTIME_BASE_URL ?? runtimeEnv?.PLAYWRIGHT_TEST_BASE_URL ?? runtimeEnv?.VITE_PLAYWRIGHT_BASE_URL;",
+  "const resolvedUrl = runtimeBaseUrl ? new URL(targetUrl, runtimeBaseUrl).toString() : targetUrl;",
+  "await this.page.goto(resolvedUrl);",
+];
+
+/**
+ * The `window`/`globalThis` key the consumer exposes the live Vue Router instance under
+ * (dev-gated), so generated `goTo()` can drive `router.push({ name, params })` instead of
+ * reconstructing URLs from opaque path-template tokens. The consumer is responsible for
+ * installing `globalThis[ROUTER_GLOBAL_NAME] = router` in test/dev builds.
+ */
+const ROUTER_GLOBAL_NAME = "__appRouter";
+
+/**
+ * Emits the router-driven `goTo()` body for a named route. Two regimes:
+ *
+ * - **Cold page** (fresh Playwright page on `about:blank` — the SPA hasn't booted, so the
+ *   router global is `undefined`): boot the app with a cheap `page.goto("/")`, wait for the
+ *   router to install, then **full-load the resolved target URL** (`router.resolve({ name,
+ *   params }).href` + `page.goto`). A full load is unavoidable here — you cannot `push`
+ *   before the router exists — and resolving the target (rather than stopping at "/") means
+ *   the route's component mounts via a stable page load, exactly as the original
+ *   `page.goto`-based tests did. This matters because the POM runtime clicks with
+ *   `force: true` (skipping Playwright's actionability check): a SPA `push` into a freshly
+ *   mounted view can resolve before radios/inputs are interactive, so a force-click fired
+ *   the instant the push resolves can miss (the control's handler isn't attached yet). A
+ *   full load gives a fully-rendered, interactive page.
+ * - **Warm page** (the app is already mounted — any later `goTo()` in the same test): the
+ *   guard is a single cheap `evaluate` that finds the router present, so the navigation is a
+ *   pure SPA `router.push({ name, params })` — no reload — the intended fast path.
+ *
+ * `routeNameExpr` is a TS expression yielding the route name (a string literal for single
+ * routes, or `params ? "edit" : "new"` for the dual-route overload). `paramsExpr` is the
+ * params source (`"undefined"` for a paramless route, `"params"` otherwise); `nullable` is
+ * true only when that source may itself be `undefined` (the all-optional-params overload),
+ * gating the `?? {}` guard that TS2871 would otherwise flag on a required param.
+ */
+const pushBlock = (routeNameExpr: string, paramsExpr: string, nullable: boolean): string[] => {
+  const routerType = `{ ${ROUTER_GLOBAL_NAME}?: { push: (to: { name: string; params: Record<string, unknown> }) => Promise<unknown>; resolve: (to: { name: string; params: Record<string, unknown> }) => { href: string } } }`;
+  const routeParamsLine = paramsExpr === "undefined"
+    ? "const routeParams = {};"
+    : nullable
+      ? `const routeParams = Object.fromEntries(Object.entries(${paramsExpr} ?? {}).filter(([, v]) => v !== undefined));`
+      : `const routeParams = Object.fromEntries(Object.entries(${paramsExpr}).filter(([, v]) => v !== undefined));`;
+  return [
+    routeParamsLine,
+    `const isCold = await this.page.evaluate(() => typeof (globalThis as { ${ROUTER_GLOBAL_NAME}?: unknown }).${ROUTER_GLOBAL_NAME} === "undefined");`,
+    `if (isCold) {`,
+    `  await this.page.goto("/", { waitUntil: "commit" });`,
+    `  await this.page.waitForFunction(() => typeof (globalThis as { ${ROUTER_GLOBAL_NAME}?: unknown }).${ROUTER_GLOBAL_NAME} !== "undefined", { timeout: 15000 });`,
+    `  const href = await this.page.evaluate(({ name, params }) => (globalThis as ${routerType}).${ROUTER_GLOBAL_NAME}?.resolve({ name, params })?.href, { name: ${routeNameExpr}, params: routeParams });`,
+    `  if (href) { await this.page.goto(href, { waitUntil: "domcontentloaded" }); }`,
+    `} else {`,
+    `  await this.page.evaluate(async ({ name, params }) => {`,
+    `    await (globalThis as ${routerType}).${ROUTER_GLOBAL_NAME}?.push({ name, params });`,
+    `  }, { name: ${routeNameExpr}, params: routeParams });`,
+    `}`,
+  ];
+};
+
+function generateGoToMethod(componentName: string, routeMeta: RouteMeta | null): TypeScriptClassMember[] {
+  // No route metadata: emit a goTo() that fails loudly when invoked.
+  if (!routeMeta) {
+    return [
+      createClassMethod({
+        name: "goTo",
+        isAsync: true,
+        statements: [
+          `throw new Error("[pom] No router path found for component/page-object '${componentName}'.");`,
+        ],
+      }),
+    ];
+  }
+
+  const paramless = chooseParamlessRoute(routeMeta.routes);
+  const parametrized = chooseParametrizedRoute(routeMeta.routes);
+  const hasParamless = paramless !== null;
+  const hasParametrized = parametrized !== null;
+
+  // Neither a paramless nor a parametrized route (shouldn't happen — routeMeta is non-null — but guard anyway).
+  if (!hasParamless && !hasParametrized) {
+    return [
+      createClassMethod({
+        name: "goTo",
+        isAsync: true,
+        statements: [
+          `throw new Error("[pom] No router path found for component/page-object '${componentName}'.");`,
+        ],
+      }),
+    ];
+  }
+
+  // Fallback (unnamed routes, e.g. Nuxt file-based routes whose names the static walk
+  // cannot recover): reconstruct the URL from the tokenized template and `page.goto` it.
+  const paramStatements = (entry: RouteEntry): string[] => {
+    const lines: string[] = [];
+    for (const param of entry.params) {
+      const token = getParamToken(param.name);
+      if (param.optional) {
+        // An omitted optional param drops its entire path segment (including the leading "/"),
+        // so `/persons/:personId/:tabName?` with tabName omitted resolves to `/persons/123`.
+        lines.push(`targetUrl = params.${param.name} === undefined ? targetUrl.replaceAll(${JSON.stringify(`/${token}`)}, "") : targetUrl.replaceAll(${JSON.stringify(token)}, String(params.${param.name}));`);
+      }
+      else {
+        lines.push(`targetUrl = targetUrl.replaceAll(${JSON.stringify(token)}, String(params.${param.name}));`);
+      }
+    }
+    return lines;
+  };
+
+  // Preferred path: the route is named, so hand the param object straight to the runtime
+  // router. `undefined` values are stripped first — omitted optional params are simply not
+  // passed, and the router builds the URL (handling optional segments, redirects, and param
+  // coercion) itself. No opaque tokens, no string substitution. See `pushBlock` for the
+  // cold-start (full-load resolved target) vs warm (SPA `router.push`) regimes.
+  // Paramless-only: simple no-arg goTo().
+  if (hasParamless && !hasParametrized) {
+    const route = paramless!;
+    return [
+      createClassMethod({
+        name: "goTo",
+        isAsync: true,
+        statements: route.name !== null
+          ? pushBlock(JSON.stringify(route.name), "undefined", false)
+          : [`const targetUrl = ${JSON.stringify(route.template)};`, ...GOTO_RUNTIME_LINES],
+      }),
+    ];
+  }
+
+  const paramType = buildParamTypeString(parametrized!.params);
+
+  // Parametrized-only: goTo(params). When every declared param is optional, the params
+  // object itself is optional too — `goTo()` is a valid call that navigates to the route
+  // with all optional params omitted (e.g. `/preferences/:tabName?` -> `/preferences`).
+  if (hasParametrized && !hasParamless) {
+    const route = parametrized!;
+    const allOptional = route.params.every(p => p.optional);
+    return [
+      createClassMethod({
+        name: "goTo",
+        isAsync: true,
+        parameters: [{ name: "params", type: paramType, hasQuestionToken: allOptional }],
+        statements: route.name !== null
+          ? pushBlock(JSON.stringify(route.name), "params", allOptional)
+          : [`let targetUrl = ${JSON.stringify(route.template)};`, ...paramStatements(route), ...GOTO_RUNTIME_LINES],
+      }),
+    ];
+  }
+
+  // Both routes present. Use the runtime router only when both chosen routes are named;
+  // otherwise fall back to token reconstruction for consistency across the overloads.
+  const paramlessRoute = paramless!;
+  const parametrizedRoute = parametrized!;
+  const usePush = paramlessRoute.name !== null && parametrizedRoute.name !== null;
+
   return [
     createClassMethod({
       name: "goTo",
       isAsync: true,
-      statements: [
-        "await this.goToSelf();",
+      overloads: [
+        { parameters: [], returnType: "Promise<void>" },
+        { parameters: [{ name: "params", type: paramType }], returnType: "Promise<void>" },
       ],
-    }),
-    createClassMethod({
-      name: "goToSelf",
-      isAsync: true,
-      statements: [
-        `const route = ${componentName}.route;`,
-        "if (!route) {",
-        `    throw new Error("[pom] No router path found for component/page-object '${componentName}'.");`,
-        "}",
-        "const runtimeEnv = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env;",
-        "const runtimeBaseUrl = runtimeEnv?.PLAYWRIGHT_RUNTIME_BASE_URL ?? runtimeEnv?.PLAYWRIGHT_TEST_BASE_URL ?? runtimeEnv?.VITE_PLAYWRIGHT_BASE_URL;",
-        "const targetUrl = runtimeBaseUrl ? new URL(route.template, runtimeBaseUrl).toString() : route.template;",
-        "await this.page.goto(targetUrl);",
-      ],
+      parameters: [{ name: "params", type: paramType, hasQuestionToken: true }],
+      statements: usePush
+        ? pushBlock(
+            `params ? ${JSON.stringify(parametrizedRoute.name)} : ${JSON.stringify(paramlessRoute.name)}`,
+            "params",
+            true,
+          )
+        : [
+            `const template = params ? ${JSON.stringify(parametrizedRoute.template)} : ${JSON.stringify(paramlessRoute.template)};`,
+            "let targetUrl = template;",
+            `if (params) {`,
+            ...paramStatements(parametrizedRoute).map(line => `  ${line}`),
+            "}",
+            ...GOTO_RUNTIME_LINES,
+          ],
     }),
   ];
 }
@@ -1795,7 +2003,7 @@ function prepareViewObjectModelClass(
   if (isView && options.vueRouterFluentChaining) {
     const routeMeta = options.routeMetaByComponent?.[componentName] ?? null;
     members.push(...generateRouteProperty(routeMeta));
-    members.push(...generateGoToSelfMethod(className));
+    members.push(...generateGoToMethod(className, routeMeta));
   }
 
   members.push(...generateMethodsContentForDependencies(componentName, dependencies));

--- a/router-introspection.ts
+++ b/router-introspection.ts
@@ -303,6 +303,8 @@ export interface RouterIntrospectionResult {
   routePathMap: Map<string, string>;
   routeMetaEntries: Array<{
     componentName: string;
+    /** Vue Router route `name` (when declared). Used for runtime `router.push({ name, params })`. */
+    name: string | null;
     pathTemplate: string;
     params: Array<{ name: string; optional: boolean }>;
     query: string[];
@@ -431,9 +433,10 @@ type RoutePropsFunction = (route: RouteLocationNormalizedLoaded) => Record<strin
 type RoutePropsValue = boolean | Record<string, RoutePropPrimitive> | RoutePropsFunction;
 type RoutePropsContainer = RoutePropsValue | { default?: RoutePropsValue };
 
-const PARAM_TOKEN_PREFIX = "__VUE_TESTID_PARAM__";
+export const PARAM_TOKEN_PREFIX = "__VUE_TESTID_PARAM__";
 
-function getParamToken(name: string) {
+/** Builds the opaque placeholder token substituted into a route template for a named param. */
+export function getParamToken(name: string) {
   return `${PARAM_TOKEN_PREFIX}${name}__`;
 }
 
@@ -1083,6 +1086,9 @@ export async function introspectNuxtPages(
       routePathMap.set(pathTemplate, componentName);
       routeMetaEntries.push({
         componentName,
+        // Nuxt file-based routes are named by convention, but the static walk does not
+        // recover those names — leave null so callers fall back to path-template navigation.
+        name: null,
         pathTemplate,
         params,
         query: [],
@@ -1212,6 +1218,7 @@ export async function parseRouterFileFromCwd(
           if (typeof pathTemplate === "string" && pathTemplate.length) {
             routeMetaEntries.push({
               componentName,
+              name: typeof r.name === "string" && r.name.length ? r.name : null,
               pathTemplate,
               params: paramsMeta,
               query: queryKeys,

--- a/tests/class-generation-coverage.test.ts
+++ b/tests/class-generation-coverage.test.ts
@@ -592,11 +592,12 @@ describe("class-generation coverage", () => {
       const aggregatedFile = path.join(outDir, "page-object-models.g.ts");
       const content = readFile(aggregatedFile);
 
-      // Route metadata + goToSelf helpers
+      // Route metadata + goTo helpers. The named route drives the runtime router via push.
       expect(content).toContain("static readonly route");
-      expect(content).toContain("async goToSelf()");
-      expect(content).toContain("const runtimeBaseUrl = runtimeEnv?.PLAYWRIGHT_RUNTIME_BASE_URL ?? runtimeEnv?.PLAYWRIGHT_TEST_BASE_URL ?? runtimeEnv?.VITE_PLAYWRIGHT_BASE_URL;");
-      expect(content).toContain("await this.page.goto(targetUrl)");
+      expect(content).toContain("async goTo()");
+      expect(content).toContain("__appRouter?.push(");
+      expect(content).toContain('name: "users"');
+      expect(content).toContain("await this.page.evaluate(async ({ name, params })");
 
       // Trim + propagate testIdAttribute into BasePage super call.
       expect(content).toContain("super(page, { testIdAttribute: \"data-qa\" });");
@@ -612,6 +613,190 @@ describe("class-generation coverage", () => {
           vueRouterFluentChaining: true,
         }),
       ).rejects.toThrow("Router entry path is required");
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  }, 120_000);
+
+  it("emits a parametrized goTo(params) that drives the runtime router via push({ name, params })", async () => {
+    const tempRoot = makeTempRoot("vue-pom-router-parametrized-");
+
+    try {
+      const thisDir = path.dirname(fileURLToPath(import.meta.url));
+      const frontendNodeModules = path.resolve(thisDir, "..", "node_modules");
+      const tempNodeModules = path.join(tempRoot, "node_modules");
+      if (!fs.existsSync(tempNodeModules)) {
+        fs.symlinkSync(frontendNodeModules, tempNodeModules, "dir");
+      }
+
+      const basePagePath = path.join(tempRoot, "base-page.ts");
+      writeMinimalBasePage(basePagePath);
+
+      // One component per scenario:
+      //   DashboardView  -> paramless route only (/dashboard)
+      //   UsersView      -> parametrized route only (/users/:id, props declare `id`)
+      //   PersonsView    -> BOTH (/persons/new paramless, /persons/:id parametrized)
+      //   OrgMembersView -> multi-param route (/orgs/:orgId/users/:userId)
+      //   ThingsView     -> optional param route (/things/:thingId?)
+      writeFile(path.join(tempRoot, "DashboardView.vue"), "<template><div /></template>\n");
+      writeFile(path.join(tempRoot, "UsersView.vue"), "<template><div /></template>\n");
+      writeFile(path.join(tempRoot, "PersonsView.vue"), "<template><div /></template>\n");
+      writeFile(path.join(tempRoot, "OrgMembersView.vue"), "<template><div /></template>\n");
+      writeFile(path.join(tempRoot, "ThingsView.vue"), "<template><div /></template>\n");
+
+      writeFile(
+        path.join(tempRoot, "router.ts"),
+        [
+          "import { createMemoryHistory, createRouter } from 'vue-router';",
+          "import DashboardView from './DashboardView.vue';",
+          "import UsersView from './UsersView.vue';",
+          "import PersonsView from './PersonsView.vue';",
+          "import OrgMembersView from './OrgMembersView.vue';",
+          "import ThingsView from './ThingsView.vue';",
+          "",
+          "export default function makeRouter() {",
+          "  return createRouter({",
+          "    history: createMemoryHistory(),",
+          "    routes: [",
+          "      { path: '/dashboard', name: 'dashboard', component: DashboardView },",
+          "      { path: '/users/:id', name: 'users', component: UsersView, props: (route) => ({ id: route.params.id }) },",
+          "      { path: '/persons/new', name: 'persons-new', component: PersonsView },",
+          "      { path: '/persons/:id', name: 'persons-edit', component: PersonsView, props: (route) => ({ id: route.params.id }) },",
+          "      { path: '/orgs/:orgId/users/:userId', name: 'org-members', component: OrgMembersView, props: (route) => ({ orgId: route.params.orgId, userId: route.params.userId }) },",
+          "      { path: '/things/:thingId?', name: 'things', component: ThingsView, props: (route) => ({ thingId: route.params.thingId }) },",
+          "    ],",
+          "  });",
+          "}",
+          "",
+        ].join("\n"),
+      );
+
+      const mkView = (name: string, fileName: string) => [
+        name,
+        makeDeps({
+          filePath: path.join(tempRoot, fileName),
+          isView: true,
+          dataTestIdSet: new Set<IDataTestId>([{ selectorValue: createPomStringPattern(`${name}-Sample-button`, "static", []) }]),
+        }),
+      ] as const;
+
+      const componentHierarchyMap = new Map<string, IComponentDependencies>([
+        mkView("DashboardView", "DashboardView.vue"),
+        mkView("UsersView", "UsersView.vue"),
+        mkView("PersonsView", "PersonsView.vue"),
+        mkView("OrgMembersView", "OrgMembersView.vue"),
+        mkView("ThingsView", "ThingsView.vue"),
+      ]);
+      const outDir = path.join(tempRoot, "pom");
+
+      await generateFiles(componentHierarchyMap, new Map(), basePagePath, {
+        outDir,
+        projectRoot: tempRoot,
+        vueRouterFluentChaining: true,
+        routerEntry: "./router.ts",
+      });
+
+      const content = readFile(path.join(outDir, "page-object-models.g.ts"));
+
+      // Extract one class block regardless of the (alphabetical) emit order.
+      const extractClass = (name: string): string => {
+        const start = content.indexOf(`export class ${name}`);
+        expect(start, `class ${name} should be generated`).toBeGreaterThan(-1);
+        const nextClass = content.indexOf("export class ", start + 1);
+        return nextClass === -1 ? content.slice(start) : content.slice(start, nextClass);
+      };
+
+      // Shared: named routes drive the runtime router, handing it a params object (undefined
+      // values stripped) instead of reconstructing a URL. Warm pages SPA-push via
+      // `__appRouter.push`; cold pages (about:blank, router not yet installed) boot then
+      // full-load the resolved target (`__appRouter.resolve(...).href`) so the route's
+      // component mounts via a stable page load instead of a race-prone SPA push.
+      const PUSH_CALL = "__appRouter?.push(";
+      const RESOLVE_CALL = "__appRouter?.resolve(";
+      const COLD_BOOT = 'this.page.goto("/", { waitUntil: "commit" })';
+      const COLD_TARGET_LOAD = 'await this.page.goto(href, { waitUntil: "domcontentloaded" })';
+      const COLD_START_WAIT = "waitForFunction(() => typeof";
+      const IS_COLD = "const isCold =";
+
+      // --- DashboardView: paramless-only, named -> no-arg goTo() that pushes the named route. ---
+      const dashboardClass = extractClass("DashboardView");
+      expect(dashboardClass).toContain('name: "dashboard"');
+      expect(dashboardClass).toContain(PUSH_CALL);
+      // Cold-start branch: boot "/", wait for the router, resolve the target, full-load it.
+      expect(dashboardClass).toContain(IS_COLD);
+      expect(dashboardClass).toContain(COLD_BOOT);
+      expect(dashboardClass).toContain(COLD_START_WAIT);
+      expect(dashboardClass).toContain(RESOLVE_CALL);
+      expect(dashboardClass).toContain(COLD_TARGET_LOAD);
+      // A paramless route has no params object: emit an empty record literally (no Object.fromEntries).
+      expect(dashboardClass).toContain("const routeParams = {};");
+      expect(dashboardClass).not.toContain("goTo(params");
+      expect(dashboardClass).not.toContain("targetUrl");
+      expect(dashboardClass).not.toContain("replaceAll");
+
+      // --- UsersView: parametrized-only, named -> goTo(params) that pushes with the param object. ---
+      const usersClass = extractClass("UsersView");
+      expect(usersClass).toContain("async goTo(params: { id: string | number })");
+      expect(usersClass).toContain('name: "users"');
+      // Required params are never nullish, so no `?? {}` guard (avoids TS2871).
+      expect(usersClass).toContain("Object.fromEntries(Object.entries(params).filter(([, v]) => v !== undefined))");
+      expect(usersClass).toContain(PUSH_CALL);
+      expect(usersClass).toContain(RESOLVE_CALL);
+      expect(usersClass).toContain(IS_COLD);
+      // No no-arg overload signature for a parametrized-only route.
+      expect(usersClass).not.toMatch(/goTo\(\): Promise<void>/);
+      expect(usersClass).not.toContain("targetUrl");
+      expect(usersClass).not.toContain("replaceAll");
+      // route property still holds the tokenized template (informational; goTo uses push).
+      expect(usersClass).toContain('{ template: "/users/__VUE_TESTID_PARAM__id__" }');
+
+      // --- PersonsView: BOTH routes, both named -> overloaded goTo() selecting the route name by params presence. ---
+      const personsClass = extractClass("PersonsView");
+      // Overload signatures precede the implementation.
+      expect(personsClass).toContain("goTo(): Promise<void>;");
+      expect(personsClass).toContain("goTo(params: { id: string | number }): Promise<void>;");
+      // The route name is selected by params presence and inlined into the router call args
+      // (no separate `const routeName`, no URL reconstruction from tokens).
+      expect(personsClass).toContain('name: params ? "persons-edit" : "persons-new"');
+      // The both-routes overload is also guarded: cold branch resolves + full-loads the target.
+      expect(personsClass).toContain(IS_COLD);
+      expect(personsClass).toContain(COLD_BOOT);
+      expect(personsClass).toContain(COLD_START_WAIT);
+      expect(personsClass).toContain(RESOLVE_CALL);
+      expect(personsClass).toContain(COLD_TARGET_LOAD);
+      expect(personsClass).toContain("Object.fromEntries(Object.entries(params ?? {})");
+      expect(personsClass).toContain(PUSH_CALL);
+      // Implementation parameter is optional (so the no-arg overload is callable).
+      expect(personsClass).toContain("async goTo(params?: { id: string | number })");
+      expect(personsClass).not.toContain("targetUrl");
+      expect(personsClass).not.toContain("replaceAll");
+      // route property is the shortest (paramless) template.
+      expect(personsClass).toContain('{ template: "/persons/new" }');
+
+      // --- OrgMembersView: multi-param, named -> goTo(params) pushing both params. ---
+      const orgMembersClass = extractClass("OrgMembersView");
+      expect(orgMembersClass).toContain("async goTo(params: { orgId: string | number; userId: string | number })");
+      expect(orgMembersClass).toContain('name: "org-members"');
+      expect(orgMembersClass).toContain("Object.fromEntries(Object.entries(params).filter(([, v]) => v !== undefined))");
+      expect(orgMembersClass).toContain(PUSH_CALL);
+      expect(orgMembersClass).not.toContain("targetUrl");
+      expect(orgMembersClass).not.toContain("replaceAll");
+
+      // --- ThingsView: optional param, named -> goTo(params?: { thingId? }) that omits it when undefined. ---
+      const thingsClass = extractClass("ThingsView");
+      // The only param is optional, so the params object itself is optional — `goTo()` is valid
+      // and navigates with the optional segment omitted.
+      expect(thingsClass).toContain("async goTo(params?: { thingId?: string | number })");
+      expect(thingsClass).toContain('name: "things"');
+      // undefined values are stripped before handing the object to the router, so an omitted
+      // optional param is simply not passed — the router builds /things (segment omitted),
+      // never /things/undefined. Because params is optional, the `?? {}` guard is used.
+      expect(thingsClass).toContain("Object.fromEntries(Object.entries(params ?? {}).filter(([, v]) => v !== undefined))");
+      expect(thingsClass).toContain(PUSH_CALL);
+      expect(thingsClass).not.toContain("targetUrl");
+      expect(thingsClass).not.toContain("replaceAll");
+      // route property holds the tokenized template (informational; the only route).
+      expect(thingsClass).toContain('{ template: "/things/__VUE_TESTID_PARAM__thingId__" }');
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
## What

View POMs whose route declares params (via a `props` function accessing `route.params.*`) now generate a **parametrized `goTo(params)`** that drives the consumer's **live Vue Router at runtime** (`router.push({ name, params })`) — instead of the previous `goToSelf()` that emitted a broken literal tokenized template.

This is rebased onto `main` (single commit on top of `83ea948`, which includes #43/#45/#46/#47/#49). It targets `main` and merges cleanly.

### Generated shapes

| Route shape | Generated `goTo` |
|---|---|
| Paramless only (`/dashboard`) | `goTo()` no-arg |
| Parametrized only, required (`/users/:id`) | `goTo(params: { id: string \| number })` |
| Parametrized only, all-optional | `goTo(params?: { id? })` — `params` optional |
| Both (`/persons/new` + `/persons/:id`) | `goTo()` → paramless route; `goTo(params)` → parametrized route |
| Multi-param (`/orgs/:orgId/users/:userId`) | `goTo(params: { orgId; userId })` |
| Unnamed routes (no route `name`) | falls back to token substitution + `page.goto` |

### How — runtime router, two regimes

The generated `goTo()` reads `globalThis.__appRouter` (the consumer exposes its live router, dev-gated by `import.meta.env.DEV`):

- **Cold page** (fresh `about:blank`, `__appRouter` undefined): boot with `page.goto("/", { waitUntil: "commit" })`, `waitForFunction` for the router, `__appRouter.resolve({ name, params }).href`, then **full-load** that href (`page.goto(href, { waitUntil: "domcontentloaded" })`). The full-load — not a SPA push — is required because the POM runtime force-clicks (`{ force: true }`); a SPA push into a freshly mounted view can resolve before form radios are interactive, so the force-click would miss.
- **Warm page** (app already mounted): pure SPA `router.push({ name, params })`, no reload.

Route-name capture: `router-introspection.ts` routeMetaEntries now include `name: string \| null` (the Vue Router route `name`), enabling `router.push`/`resolve` by name. Token substitution is retained only as the unnamed-route fallback.

## Tests

TDD in `tests/class-generation-coverage.test.ts`: cases cover paramless / parametrized-required / all-optional / dual-route overload / multi-param, asserting the emitted signatures, the `isCold`/`resolve`/full-load cold branch, the SPA `push` warm branch, `routeParams` construction (literal `{}` for paramless, `?? {}` only for all-optional to avoid TS2871), and inlined `name: params ? "x" : "y"` for dual routes. All 373 tests pass; `npm run typecheck` + `npm run build` green (verified against current `main`).