### PR TITLE
Support query-aware generated navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you already use Playwright with `getByTestId`, the point is simple: this pack
 
 - **It is not a runtime DOM crawler.** It only knows what it can learn from Vue SFC templates and router introspection.
 - **It does not fully understand arbitrary wrapper components automatically.** There is some wrapper inference for simple local SFCs and some naming conventions, but serious design-system components still need `injection.nativeWrappers`.
-- **It does not fully fill route params for you.** Generated `goTo()` / `goToSelf()` methods use the discovered route template literally. A route like `/users/:id` still needs a real `/users/123` when you actually navigate.
+- **It cannot infer query-value types from arbitrary route-props code.** Generated `goTo()` accepts discovered query keys as optional `string | number` values; callers still choose and supply the values appropriate for their application.
 - **It does not auto-attach every file in `pom/custom`.** Custom helpers are imported, but they only affect generated classes when you explicitly configure attachments, or when they match the built-in `Toggle` / `Checkbox` widget conventions.
 - **It does not make override classes globally replace generated classes.** `pom/overrides` only changes generated fixture instantiation. Direct imports from the generated barrel still give you the generated class unless you import your override yourself.
 - **The C# emitter is not feature-parity with the TypeScript emitter.** It emits locator/action classes, but not Playwright fixtures, not helper attachments, and not the same route helper surface.
@@ -407,26 +407,45 @@ What is not fully supported:
 
 - arbitrary computed `:to` expressions
 - parameter-aware `goToSelf()` URL filling
-- exposing rich route-param metadata on the generated POM surface
+- inferring query-value types from arbitrary route-props transformations
 
 ### 2) View-level `route`, `goTo()`, and `goToSelf()`
 
 When `generation.router` is enabled, each view POM gets:
 
 - `static readonly route: { template: string } | null`
-- `async goTo()`
+- a typed `async goTo(...)` whose flat input includes discovered path params and optional query keys
 - `async goToSelf()`
+
+For a route such as:
+
+```ts
+{
+  path: "/users/:userId",
+  name: "user-details",
+  component: UserDetailsPage,
+  props: route => ({
+    userId: route.params.userId,
+    tab: route.query.tab,
+  }),
+}
+```
+
+the generated method is shaped like this:
+
+```ts
+goTo(params: { userId: string | number; tab?: string | number }): Promise<void>
+```
+
+`goTo({ userId: 42, tab: "activity" })` partitions the flat input into Vue Router's
+`params` and `query` records. On a cold page it resolves and fully loads the named route;
+on a warm page it uses `router.push`.
 
 Important caveats:
 
 - `goToSelf()` calls `page.goto(...)`, resolving the route template against `PLAYWRIGHT_RUNTIME_BASE_URL`, `PLAYWRIGHT_TEST_BASE_URL`, or `VITE_PLAYWRIGHT_BASE_URL` when those runtime env vars are present
-- a dynamic route template like `/users/:id` stays `/users/:id`
+- unlike `goTo()`, a dynamic `goToSelf()` template like `/users/:id` stays `/users/:id`
 - if a component is matched by multiple routes, the generator currently picks one route template (the shortest one)
-
-So the safe rule is:
-
-- use generated `goTo()` for simple/static routes
-- for dynamic routes, navigate with a real URL yourself or wrap that behavior in your override/custom code
 
 ### Why `moduleShims` exists
 
@@ -1266,7 +1285,7 @@ If you are evaluating this package critically, the most accurate short version i
 - it is strongest when your team already wants `getByTestId`-style Playwright tests
 - it is strongest in TypeScript-first Playwright projects
 - it is strongest when your Vue component library is either native-heavy or can be described with `nativeWrappers`
-- it is useful with router-aware pages, but you should treat dynamic-route `goTo()` support as partial and explicit
+- it is useful with router-aware pages, including typed path params and discovered query keys
 - it becomes much more maintainable when you pair it with the ESLint cleanup rule and a small `pom/custom` folder for the genuinely hard widgets
 
 If that matches your codebase, the package removes a surprising amount of repetitive test maintenance. If it does not, the caveats above are the important ones to believe.

--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ Important caveats:
 - `goToSelf()` calls `page.goto(...)`, resolving the route template against `PLAYWRIGHT_RUNTIME_BASE_URL`, `PLAYWRIGHT_TEST_BASE_URL`, or `VITE_PLAYWRIGHT_BASE_URL` when those runtime env vars are present
 - unlike `goTo()`, a dynamic `goToSelf()` template like `/users/:id` stays `/users/:id`
 - if a component is matched by multiple routes, the generator currently picks one route template (the shortest one)
+- when a component has both a paramless route and a route whose path params are all optional, pass at least one path-param key (it may be `undefined`) to select the parametrized route; a query-only object selects the paramless route
 
 ### Why `moduleShims` exists
 

--- a/class-generation/index.ts
+++ b/class-generation/index.ts
@@ -28,8 +28,7 @@ import {
   type PomStringPattern,
 } from "../pom-patterns";
 import { buildPomLocatorDescription, stripPomActionPrefix } from "../pom-discoverability";
-import { getParamToken, introspectNuxtPages, parseRouterFileFromCwd } from "../router-introspection";
-import { POM_ROUTER_GLOBAL_NAME } from "../router-bridge";
+import { introspectNuxtPages, parseRouterFileFromCwd } from "../router-introspection";
 import {
   addExportAll,
   addNamedImport,
@@ -62,6 +61,10 @@ import {
 // Intentionally imported so tooling understands this exported helper is part of the
 // generated POM public surface (it is consumed by generated Playwright fixtures).
 import { setPlaywrightAnimationOptions } from "./pointer";
+import {
+  createRouterNavigationWriter,
+  createUrlNavigationWriter,
+} from "../route-navigation-codegen";
 
 void setPlaywrightAnimationOptions;
 
@@ -410,106 +413,12 @@ function chooseParametrizedRoute(routes: RouteEntry[]): RouteEntry | null {
     .sort((a, b) => a.params.length - b.params.length || a.template.length - b.template.length || a.template.localeCompare(b.template))[0];
 }
 
-const GOTO_RUNTIME_LINES = [
-  "const runtimeEnv = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env;",
-  "const runtimeBaseUrl = runtimeEnv?.PLAYWRIGHT_RUNTIME_BASE_URL ?? runtimeEnv?.PLAYWRIGHT_TEST_BASE_URL ?? runtimeEnv?.VITE_PLAYWRIGHT_BASE_URL;",
-  "const resolvedUrl = runtimeBaseUrl ? new URL(targetUrl, runtimeBaseUrl).toString() : targetUrl;",
-  "await this.page.goto(resolvedUrl);",
-];
-
-/**
- * The generator-owned `window`/`globalThis` key used by `exposeRouterForPomNavigation`,
- * so generated `goTo()` can drive `router.push({ name, params, query })` instead of reconstructing
- * URLs from opaque path-template tokens.
- */
-const ROUTER_GLOBAL_NAME = POM_ROUTER_GLOBAL_NAME;
-
-/**
- * Emits the router-driven `goTo()` body for a named route. Two regimes:
- *
- * - **Cold page** (fresh Playwright page on `about:blank` — the SPA hasn't booted, so the
- *   router global is `undefined`): boot the app with a cheap `page.goto("/")`, wait for the
- *   router to install, then **full-load the resolved target URL** (`router.resolve({ name,
- *   params, query }).href` + `page.goto`). A full load is unavoidable here — you cannot `push`
- *   before the router exists — and resolving the target (rather than stopping at "/") means
- *   the route's component mounts via a stable page load, exactly as the original
- *   `page.goto`-based tests did. This matters because the POM runtime clicks with
- *   `force: true` (skipping Playwright's actionability check): a SPA `push` into a freshly
- *   mounted view can resolve before radios/inputs are interactive, so a force-click fired
- *   the instant the push resolves can miss (the control's handler isn't attached yet). A
- *   full load gives a fully-rendered, interactive page.
- * - **Warm page** (the app is already mounted — any later `goTo()` in the same test): the
- *   guard is a single cheap `evaluate` that finds the router present, so the navigation is a
- *   pure SPA `router.push({ name, params, query })` — no reload — the intended fast path.
- *
- * `routeNameExpr` is a TS expression yielding the route name. `paramsExpr` is the generated
- * method's flat navigation input (`"undefined"` when the route accepts no values); path and
- * query key lists partition that input before handing it to Vue Router. `nullable` records
- * whether the input itself may be omitted.
- */
-const navigationRecordLine = (
-  variableName: "routeParams" | "routeQuery",
-  paramsExpr: string,
-  names: string[],
-  nullable: boolean,
-): string => {
-  if (!names.length || paramsExpr === "undefined") {
-    return `const ${variableName} = {};`;
+function requireRouteName(route: RouteEntry): string {
+  if (route.name === null) {
+    throw new VuePomGeneratorError(`Named navigation requires a route name for template "${route.template}".`);
   }
-  const entries = names.map((name) => {
-    const value = nullable ? `${paramsExpr}?.[${JSON.stringify(name)}]` : `${paramsExpr}[${JSON.stringify(name)}]`;
-    return `[${JSON.stringify(name)}, ${value}]`;
-  });
-  return `const ${variableName} = Object.fromEntries([${entries.join(", ")}].filter(([, value]) => value !== undefined));`;
-};
-
-const pushBlock = (
-  routeNameExpr: string,
-  paramsExpr: string,
-  nullable: boolean,
-  routeParamNames: string[],
-  routeQueryNames: string[],
-): string[] => {
-  if (!routeQueryNames.length) {
-    const routerType = `{ ${ROUTER_GLOBAL_NAME}?: { push: (to: { name: string; params: Record<string, unknown> }) => Promise<unknown>; resolve: (to: { name: string; params: Record<string, unknown> }) => { href: string } } }`;
-    const routeParamsLine = paramsExpr === "undefined"
-      ? "const routeParams = {};"
-      : nullable
-        ? `const routeParams = Object.fromEntries(Object.entries(${paramsExpr} ?? {}).filter(([, v]) => v !== undefined));`
-        : `const routeParams = Object.fromEntries(Object.entries(${paramsExpr}).filter(([, v]) => v !== undefined));`;
-    return [
-      routeParamsLine,
-      `const isCold = await this.page.evaluate(() => typeof (globalThis as { ${ROUTER_GLOBAL_NAME}?: unknown }).${ROUTER_GLOBAL_NAME} === "undefined");`,
-      `if (isCold) {`,
-      `  await this.page.goto("/", { waitUntil: "commit" });`,
-      `  await this.page.waitForFunction(() => typeof (globalThis as { ${ROUTER_GLOBAL_NAME}?: unknown }).${ROUTER_GLOBAL_NAME} !== "undefined", { timeout: 15000 });`,
-      `  const href = await this.page.evaluate(({ name, params }) => (globalThis as ${routerType}).${ROUTER_GLOBAL_NAME}?.resolve({ name, params })?.href, { name: ${routeNameExpr}, params: routeParams });`,
-      `  if (href) { await this.page.goto(href, { waitUntil: "domcontentloaded" }); }`,
-      `} else {`,
-      `  await this.page.evaluate(async ({ name, params }) => {`,
-      `    await (globalThis as ${routerType}).${ROUTER_GLOBAL_NAME}?.push({ name, params });`,
-      `  }, { name: ${routeNameExpr}, params: routeParams });`,
-      `}`,
-    ];
-  }
-
-  const routerType = `{ ${ROUTER_GLOBAL_NAME}?: { push: (to: { name: string; params: Record<string, unknown>; query: Record<string, unknown> }) => Promise<unknown>; resolve: (to: { name: string; params: Record<string, unknown>; query: Record<string, unknown> }) => { href: string } } }`;
-  return [
-    navigationRecordLine("routeParams", paramsExpr, routeParamNames, nullable),
-    navigationRecordLine("routeQuery", paramsExpr, routeQueryNames, nullable),
-    `const isCold = await this.page.evaluate(() => typeof (globalThis as { ${ROUTER_GLOBAL_NAME}?: unknown }).${ROUTER_GLOBAL_NAME} === "undefined");`,
-    `if (isCold) {`,
-    `  await this.page.goto("/", { waitUntil: "commit" });`,
-    `  await this.page.waitForFunction(() => typeof (globalThis as { ${ROUTER_GLOBAL_NAME}?: unknown }).${ROUTER_GLOBAL_NAME} !== "undefined", { timeout: 15000 });`,
-    `  const href = await this.page.evaluate(({ name, params, query }) => (globalThis as ${routerType}).${ROUTER_GLOBAL_NAME}?.resolve({ name, params, query })?.href, { name: ${routeNameExpr}, params: routeParams, query: routeQuery });`,
-    `  if (href) { await this.page.goto(href, { waitUntil: "domcontentloaded" }); }`,
-    `} else {`,
-    `  await this.page.evaluate(async ({ name, params, query }) => {`,
-    `    await (globalThis as ${routerType}).${ROUTER_GLOBAL_NAME}?.push({ name, params, query });`,
-    `  }, { name: ${routeNameExpr}, params: routeParams, query: routeQuery });`,
-    `}`,
-  ];
-};
+  return route.name;
+}
 
 function generateGoToMethod(componentName: string, routeMeta: RouteMeta | null): TypeScriptClassMember[] {
   // No route metadata: emit a goTo() that fails loudly when invoked.
@@ -543,42 +452,10 @@ function generateGoToMethod(componentName: string, routeMeta: RouteMeta | null):
     ];
   }
 
-  // Fallback (unnamed routes, e.g. Nuxt file-based routes whose names the static walk
-  // cannot recover): reconstruct the URL from the tokenized template and `page.goto` it.
-  const paramStatements = (entry: RouteEntry): string[] => {
-    const lines: string[] = [];
-    for (const param of entry.params) {
-      const token = getParamToken(param.name);
-      const value = `params[${JSON.stringify(param.name)}]`;
-      if (param.optional) {
-        // An omitted optional param drops its entire path segment (including the leading "/"),
-        // so `/persons/:personId/:tabName?` with tabName omitted resolves to `/persons/123`.
-        lines.push(`targetUrl = ${value} === undefined ? targetUrl.replaceAll(${JSON.stringify(`/${token}`)}, "") : targetUrl.replaceAll(${JSON.stringify(token)}, String(${value}));`);
-      }
-      else {
-        lines.push(`targetUrl = targetUrl.replaceAll(${JSON.stringify(token)}, String(${value}));`);
-      }
-    }
-    return lines;
-  };
-
-  const queryStatements = (queryNames: string[], nullable: boolean): string[] => {
-    if (!queryNames.length)
-      return [];
-    const lines = ["const routeQuery = new URLSearchParams();"];
-    for (const query of queryNames) {
-      const value = nullable ? `params?.[${JSON.stringify(query)}]` : `params[${JSON.stringify(query)}]`;
-      lines.push(`if (${value} !== undefined) { routeQuery.set(${JSON.stringify(query)}, String(${value})); }`);
-    }
-    lines.push("const routeQueryString = routeQuery.toString();");
-    lines.push('if (routeQueryString) { targetUrl += `?${routeQueryString}`; }');
-    return lines;
-  };
-
   // Preferred path: the route is named, so hand the param object straight to the runtime
   // router. `undefined` values are stripped first — omitted optional params are simply not
   // passed, and the router builds the URL (handling optional segments, redirects, and param
-  // coercion) itself. No opaque tokens, no string substitution. See `pushBlock` for the
+  // coercion) itself. No opaque tokens, no string substitution. The centralized router writer owns the
   // cold-start (full-load resolved target) vs warm (SPA `router.push`) regimes.
   // Paramless-only: query keys, when present, are optional navigation arguments.
   if (hasParamless && !hasParametrized) {
@@ -591,12 +468,18 @@ function generateGoToMethod(componentName: string, routeMeta: RouteMeta | null):
         isAsync: true,
         parameters: hasQuery ? [{ name: "params", type: paramType, hasQuestionToken: true }] : [],
         statements: route.name !== null
-          ? pushBlock(JSON.stringify(route.name), hasQuery ? "params" : "undefined", hasQuery, [], route.query)
-          : [
-              `let targetUrl = ${JSON.stringify(route.template)};`,
-              ...queryStatements(route.query, true),
-              ...GOTO_RUNTIME_LINES,
-            ],
+          ? createRouterNavigationWriter({
+              routeName: { kind: "single", target: route.name },
+              input: hasQuery ? { identifier: "params", optional: true } : undefined,
+              pathParamNames: [],
+              queryNames: route.query,
+            })
+          : createUrlNavigationWriter({
+              routeTemplate: { kind: "single", target: route.template },
+              input: hasQuery ? { identifier: "params", optional: true } : undefined,
+              pathParams: [],
+              queryNames: route.query,
+            }),
       }),
     ];
   }
@@ -615,19 +498,18 @@ function generateGoToMethod(componentName: string, routeMeta: RouteMeta | null):
         isAsync: true,
         parameters: [{ name: "params", type: paramType, hasQuestionToken: allOptional }],
         statements: route.name !== null
-          ? pushBlock(
-              JSON.stringify(route.name),
-              "params",
-              allOptional,
-              route.params.map(param => param.name),
-              route.query,
-            )
-          : [
-              `let targetUrl = ${JSON.stringify(route.template)};`,
-              ...paramStatements(route),
-              ...queryStatements(route.query, allOptional),
-              ...GOTO_RUNTIME_LINES,
-            ],
+          ? createRouterNavigationWriter({
+              routeName: { kind: "single", target: route.name },
+              input: { identifier: "params", optional: allOptional },
+              pathParamNames: route.params.map(param => param.name),
+              queryNames: route.query,
+            })
+          : createUrlNavigationWriter({
+              routeTemplate: { kind: "single", target: route.template },
+              input: { identifier: "params", optional: allOptional },
+              pathParams: route.params,
+              queryNames: route.query,
+            }),
       }),
     ];
   }
@@ -644,8 +526,6 @@ function generateGoToMethod(componentName: string, routeMeta: RouteMeta | null):
   const implementationType = hasQuery
     ? buildImplementationNavigationTypeString([paramlessRoute, parametrizedRoute])
     : paramType;
-  const routeSelector = `const useParametrizedRoute = params !== undefined && [${parametrizedRoute.params.map(param => JSON.stringify(param.name)).join(", ")}].some(key => Object.prototype.hasOwnProperty.call(params, key));`;
-
   return [
     createClassMethod({
       name: "goTo",
@@ -661,43 +541,28 @@ function generateGoToMethod(componentName: string, routeMeta: RouteMeta | null):
       ],
       parameters: [{ name: "params", type: implementationType, hasQuestionToken: true }],
       statements: usePush
-        ? hasQuery
-          ? [
-              routeSelector,
-              ...pushBlock(
-                `useParametrizedRoute ? ${JSON.stringify(parametrizedRoute.name)} : ${JSON.stringify(paramlessRoute.name)}`,
-                "params",
-                true,
-                parametrizedRoute.params.map(param => param.name),
-                queryNames,
-              ),
-            ]
-          : pushBlock(
-              `params ? ${JSON.stringify(parametrizedRoute.name)} : ${JSON.stringify(paramlessRoute.name)}`,
-              "params",
-              true,
-              parametrizedRoute.params.map(param => param.name),
-              [],
-            )
-        : hasQuery
-          ? [
-              routeSelector,
-              `const template = useParametrizedRoute ? ${JSON.stringify(parametrizedRoute.template)} : ${JSON.stringify(paramlessRoute.template)};`,
-              "let targetUrl = template;",
-              `if (params && useParametrizedRoute) {`,
-              ...paramStatements(parametrizedRoute).map(line => `  ${line}`),
-              "}",
-              ...queryStatements(queryNames, true),
-              ...GOTO_RUNTIME_LINES,
-            ]
-          : [
-              `const template = params ? ${JSON.stringify(parametrizedRoute.template)} : ${JSON.stringify(paramlessRoute.template)};`,
-              "let targetUrl = template;",
-              `if (params) {`,
-              ...paramStatements(parametrizedRoute).map(line => `  ${line}`),
-              "}",
-              ...GOTO_RUNTIME_LINES,
-            ],
+        ? createRouterNavigationWriter({
+            routeName: {
+              kind: "dual",
+              parametrizedTarget: requireRouteName(parametrizedRoute),
+              paramlessTarget: requireRouteName(paramlessRoute),
+              selectBy: hasQuery ? "path-param-presence" : "input-presence",
+            },
+            input: { identifier: "params", optional: true },
+            pathParamNames: parametrizedRoute.params.map(param => param.name),
+            queryNames: hasQuery ? queryNames : [],
+          })
+        : createUrlNavigationWriter({
+            routeTemplate: {
+              kind: "dual",
+              parametrizedTarget: parametrizedRoute.template,
+              paramlessTarget: paramlessRoute.template,
+              selectBy: hasQuery ? "path-param-presence" : "input-presence",
+            },
+            input: { identifier: "params", optional: true },
+            pathParams: parametrizedRoute.params,
+            queryNames: hasQuery ? queryNames : [],
+          }),
     }),
   ];
 }

--- a/class-generation/index.ts
+++ b/class-generation/index.ts
@@ -118,6 +118,7 @@ interface RouteEntry {
   name: string | null;
   template: string;
   params: RouteParamMeta[];
+  query: string[];
 }
 
 interface RouteMeta {
@@ -295,7 +296,7 @@ async function getRouteMetaByComponent(
   const map = new Map<string, RouteEntry[]>();
   for (const entry of routeMetaEntries) {
     const list = map.get(entry.componentName) ?? [];
-    list.push({ name: entry.name, template: entry.pathTemplate, params: entry.params });
+    list.push({ name: entry.name, template: entry.pathTemplate, params: entry.params, query: entry.query });
     map.set(entry.componentName, list);
   }
 
@@ -345,8 +346,32 @@ function generateRouteProperty(routeMeta: RouteMeta | null): TypeScriptClassMemb
   ];
 }
 
-function buildParamTypeString(params: RouteParamMeta[]): string {
-  return `{ ${params.map(p => `${p.name}${p.optional ? "?" : ""}: string | number`).join("; ")} }`;
+function formatNavigationFieldName(name: string): string {
+  return /^[$a-z_][$\w]*$/i.test(name) ? name : JSON.stringify(name);
+}
+
+function buildNavigationTypeString(route: RouteEntry): string {
+  const pathFields = route.params.map(param => `${formatNavigationFieldName(param.name)}${param.optional ? "?" : ""}: string | number`);
+  const pathNames = new Set(route.params.map(param => param.name));
+  const queryFields = route.query
+    .filter(query => !pathNames.has(query))
+    .map(query => `${formatNavigationFieldName(query)}?: string | number`);
+  return `{ ${[...pathFields, ...queryFields].join("; ")} }`;
+}
+
+function buildImplementationNavigationTypeString(routes: RouteEntry[]): string {
+  const fields = new Map<string, boolean>();
+  for (const route of routes) {
+    for (const param of route.params) {
+      fields.set(param.name, true);
+    }
+    for (const query of route.query) {
+      if (!fields.has(query)) {
+        fields.set(query, true);
+      }
+    }
+  }
+  return `{ ${Array.from(fields.keys()).map(name => `${formatNavigationFieldName(name)}?: string | number`).join("; ")} }`;
 }
 
 function chooseParamlessRoute(routes: RouteEntry[]): RouteEntry | null {
@@ -376,7 +401,7 @@ const GOTO_RUNTIME_LINES = [
 
 /**
  * The generator-owned `window`/`globalThis` key used by `exposeRouterForPomNavigation`,
- * so generated `goTo()` can drive `router.push({ name, params })` instead of reconstructing
+ * so generated `goTo()` can drive `router.push({ name, params, query })` instead of reconstructing
  * URLs from opaque path-template tokens.
  */
 const ROUTER_GLOBAL_NAME = POM_ROUTER_GLOBAL_NAME;
@@ -387,7 +412,7 @@ const ROUTER_GLOBAL_NAME = POM_ROUTER_GLOBAL_NAME;
  * - **Cold page** (fresh Playwright page on `about:blank` — the SPA hasn't booted, so the
  *   router global is `undefined`): boot the app with a cheap `page.goto("/")`, wait for the
  *   router to install, then **full-load the resolved target URL** (`router.resolve({ name,
- *   params }).href` + `page.goto`). A full load is unavoidable here — you cannot `push`
+ *   params, query }).href` + `page.goto`). A full load is unavoidable here — you cannot `push`
  *   before the router exists — and resolving the target (rather than stopping at "/") means
  *   the route's component mounts via a stable page load, exactly as the original
  *   `page.goto`-based tests did. This matters because the POM runtime clicks with
@@ -397,33 +422,73 @@ const ROUTER_GLOBAL_NAME = POM_ROUTER_GLOBAL_NAME;
  *   full load gives a fully-rendered, interactive page.
  * - **Warm page** (the app is already mounted — any later `goTo()` in the same test): the
  *   guard is a single cheap `evaluate` that finds the router present, so the navigation is a
- *   pure SPA `router.push({ name, params })` — no reload — the intended fast path.
+ *   pure SPA `router.push({ name, params, query })` — no reload — the intended fast path.
  *
- * `routeNameExpr` is a TS expression yielding the route name (a string literal for single
- * routes, or `params ? "edit" : "new"` for the dual-route overload). `paramsExpr` is the
- * params source (`"undefined"` for a paramless route, `"params"` otherwise); `nullable` is
- * true only when that source may itself be `undefined` (the all-optional-params overload),
- * gating the `?? {}` guard that TS2871 would otherwise flag on a required param.
+ * `routeNameExpr` is a TS expression yielding the route name. `paramsExpr` is the generated
+ * method's flat navigation input (`"undefined"` when the route accepts no values); path and
+ * query key lists partition that input before handing it to Vue Router. `nullable` records
+ * whether the input itself may be omitted.
  */
-const pushBlock = (routeNameExpr: string, paramsExpr: string, nullable: boolean): string[] => {
-  const routerType = `{ ${ROUTER_GLOBAL_NAME}?: { push: (to: { name: string; params: Record<string, unknown> }) => Promise<unknown>; resolve: (to: { name: string; params: Record<string, unknown> }) => { href: string } } }`;
-  const routeParamsLine = paramsExpr === "undefined"
-    ? "const routeParams = {};"
-    : nullable
-      ? `const routeParams = Object.fromEntries(Object.entries(${paramsExpr} ?? {}).filter(([, v]) => v !== undefined));`
-      : `const routeParams = Object.fromEntries(Object.entries(${paramsExpr}).filter(([, v]) => v !== undefined));`;
+const navigationRecordLine = (
+  variableName: "routeParams" | "routeQuery",
+  paramsExpr: string,
+  names: string[],
+  nullable: boolean,
+): string => {
+  if (!names.length || paramsExpr === "undefined") {
+    return `const ${variableName} = {};`;
+  }
+  const entries = names.map((name) => {
+    const value = nullable ? `${paramsExpr}?.[${JSON.stringify(name)}]` : `${paramsExpr}[${JSON.stringify(name)}]`;
+    return `[${JSON.stringify(name)}, ${value}]`;
+  });
+  return `const ${variableName} = Object.fromEntries([${entries.join(", ")}].filter(([, value]) => value !== undefined));`;
+};
+
+const pushBlock = (
+  routeNameExpr: string,
+  paramsExpr: string,
+  nullable: boolean,
+  routeParamNames: string[],
+  routeQueryNames: string[],
+): string[] => {
+  if (!routeQueryNames.length) {
+    const routerType = `{ ${ROUTER_GLOBAL_NAME}?: { push: (to: { name: string; params: Record<string, unknown> }) => Promise<unknown>; resolve: (to: { name: string; params: Record<string, unknown> }) => { href: string } } }`;
+    const routeParamsLine = paramsExpr === "undefined"
+      ? "const routeParams = {};"
+      : nullable
+        ? `const routeParams = Object.fromEntries(Object.entries(${paramsExpr} ?? {}).filter(([, v]) => v !== undefined));`
+        : `const routeParams = Object.fromEntries(Object.entries(${paramsExpr}).filter(([, v]) => v !== undefined));`;
+    return [
+      routeParamsLine,
+      `const isCold = await this.page.evaluate(() => typeof (globalThis as { ${ROUTER_GLOBAL_NAME}?: unknown }).${ROUTER_GLOBAL_NAME} === "undefined");`,
+      `if (isCold) {`,
+      `  await this.page.goto("/", { waitUntil: "commit" });`,
+      `  await this.page.waitForFunction(() => typeof (globalThis as { ${ROUTER_GLOBAL_NAME}?: unknown }).${ROUTER_GLOBAL_NAME} !== "undefined", { timeout: 15000 });`,
+      `  const href = await this.page.evaluate(({ name, params }) => (globalThis as ${routerType}).${ROUTER_GLOBAL_NAME}?.resolve({ name, params })?.href, { name: ${routeNameExpr}, params: routeParams });`,
+      `  if (href) { await this.page.goto(href, { waitUntil: "domcontentloaded" }); }`,
+      `} else {`,
+      `  await this.page.evaluate(async ({ name, params }) => {`,
+      `    await (globalThis as ${routerType}).${ROUTER_GLOBAL_NAME}?.push({ name, params });`,
+      `  }, { name: ${routeNameExpr}, params: routeParams });`,
+      `}`,
+    ];
+  }
+
+  const routerType = `{ ${ROUTER_GLOBAL_NAME}?: { push: (to: { name: string; params: Record<string, unknown>; query: Record<string, unknown> }) => Promise<unknown>; resolve: (to: { name: string; params: Record<string, unknown>; query: Record<string, unknown> }) => { href: string } } }`;
   return [
-    routeParamsLine,
+    navigationRecordLine("routeParams", paramsExpr, routeParamNames, nullable),
+    navigationRecordLine("routeQuery", paramsExpr, routeQueryNames, nullable),
     `const isCold = await this.page.evaluate(() => typeof (globalThis as { ${ROUTER_GLOBAL_NAME}?: unknown }).${ROUTER_GLOBAL_NAME} === "undefined");`,
     `if (isCold) {`,
     `  await this.page.goto("/", { waitUntil: "commit" });`,
     `  await this.page.waitForFunction(() => typeof (globalThis as { ${ROUTER_GLOBAL_NAME}?: unknown }).${ROUTER_GLOBAL_NAME} !== "undefined", { timeout: 15000 });`,
-    `  const href = await this.page.evaluate(({ name, params }) => (globalThis as ${routerType}).${ROUTER_GLOBAL_NAME}?.resolve({ name, params })?.href, { name: ${routeNameExpr}, params: routeParams });`,
+    `  const href = await this.page.evaluate(({ name, params, query }) => (globalThis as ${routerType}).${ROUTER_GLOBAL_NAME}?.resolve({ name, params, query })?.href, { name: ${routeNameExpr}, params: routeParams, query: routeQuery });`,
     `  if (href) { await this.page.goto(href, { waitUntil: "domcontentloaded" }); }`,
     `} else {`,
-    `  await this.page.evaluate(async ({ name, params }) => {`,
-    `    await (globalThis as ${routerType}).${ROUTER_GLOBAL_NAME}?.push({ name, params });`,
-    `  }, { name: ${routeNameExpr}, params: routeParams });`,
+    `  await this.page.evaluate(async ({ name, params, query }) => {`,
+    `    await (globalThis as ${routerType}).${ROUTER_GLOBAL_NAME}?.push({ name, params, query });`,
+    `  }, { name: ${routeNameExpr}, params: routeParams, query: routeQuery });`,
     `}`,
   ];
 };
@@ -466,15 +531,29 @@ function generateGoToMethod(componentName: string, routeMeta: RouteMeta | null):
     const lines: string[] = [];
     for (const param of entry.params) {
       const token = getParamToken(param.name);
+      const value = `params[${JSON.stringify(param.name)}]`;
       if (param.optional) {
         // An omitted optional param drops its entire path segment (including the leading "/"),
         // so `/persons/:personId/:tabName?` with tabName omitted resolves to `/persons/123`.
-        lines.push(`targetUrl = params.${param.name} === undefined ? targetUrl.replaceAll(${JSON.stringify(`/${token}`)}, "") : targetUrl.replaceAll(${JSON.stringify(token)}, String(params.${param.name}));`);
+        lines.push(`targetUrl = ${value} === undefined ? targetUrl.replaceAll(${JSON.stringify(`/${token}`)}, "") : targetUrl.replaceAll(${JSON.stringify(token)}, String(${value}));`);
       }
       else {
-        lines.push(`targetUrl = targetUrl.replaceAll(${JSON.stringify(token)}, String(params.${param.name}));`);
+        lines.push(`targetUrl = targetUrl.replaceAll(${JSON.stringify(token)}, String(${value}));`);
       }
     }
+    return lines;
+  };
+
+  const queryStatements = (queryNames: string[], nullable: boolean): string[] => {
+    if (!queryNames.length)
+      return [];
+    const lines = ["const routeQuery = new URLSearchParams();"];
+    for (const query of queryNames) {
+      const value = nullable ? `params?.[${JSON.stringify(query)}]` : `params[${JSON.stringify(query)}]`;
+      lines.push(`if (${value} !== undefined) { routeQuery.set(${JSON.stringify(query)}, String(${value})); }`);
+    }
+    lines.push("const routeQueryString = routeQuery.toString();");
+    lines.push('if (routeQueryString) { targetUrl += `?${routeQueryString}`; }');
     return lines;
   };
 
@@ -483,21 +562,28 @@ function generateGoToMethod(componentName: string, routeMeta: RouteMeta | null):
   // passed, and the router builds the URL (handling optional segments, redirects, and param
   // coercion) itself. No opaque tokens, no string substitution. See `pushBlock` for the
   // cold-start (full-load resolved target) vs warm (SPA `router.push`) regimes.
-  // Paramless-only: simple no-arg goTo().
+  // Paramless-only: query keys, when present, are optional navigation arguments.
   if (hasParamless && !hasParametrized) {
     const route = paramless!;
+    const hasQuery = route.query.length > 0;
+    const paramType = buildNavigationTypeString(route);
     return [
       createClassMethod({
         name: "goTo",
         isAsync: true,
+        parameters: hasQuery ? [{ name: "params", type: paramType, hasQuestionToken: true }] : [],
         statements: route.name !== null
-          ? pushBlock(JSON.stringify(route.name), "undefined", false)
-          : [`const targetUrl = ${JSON.stringify(route.template)};`, ...GOTO_RUNTIME_LINES],
+          ? pushBlock(JSON.stringify(route.name), hasQuery ? "params" : "undefined", hasQuery, [], route.query)
+          : [
+              `let targetUrl = ${JSON.stringify(route.template)};`,
+              ...queryStatements(route.query, true),
+              ...GOTO_RUNTIME_LINES,
+            ],
       }),
     ];
   }
 
-  const paramType = buildParamTypeString(parametrized!.params);
+  const paramType = buildNavigationTypeString(parametrized!);
 
   // Parametrized-only: goTo(params). When every declared param is optional, the params
   // object itself is optional too — `goTo()` is a valid call that navigates to the route
@@ -511,8 +597,19 @@ function generateGoToMethod(componentName: string, routeMeta: RouteMeta | null):
         isAsync: true,
         parameters: [{ name: "params", type: paramType, hasQuestionToken: allOptional }],
         statements: route.name !== null
-          ? pushBlock(JSON.stringify(route.name), "params", allOptional)
-          : [`let targetUrl = ${JSON.stringify(route.template)};`, ...paramStatements(route), ...GOTO_RUNTIME_LINES],
+          ? pushBlock(
+              JSON.stringify(route.name),
+              "params",
+              allOptional,
+              route.params.map(param => param.name),
+              route.query,
+            )
+          : [
+              `let targetUrl = ${JSON.stringify(route.template)};`,
+              ...paramStatements(route),
+              ...queryStatements(route.query, allOptional),
+              ...GOTO_RUNTIME_LINES,
+            ],
       }),
     ];
   }
@@ -522,30 +619,66 @@ function generateGoToMethod(componentName: string, routeMeta: RouteMeta | null):
   const paramlessRoute = paramless!;
   const parametrizedRoute = parametrized!;
   const usePush = paramlessRoute.name !== null && parametrizedRoute.name !== null;
+  const paramlessType = buildNavigationTypeString(paramlessRoute);
+  const queryNames = Array.from(new Set([...paramlessRoute.query, ...parametrizedRoute.query]));
+  const hasQuery = queryNames.length > 0;
+  const implementationType = hasQuery
+    ? buildImplementationNavigationTypeString([paramlessRoute, parametrizedRoute])
+    : paramType;
+  const routeSelector = `const useParametrizedRoute = params !== undefined && [${parametrizedRoute.params.map(param => JSON.stringify(param.name)).join(", ")}].some(key => Object.prototype.hasOwnProperty.call(params, key));`;
 
   return [
     createClassMethod({
       name: "goTo",
       isAsync: true,
       overloads: [
-        { parameters: [], returnType: "Promise<void>" },
+        {
+          parameters: paramlessRoute.query.length
+            ? [{ name: "params", type: paramlessType, hasQuestionToken: true }]
+            : [],
+          returnType: "Promise<void>",
+        },
         { parameters: [{ name: "params", type: paramType }], returnType: "Promise<void>" },
       ],
-      parameters: [{ name: "params", type: paramType, hasQuestionToken: true }],
+      parameters: [{ name: "params", type: implementationType, hasQuestionToken: true }],
       statements: usePush
-        ? pushBlock(
-            `params ? ${JSON.stringify(parametrizedRoute.name)} : ${JSON.stringify(paramlessRoute.name)}`,
-            "params",
-            true,
-          )
-        : [
-            `const template = params ? ${JSON.stringify(parametrizedRoute.template)} : ${JSON.stringify(paramlessRoute.template)};`,
-            "let targetUrl = template;",
-            `if (params) {`,
-            ...paramStatements(parametrizedRoute).map(line => `  ${line}`),
-            "}",
-            ...GOTO_RUNTIME_LINES,
-          ],
+        ? hasQuery
+          ? [
+              routeSelector,
+              ...pushBlock(
+                `useParametrizedRoute ? ${JSON.stringify(parametrizedRoute.name)} : ${JSON.stringify(paramlessRoute.name)}`,
+                "params",
+                true,
+                parametrizedRoute.params.map(param => param.name),
+                queryNames,
+              ),
+            ]
+          : pushBlock(
+              `params ? ${JSON.stringify(parametrizedRoute.name)} : ${JSON.stringify(paramlessRoute.name)}`,
+              "params",
+              true,
+              parametrizedRoute.params.map(param => param.name),
+              [],
+            )
+        : hasQuery
+          ? [
+              routeSelector,
+              `const template = useParametrizedRoute ? ${JSON.stringify(parametrizedRoute.template)} : ${JSON.stringify(paramlessRoute.template)};`,
+              "let targetUrl = template;",
+              `if (params && useParametrizedRoute) {`,
+              ...paramStatements(parametrizedRoute).map(line => `  ${line}`),
+              "}",
+              ...queryStatements(queryNames, true),
+              ...GOTO_RUNTIME_LINES,
+            ]
+          : [
+              `const template = params ? ${JSON.stringify(parametrizedRoute.template)} : ${JSON.stringify(paramlessRoute.template)};`,
+              "let targetUrl = template;",
+              `if (params) {`,
+              ...paramStatements(parametrizedRoute).map(line => `  ${line}`),
+              "}",
+              ...GOTO_RUNTIME_LINES,
+            ],
     }),
   ];
 }

--- a/class-generation/index.ts
+++ b/class-generation/index.ts
@@ -350,13 +350,31 @@ function formatNavigationFieldName(name: string): string {
   return /^[$a-z_][$\w]*$/i.test(name) ? name : JSON.stringify(name);
 }
 
-function buildNavigationTypeString(route: RouteEntry): string {
-  const pathFields = route.params.map(param => `${formatNavigationFieldName(param.name)}${param.optional ? "?" : ""}: string | number`);
+function buildNavigationTypeString(route: RouteEntry, requiredOptionalParamName?: string): string {
+  const pathFields = route.params.map((param) => {
+    const forcePresent = param.optional && param.name === requiredOptionalParamName;
+    return `${formatNavigationFieldName(param.name)}${param.optional && !forcePresent ? "?" : ""}: string | number${forcePresent ? " | undefined" : ""}`;
+  });
   const pathNames = new Set(route.params.map(param => param.name));
   const queryFields = route.query
     .filter(query => !pathNames.has(query))
     .map(query => `${formatNavigationFieldName(query)}?: string | number`);
   return `{ ${[...pathFields, ...queryFields].join("; ")} }`;
+}
+
+function buildParametrizedRouteSelectionTypeString(route: RouteEntry): string {
+  if (route.params.some(param => !param.optional)) {
+    return buildNavigationTypeString(route);
+  }
+
+  // In a dual-route overload, the runtime selects the parametrized route by path-key
+  // presence. Require at least one optional path key to be present so the public type
+  // cannot accept an object that runtime would send to the paramless route. Its value may
+  // still be undefined, which intentionally selects the optional-param route with that
+  // segment omitted.
+  return route.params
+    .map(param => buildNavigationTypeString(route, param.name))
+    .join(" | ");
 }
 
 function buildImplementationNavigationTypeString(routes: RouteEntry[]): string {
@@ -620,6 +638,7 @@ function generateGoToMethod(componentName: string, routeMeta: RouteMeta | null):
   const parametrizedRoute = parametrized!;
   const usePush = paramlessRoute.name !== null && parametrizedRoute.name !== null;
   const paramlessType = buildNavigationTypeString(paramlessRoute);
+  const parametrizedOverloadType = buildParametrizedRouteSelectionTypeString(parametrizedRoute);
   const queryNames = Array.from(new Set([...paramlessRoute.query, ...parametrizedRoute.query]));
   const hasQuery = queryNames.length > 0;
   const implementationType = hasQuery
@@ -638,7 +657,7 @@ function generateGoToMethod(componentName: string, routeMeta: RouteMeta | null):
             : [],
           returnType: "Promise<void>",
         },
-        { parameters: [{ name: "params", type: paramType }], returnType: "Promise<void>" },
+        { parameters: [{ name: "params", type: parametrizedOverloadType }], returnType: "Promise<void>" },
       ],
       parameters: [{ name: "params", type: implementationType, hasQuestionToken: true }],
       statements: usePush

--- a/route-navigation-codegen.ts
+++ b/route-navigation-codegen.ts
@@ -1,0 +1,360 @@
+import { getParamToken } from "./router-introspection";
+import { POM_ROUTER_GLOBAL_NAME } from "./router-bridge";
+import type { TypeScriptWriter, WriterFunction } from "./typescript-codegen";
+
+export interface NavigationPathParam {
+  name: string;
+  optional: boolean;
+}
+
+export interface NavigationInput {
+  identifier: string;
+  optional: boolean;
+}
+
+export type NavigationTargetSelection =
+  | { kind: "single"; target: string }
+  | {
+      kind: "dual";
+      paramlessTarget: string;
+      parametrizedTarget: string;
+      selectBy: "input-presence" | "path-param-presence";
+    };
+
+export interface RouterNavigationWriterOptions {
+  routeName: NavigationTargetSelection;
+  input?: NavigationInput;
+  pathParamNames: string[];
+  queryNames: string[];
+}
+
+export interface UrlNavigationWriterOptions {
+  routeTemplate: NavigationTargetSelection;
+  input?: NavigationInput;
+  pathParams: NavigationPathParam[];
+  queryNames: string[];
+}
+
+function writeNavigationValue(
+  writer: TypeScriptWriter,
+  input: NavigationInput,
+  name: string,
+): void {
+  writer.write(input.identifier);
+  if (input.optional) {
+    writer.write("?.");
+  }
+  writer.write(`[${JSON.stringify(name)}]`);
+}
+
+function writeFilteredNavigationRecord(
+  writer: TypeScriptWriter,
+  variableName: "routeParams" | "routeQuery",
+  input: NavigationInput | undefined,
+  names: string[],
+): void {
+  writer.write(`const ${variableName} = `);
+  if (!input || names.length === 0) {
+    writer.write("{};").newLine();
+    return;
+  }
+
+  writer.write("Object.fromEntries([");
+  names.forEach((name, index) => {
+    if (index > 0) {
+      writer.write(", ");
+    }
+    writer.write(`[${JSON.stringify(name)}, `);
+    writeNavigationValue(writer, input, name);
+    writer.write("]");
+  });
+  writer.write("].filter(([, value]) => value !== undefined));").newLine();
+}
+
+function writeUnpartitionedRouteParams(
+  writer: TypeScriptWriter,
+  input: NavigationInput | undefined,
+): void {
+  writer.write("const routeParams = ");
+  if (!input) {
+    writer.write("{};").newLine();
+    return;
+  }
+
+  writer.write("Object.fromEntries(Object.entries(");
+  writer.write(input.identifier);
+  if (input.optional) {
+    writer.write(" ?? {}");
+  }
+  writer.write(").filter(([, v]) => v !== undefined));").newLine();
+}
+
+function writeRouterTargetType(writer: TypeScriptWriter, includeQuery: boolean): void {
+  writer.write("{ name: string; params: Record<string, unknown>");
+  if (includeQuery) {
+    writer.write("; query: Record<string, unknown>");
+  }
+  writer.write(" }");
+}
+
+function writeRouterType(writer: TypeScriptWriter, includeQuery: boolean): void {
+  writer.write(`{ ${POM_ROUTER_GLOBAL_NAME}?: { push: (to: `);
+  writeRouterTargetType(writer, includeQuery);
+  writer.write(") => Promise<unknown>; resolve: (to: ");
+  writeRouterTargetType(writer, includeQuery);
+  writer.write(") => { href: string } } }");
+}
+
+function writeRouterBinding(writer: TypeScriptWriter, includeQuery: boolean): void {
+  writer.write("{ name, params");
+  if (includeQuery) {
+    writer.write(", query");
+  }
+  writer.write(" }");
+}
+
+function writeRouterTarget(
+  writer: TypeScriptWriter,
+  writeName: WriterFunction,
+  includeQuery: boolean,
+  paramsExpression: string,
+  queryExpression: string,
+): void {
+  writer.write("{ name: ");
+  writeName(writer);
+  writer.write(`, params: ${paramsExpression}`);
+  if (includeQuery) {
+    writer.write(`, query: ${queryExpression}`);
+  }
+  writer.write(" }");
+}
+
+function requireNavigationInput(
+  input: NavigationInput | undefined,
+  context: string,
+): NavigationInput {
+  if (!input) {
+    throw new Error(`${context} requires a navigation input.`);
+  }
+  return input;
+}
+
+function writeParametrizedRouteSelector(
+  writer: TypeScriptWriter,
+  input: NavigationInput,
+  pathParamNames: string[],
+): void {
+  writer.write(`const useParametrizedRoute = ${input.identifier} !== undefined && [`);
+  pathParamNames.forEach((name, index) => {
+    if (index > 0) {
+      writer.write(", ");
+    }
+    writer.write(JSON.stringify(name));
+  });
+  writer.write(`].some(key => Object.prototype.hasOwnProperty.call(${input.identifier}, key));`).newLine();
+}
+
+function writeSelectionPrelude(
+  writer: TypeScriptWriter,
+  selection: NavigationTargetSelection,
+  input: NavigationInput | undefined,
+  pathParamNames: string[],
+): void {
+  if (selection.kind === "dual" && selection.selectBy === "path-param-presence") {
+    writeParametrizedRouteSelector(
+      writer,
+      requireNavigationInput(input, "Path-param route selection"),
+      pathParamNames,
+    );
+  }
+}
+
+function writeSelectedTarget(
+  writer: TypeScriptWriter,
+  selection: NavigationTargetSelection,
+  input: NavigationInput | undefined,
+): void {
+  if (selection.kind === "single") {
+    writer.write(JSON.stringify(selection.target));
+    return;
+  }
+
+  if (selection.selectBy === "path-param-presence") {
+    writer.write("useParametrizedRoute");
+  }
+  else {
+    writer.write(requireNavigationInput(input, "Input-presence route selection").identifier);
+  }
+  writer.write(` ? ${JSON.stringify(selection.parametrizedTarget)} : ${JSON.stringify(selection.paramlessTarget)}`);
+}
+
+/**
+ * Emits the complete named-route navigation body. The caller supplies route metadata;
+ * this writer owns params/query partitioning and both the cold-load and warm-router paths.
+ */
+export function createRouterNavigationWriter(options: RouterNavigationWriterOptions): WriterFunction {
+  return (writer) => {
+    writeSelectionPrelude(writer, options.routeName, options.input, options.pathParamNames);
+    const writeRouteName: WriterFunction = nameWriter => writeSelectedTarget(nameWriter, options.routeName, options.input);
+
+    const includeQuery = options.queryNames.length > 0;
+    if (includeQuery) {
+      writeFilteredNavigationRecord(writer, "routeParams", options.input, options.pathParamNames);
+      writeFilteredNavigationRecord(writer, "routeQuery", options.input, options.queryNames);
+    }
+    else {
+      // Preserve the compact output for routes whose input contains only path params.
+      writeUnpartitionedRouteParams(writer, options.input);
+    }
+
+    writer.writeLine(
+      `const isCold = await this.page.evaluate(() => typeof (globalThis as { ${POM_ROUTER_GLOBAL_NAME}?: unknown }).${POM_ROUTER_GLOBAL_NAME} === "undefined");`,
+    );
+    writer.writeLine("if (isCold) {");
+    writer.indent(() => {
+      writer.writeLine('await this.page.goto("/", { waitUntil: "commit" });');
+      writer.writeLine(
+        `await this.page.waitForFunction(() => typeof (globalThis as { ${POM_ROUTER_GLOBAL_NAME}?: unknown }).${POM_ROUTER_GLOBAL_NAME} !== "undefined", { timeout: 15000 });`,
+      );
+      writer.write("const href = await this.page.evaluate((");
+      writeRouterBinding(writer, includeQuery);
+      writer.write(") => (globalThis as ");
+      writeRouterType(writer, includeQuery);
+      writer.write(`).${POM_ROUTER_GLOBAL_NAME}?.resolve(`);
+      writeRouterBinding(writer, includeQuery);
+      writer.write(")?.href, ");
+      writeRouterTarget(writer, writeRouteName, includeQuery, "routeParams", "routeQuery");
+      writer.write(");").newLine();
+      writer.writeLine("if (href) {");
+      writer.indent(() => {
+        writer.writeLine('await this.page.goto(href, { waitUntil: "domcontentloaded" });');
+      });
+      writer.writeLine("}");
+    });
+    writer.writeLine("} else {");
+    writer.indent(() => {
+      writer.write("await this.page.evaluate(async (");
+      writeRouterBinding(writer, includeQuery);
+      writer.write(") => {").newLine();
+      writer.indent(() => {
+        writer.write("await (globalThis as ");
+        writeRouterType(writer, includeQuery);
+        writer.write(`).${POM_ROUTER_GLOBAL_NAME}?.push(`);
+        writeRouterBinding(writer, includeQuery);
+        writer.write(");").newLine();
+      });
+      writer.write("}, ");
+      writeRouterTarget(writer, writeRouteName, includeQuery, "routeParams", "routeQuery");
+      writer.write(");").newLine();
+    });
+    writer.writeLine("}");
+  };
+}
+
+function writePathParamAssignments(
+  writer: TypeScriptWriter,
+  input: NavigationInput,
+  pathParams: NavigationPathParam[],
+): void {
+  for (const param of pathParams) {
+    const token = getParamToken(param.name);
+    if (param.optional) {
+      writer.write("targetUrl = ");
+      writeNavigationValue(writer, input, param.name);
+      writer.write(` === undefined ? targetUrl.replaceAll(${JSON.stringify(`/${token}`)}, "") : targetUrl.replaceAll(${JSON.stringify(token)}, String(`);
+      writeNavigationValue(writer, input, param.name);
+      writer.write("));").newLine();
+    }
+    else {
+      writer.write(`targetUrl = targetUrl.replaceAll(${JSON.stringify(token)}, String(`);
+      writeNavigationValue(writer, input, param.name);
+      writer.write("));").newLine();
+    }
+  }
+}
+
+function writeQueryString(
+  writer: TypeScriptWriter,
+  input: NavigationInput,
+  queryNames: string[],
+): void {
+  if (queryNames.length === 0) {
+    return;
+  }
+
+  writer.writeLine("const routeQuery = new URLSearchParams();");
+  for (const queryName of queryNames) {
+    writer.write("if (");
+    writeNavigationValue(writer, input, queryName);
+    writer.write(" !== undefined) {").newLine();
+    writer.indent(() => {
+      writer.write(`routeQuery.set(${JSON.stringify(queryName)}, String(`);
+      writeNavigationValue(writer, input, queryName);
+      writer.write("));").newLine();
+    });
+    writer.writeLine("}");
+  }
+  writer.writeLine("const routeQueryString = routeQuery.toString();");
+  writer.writeLine("if (routeQueryString) {");
+  writer.indent(() => {
+    writer.writeLine('targetUrl += `?${routeQueryString}`;');
+  });
+  writer.writeLine("}");
+}
+
+function writeRuntimeUrlNavigation(writer: TypeScriptWriter): void {
+  writer.writeLine(
+    "const runtimeEnv = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env;",
+  );
+  writer.writeLine(
+    "const runtimeBaseUrl = runtimeEnv?.PLAYWRIGHT_RUNTIME_BASE_URL ?? runtimeEnv?.PLAYWRIGHT_TEST_BASE_URL ?? runtimeEnv?.VITE_PLAYWRIGHT_BASE_URL;",
+  );
+  writer.writeLine("const resolvedUrl = runtimeBaseUrl ? new URL(targetUrl, runtimeBaseUrl).toString() : targetUrl;");
+  writer.writeLine("await this.page.goto(resolvedUrl);");
+}
+
+/** Emits the complete URL-construction navigation body used for unnamed routes. */
+export function createUrlNavigationWriter(options: UrlNavigationWriterOptions): WriterFunction {
+  return (writer) => {
+    writeSelectionPrelude(writer, options.routeTemplate, options.input, options.pathParams.map(param => param.name));
+    if (options.routeTemplate.kind === "single") {
+      writer.write(`let targetUrl = ${JSON.stringify(options.routeTemplate.target)};`).newLine();
+    }
+    else {
+      writer.write("const template = ");
+      writeSelectedTarget(writer, options.routeTemplate, options.input);
+      writer.write(";").newLine();
+      writer.writeLine("let targetUrl = template;");
+    }
+
+    if (options.pathParams.length > 0) {
+      const input = requireNavigationInput(options.input, "URL navigation with path params");
+
+      if (options.routeTemplate.kind === "dual") {
+        writer.write("if (");
+        writer.write(input.identifier);
+        if (options.routeTemplate.selectBy === "path-param-presence") {
+          writer.write(" && useParametrizedRoute");
+        }
+        writer.write(") {").newLine();
+        writer.indent(() => {
+          writePathParamAssignments(writer, input, options.pathParams);
+        });
+        writer.writeLine("}");
+      }
+      else {
+        writePathParamAssignments(writer, input, options.pathParams);
+      }
+    }
+
+    if (options.queryNames.length > 0) {
+      writeQueryString(
+        writer,
+        requireNavigationInput(options.input, "URL navigation with query params"),
+        options.queryNames,
+      );
+    }
+
+    writeRuntimeUrlNavigation(writer);
+  };
+}

--- a/router-bridge.ts
+++ b/router-bridge.ts
@@ -1,6 +1,7 @@
 export interface PomNavigationTarget {
   name: string;
   params: Record<string, unknown>;
+  query?: Record<string, unknown>;
 }
 
 export interface PomNavigationRouter {

--- a/tests/class-generation-coverage.test.ts
+++ b/tests/class-generation-coverage.test.ts
@@ -634,16 +634,18 @@ describe("class-generation coverage", () => {
       writeMinimalBasePage(basePagePath);
 
       // One component per scenario:
-      //   DashboardView  -> paramless route only (/dashboard)
-      //   UsersView      -> parametrized route only (/users/:id, props declare `id`)
-      //   PersonsView    -> BOTH (/persons/new paramless, /persons/:id parametrized)
+      //   DashboardView  -> paramless route with an optional query prop (/dashboard?section=...)
+      //   UsersView      -> parametrized route with a query prop (/users/:id?q=...)
+      //   PersonsView    -> BOTH (/persons/new and /persons/:id), each with a query prop
       //   OrgMembersView -> multi-param route (/orgs/:orgId/users/:userId)
       //   ThingsView     -> optional param route (/things/:thingId?)
+      //   UnnamedView    -> unnamed parametrized route with a query prop
       writeFile(path.join(tempRoot, "DashboardView.vue"), "<template><div /></template>\n");
       writeFile(path.join(tempRoot, "UsersView.vue"), "<template><div /></template>\n");
       writeFile(path.join(tempRoot, "PersonsView.vue"), "<template><div /></template>\n");
       writeFile(path.join(tempRoot, "OrgMembersView.vue"), "<template><div /></template>\n");
       writeFile(path.join(tempRoot, "ThingsView.vue"), "<template><div /></template>\n");
+      writeFile(path.join(tempRoot, "UnnamedView.vue"), "<template><div /></template>\n");
 
       writeFile(
         path.join(tempRoot, "router.ts"),
@@ -654,17 +656,19 @@ describe("class-generation coverage", () => {
           "import PersonsView from './PersonsView.vue';",
           "import OrgMembersView from './OrgMembersView.vue';",
           "import ThingsView from './ThingsView.vue';",
+          "import UnnamedView from './UnnamedView.vue';",
           "",
           "export default function makeRouter() {",
           "  return createRouter({",
           "    history: createMemoryHistory(),",
           "    routes: [",
-          "      { path: '/dashboard', name: 'dashboard', component: DashboardView },",
-          "      { path: '/users/:id', name: 'users', component: UsersView, props: (route) => ({ id: route.params.id }) },",
-          "      { path: '/persons/new', name: 'persons-new', component: PersonsView },",
-          "      { path: '/persons/:id', name: 'persons-edit', component: PersonsView, props: (route) => ({ id: route.params.id }) },",
+          "      { path: '/dashboard', name: 'dashboard', component: DashboardView, props: (route) => ({ section: route.query.section }) },",
+          "      { path: '/users/:id', name: 'users', component: UsersView, props: (route) => ({ id: route.params.id, q: route.query.q }) },",
+          "      { path: '/persons/new', name: 'persons-new', component: PersonsView, props: (route) => ({ mode: route.query.mode }) },",
+          "      { path: '/persons/:id', name: 'persons-edit', component: PersonsView, props: (route) => ({ id: route.params.id, mode: route.query.mode }) },",
           "      { path: '/orgs/:orgId/users/:userId', name: 'org-members', component: OrgMembersView, props: (route) => ({ orgId: route.params.orgId, userId: route.params.userId }) },",
           "      { path: '/things/:thingId?', name: 'things', component: ThingsView, props: (route) => ({ thingId: route.params.thingId }) },",
+          "      { path: '/unnamed/:id', component: UnnamedView, props: (route) => ({ id: route.params.id, sort: route.query.sort }) },",
           "    ],",
           "  });",
           "}",
@@ -687,6 +691,7 @@ describe("class-generation coverage", () => {
         mkView("PersonsView", "PersonsView.vue"),
         mkView("OrgMembersView", "OrgMembersView.vue"),
         mkView("ThingsView", "ThingsView.vue"),
+        mkView("UnnamedView", "UnnamedView.vue"),
       ]);
       const outDir = path.join(tempRoot, "pom");
 
@@ -707,8 +712,8 @@ describe("class-generation coverage", () => {
         return nextClass === -1 ? content.slice(start) : content.slice(start, nextClass);
       };
 
-      // Shared: named routes drive the runtime router, handing it a params object (undefined
-      // values stripped) instead of reconstructing a URL. Warm pages SPA-push via
+      // Shared: named routes drive the runtime router, partitioning the generated method's
+      // flat navigation arguments into params and query records. Warm pages SPA-push via
       // `__vuePomGeneratorRouter.push`; cold pages (about:blank, router not yet installed) boot then
       // full-load the resolved target (`__vuePomGeneratorRouter.resolve(...).href`) so the route's
       // component mounts via a stable page load instead of a race-prone SPA push.
@@ -719,8 +724,9 @@ describe("class-generation coverage", () => {
       const COLD_START_WAIT = "waitForFunction(() => typeof";
       const IS_COLD = "const isCold =";
 
-      // --- DashboardView: paramless-only, named -> no-arg goTo() that pushes the named route. ---
+      // --- DashboardView: query-only, named -> optional goTo(params) that pushes query. ---
       const dashboardClass = extractClass("DashboardView");
+      expect(dashboardClass).toContain("async goTo(params?: { section?: string | number })");
       expect(dashboardClass).toContain('name: "dashboard"');
       expect(dashboardClass).toContain(PUSH_CALL);
       // Cold-start branch: boot "/", wait for the router, resolve the target, full-load it.
@@ -729,18 +735,20 @@ describe("class-generation coverage", () => {
       expect(dashboardClass).toContain(COLD_START_WAIT);
       expect(dashboardClass).toContain(RESOLVE_CALL);
       expect(dashboardClass).toContain(COLD_TARGET_LOAD);
-      // A paramless route has no params object: emit an empty record literally (no Object.fromEntries).
+      // A path-paramless route emits an empty params record and a filtered query record.
       expect(dashboardClass).toContain("const routeParams = {};");
-      expect(dashboardClass).not.toContain("goTo(params");
+      expect(dashboardClass).toContain('const routeQuery = Object.fromEntries([["section", params?.["section"]]]');
+      expect(dashboardClass).toContain("resolve({ name, params, query })");
+      expect(dashboardClass).toContain("push({ name, params, query })");
       expect(dashboardClass).not.toContain("targetUrl");
       expect(dashboardClass).not.toContain("replaceAll");
 
-      // --- UsersView: parametrized-only, named -> goTo(params) that pushes with the param object. ---
+      // --- UsersView: path + query, named -> one flat typed input partitioned for the router. ---
       const usersClass = extractClass("UsersView");
-      expect(usersClass).toContain("async goTo(params: { id: string | number })");
+      expect(usersClass).toContain("async goTo(params: { id: string | number; q?: string | number })");
       expect(usersClass).toContain('name: "users"');
-      // Required params are never nullish, so no `?? {}` guard (avoids TS2871).
-      expect(usersClass).toContain("Object.fromEntries(Object.entries(params).filter(([, v]) => v !== undefined))");
+      expect(usersClass).toContain('const routeParams = Object.fromEntries([["id", params["id"]]]');
+      expect(usersClass).toContain('const routeQuery = Object.fromEntries([["q", params["q"]]]');
       expect(usersClass).toContain(PUSH_CALL);
       expect(usersClass).toContain(RESOLVE_CALL);
       expect(usersClass).toContain(IS_COLD);
@@ -754,21 +762,23 @@ describe("class-generation coverage", () => {
       // --- PersonsView: BOTH routes, both named -> overloaded goTo() selecting the route name by params presence. ---
       const personsClass = extractClass("PersonsView");
       // Overload signatures precede the implementation.
-      expect(personsClass).toContain("goTo(): Promise<void>;");
-      expect(personsClass).toContain("goTo(params: { id: string | number }): Promise<void>;");
-      // The route name is selected by params presence and inlined into the router call args
-      // (no separate `const routeName`, no URL reconstruction from tokens).
-      expect(personsClass).toContain('name: params ? "persons-edit" : "persons-new"');
+      expect(personsClass).toContain("goTo(params?: { mode?: string | number }): Promise<void>;");
+      expect(personsClass).toContain("goTo(params: { id: string | number; mode?: string | number }): Promise<void>;");
+      // A query-only object selects the path-paramless route; presence of the path-param key
+      // selects the parametrized route, including when an optional path param is undefined.
+      expect(personsClass).toContain('const useParametrizedRoute = params !== undefined && ["id"].some(');
+      expect(personsClass).toContain('name: useParametrizedRoute ? "persons-edit" : "persons-new"');
       // The both-routes overload is also guarded: cold branch resolves + full-loads the target.
       expect(personsClass).toContain(IS_COLD);
       expect(personsClass).toContain(COLD_BOOT);
       expect(personsClass).toContain(COLD_START_WAIT);
       expect(personsClass).toContain(RESOLVE_CALL);
       expect(personsClass).toContain(COLD_TARGET_LOAD);
-      expect(personsClass).toContain("Object.fromEntries(Object.entries(params ?? {})");
+      expect(personsClass).toContain('const routeParams = Object.fromEntries([["id", params?.["id"]]]');
+      expect(personsClass).toContain('const routeQuery = Object.fromEntries([["mode", params?.["mode"]]]');
       expect(personsClass).toContain(PUSH_CALL);
       // Implementation parameter is optional (so the no-arg overload is callable).
-      expect(personsClass).toContain("async goTo(params?: { id: string | number })");
+      expect(personsClass).toContain("async goTo(params?: { mode?: string | number; id?: string | number })");
       expect(personsClass).not.toContain("targetUrl");
       expect(personsClass).not.toContain("replaceAll");
       // route property is the shortest (paramless) template.
@@ -798,6 +808,14 @@ describe("class-generation coverage", () => {
       expect(thingsClass).not.toContain("replaceAll");
       // route property holds the tokenized template (informational; the only route).
       expect(thingsClass).toContain('{ template: "/things/__VUE_TESTID_PARAM__thingId__" }');
+
+      // --- UnnamedView: fallback URL construction preserves both path and query values. ---
+      const unnamedClass = extractClass("UnnamedView");
+      expect(unnamedClass).toContain("async goTo(params: { id: string | number; sort?: string | number })");
+      expect(unnamedClass).toContain("targetUrl.replaceAll");
+      expect(unnamedClass).toContain("const routeQuery = new URLSearchParams();");
+      expect(unnamedClass).toContain('routeQuery.set("sort", String(params["sort"]))');
+      expect(unnamedClass).toContain('targetUrl += `?${routeQueryString}`');
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }

--- a/tests/generated-tsc.test.ts
+++ b/tests/generated-tsc.test.ts
@@ -147,6 +147,74 @@ describe("generated output", () => {
     }
   });
 
+  it("typechecks query-aware navigation for create and details routes", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vue-pom-generator-query-navigation-"));
+
+    try {
+      fs.symlinkSync(path.resolve(process.cwd(), "node_modules"), path.join(tempRoot, "node_modules"), "dir");
+      const basePagePath = path.join(tempRoot, "base-page.ts");
+      copyRepoFixture(tempRoot, "base-page.full.ts", "base-page.ts");
+      copyRepoFixture(tempRoot, "pointer.ts", "pointer.ts");
+
+      const componentName = "RecordDetailsPage";
+      const viewPath = path.join(tempRoot, `${componentName}.vue`);
+      writeFile(viewPath, "<template><div /></template>\n");
+      writeFile(
+        path.join(tempRoot, "router.ts"),
+        [
+          "import { createMemoryHistory, createRouter } from 'vue-router';",
+          "import RecordDetailsPage from './RecordDetailsPage.vue';",
+          "export default function makeRouter() {",
+          "  return createRouter({",
+          "    history: createMemoryHistory(),",
+          "    routes: [",
+          "      { path: '/records/new', name: 'record-new', component: RecordDetailsPage, props: route => ({ tab: route.query.tab }) },",
+          "      { path: '/records/:recordId', name: 'record-details', component: RecordDetailsPage, props: route => ({ recordId: route.params.recordId, tab: route.query.tab }) },",
+          "    ],",
+          "  });",
+          "}",
+        ].join("\n"),
+      );
+
+      const dependencies: IComponentDependencies = {
+        filePath: viewPath,
+        childrenComponentSet: new Set(),
+        usedComponentSet: new Set(),
+        dataTestIdSet: new Set(),
+        generatedMethods: new Map(),
+        isView: true,
+      };
+      const outDir = path.join(tempRoot, "out");
+      await generateFiles(new Map([[componentName, dependencies]]), new Map(), basePagePath, {
+        outDir,
+        projectRoot: tempRoot,
+        routerEntry: "./router.ts",
+        vueRouterFluentChaining: true,
+      });
+
+      const generatedFilePath = path.join(outDir, "page-object-models.g.ts");
+      writeFile(
+        path.join(tempRoot, "usage.ts"),
+        [
+          'import type { Page } from "@playwright/test";',
+          'import { RecordDetailsPage } from "./out/page-object-models.g";',
+          "declare const page: Page;",
+          "const recordDetailsPage = new RecordDetailsPage(page);",
+          'void recordDetailsPage.goTo({ tab: "summary" });',
+          'void recordDetailsPage.goTo({ recordId: 42, tab: "history" });',
+        ].join("\n"),
+      );
+
+      const result = runTscNoEmit([generatedFilePath, basePagePath, path.join(tempRoot, "usage.ts")], { cwd: tempRoot });
+      if (result.status !== 0) {
+        throw new Error(`tsc failed (exit ${result.status})\n\nSTDOUT:\n${result.stdout}\n\nSTDERR:\n${result.stderr}`);
+      }
+    }
+    finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  }, 120_000);
+
   it("fails fast when parameterized input methods omit key params", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vue-pom-generator-keyed-input-"));
 

--- a/tests/generated-tsc.test.ts
+++ b/tests/generated-tsc.test.ts
@@ -168,8 +168,8 @@ describe("generated output", () => {
           "  return createRouter({",
           "    history: createMemoryHistory(),",
           "    routes: [",
-          "      { path: '/records/new', name: 'record-new', component: RecordDetailsPage, props: route => ({ tab: route.query.tab }) },",
-          "      { path: '/records/:recordId', name: 'record-details', component: RecordDetailsPage, props: route => ({ recordId: route.params.recordId, tab: route.query.tab }) },",
+          "      { path: '/records/new', name: 'record-new', component: RecordDetailsPage, props: route => ({ mode: route.query.mode }) },",
+          "      { path: '/records/:recordId?', name: 'record-details', component: RecordDetailsPage, props: route => ({ recordId: route.params.recordId, tab: route.query.tab }) },",
           "    ],",
           "  });",
           "}",
@@ -200,8 +200,11 @@ describe("generated output", () => {
           'import { RecordDetailsPage } from "./out/page-object-models.g";',
           "declare const page: Page;",
           "const recordDetailsPage = new RecordDetailsPage(page);",
-          'void recordDetailsPage.goTo({ tab: "summary" });',
+          'void recordDetailsPage.goTo({ mode: "summary" });',
           'void recordDetailsPage.goTo({ recordId: 42, tab: "history" });',
+          'void recordDetailsPage.goTo({ recordId: undefined, tab: "history" });',
+          "// @ts-expect-error A details-only query cannot select the details route without path-key presence.",
+          'void recordDetailsPage.goTo({ tab: "history" });',
         ].join("\n"),
       );
 


### PR DESCRIPTION
## Summary
- carry discovered route query keys into generated navigation metadata
- expose query keys as optional typed `goTo` arguments and partition them from path params
- preserve existing output for routes without query props
- support query strings for unnamed-route URL generation

## Verification
- `npm run typecheck`
- `npm test` (383 tests)
- `npm run build`
- changed-file ESLint
- immybot development build using this checkout as a local file dependency

Full-repository ESLint still reports three pre-existing errors in untouched files (two `as unknown` assertions in `class-generation/base-page.ts` and one unused fixture variable).