### PR TITLE
Add fast, actionable Playwright diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ If you already use Playwright with `getByTestId`, the point is simple: this pack
 - **Generates TypeScript POM output as either one aggregate or split per class, always with a stable `index.ts` barrel.**
 - **Describes generated Playwright locators** with deterministic human-readable labels via `Locator.describe()`.
 - **Can generate Playwright fixtures** so tests can request `userListPage` instead of constructing `new UserListPage(page)` manually.
+- **Captures generator-aware failure diagnostics before fixture teardown** and prints the relevant DOM, accessibility tree, browser errors, generated methods, and isolated rerun command to stdout.
 - **Can fail fast on unnameable wrapper-button actions** so complex inline handlers do not silently degrade into low-signal generated APIs.
 - **Can emit a single C# POM file** for Playwright .NET consumers.
 - **Exposes `virtual:testids` and `virtual:pom-manifest`** so your app can inspect collected ids and generated POM metadata at runtime.
@@ -215,6 +216,7 @@ Exports:
 - `defineVuePomGeneratorConfig()`
 - `defineNuxtPomGeneratorConfig()`
 - `@immense/vue-pom-generator/eslint`
+- `@immense/vue-pom-generator/playwright/reporter`
 - `@immense/vue-pom-generator/router` (browser-safe runtime bridge)
 
 ## Basic Vue/Vite setup
@@ -366,6 +368,7 @@ TypeScript output:
 Optional Playwright fixture output:
 
 - `fixtures.g.ts` next to the POMs by default
+- `pom-manifest.g.ts` — a Node-importable map from Vue source/test ids to generated methods
 - or a custom directory / file path when configured
 
 Optional C# output:
@@ -373,6 +376,60 @@ Optional C# output:
 - `page-object-models.g.cs`
 
 If you emit outside a `__generated__` path, the generator also manages `.gitattributes` entries for generated files.
+
+## Fast, loud Playwright failures
+
+Generated fixtures install a failure capture around the browser page. On every unexpected failed attempt, before Playwright destroys the browser context, it captures within one five-second total budget:
+
+- the URL and page title
+- rendered generated test ids with visible/hidden and enabled/disabled state
+- the best matching generated POM and its method catalog
+- the most recent generated action and all test-id candidates it expected
+- an accessibility snapshot
+- buffered browser console errors, uncaught page errors, failed requests, and HTTP error responses
+- a screenshot and structured JSON attachment
+
+Add the reporter to print this as one bounded, LLM-friendly stdout block. In GitHub Actions, compose Playwright's built-in `github` reporter for canonical line annotations:
+
+```ts
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  expect: { timeout: 5_000 },
+  reporter: process.env.CI
+    ? [
+        ["github"],
+        ["@immense/vue-pom-generator/playwright/reporter"],
+      ]
+    : [
+        ["list"],
+        ["@immense/vue-pom-generator/playwright/reporter"],
+      ],
+  use: {
+    actionTimeout: 5_000,
+    navigationTimeout: 5_000,
+    trace: "retain-on-first-failure",
+  },
+});
+```
+
+The report ends with a file-and-line-targeted command that includes `--max-failures=1`. Method availability is descriptive only: `absent`, `hidden`, or `disabled` can be a valid state for the current page.
+
+Animations and presentation delays are disabled by default. Recording/demo projects can opt in through the generated `animation` fixture option; ordinary tests use Playwright's actionability checks without forced clicks. Before clicking, generated actions also await finite CSS animations on the target's ancestor chain (bounded by five seconds). This covers overlays that are visible to Playwright while their component library still suppresses input during an opening transition; infinite decorative animations are ignored.
+
+## Recommended Playwright lint rules
+
+The ESLint export composes its generator-specific conventions with `eslint-plugin-playwright`. The flat recommended config treats manual sleeps, `networkidle`, selector waits, forced actions, and non-web-first assertions as errors:
+
+```ts
+import { recommendedPlaywrightConfig } from "@immense/vue-pom-generator/eslint";
+
+export default [
+  ...recommendedPlaywrightConfig,
+];
+```
+
+It enables `playwright/no-wait-for-timeout`, `playwright/no-networkidle`, `playwright/no-wait-for-selector`, `playwright/no-force-option`, and `playwright/prefer-web-first-assertions` alongside the generated-POM rules. Presentation waits inside the generator's explicitly enabled animation runtime are not test-authored waits and remain isolated there.
 
 ## Actual Vite dev/build behavior
 
@@ -438,8 +495,9 @@ goTo(params: { userId: string | number; tab?: string | number }): Promise<void>
 ```
 
 `goTo({ userId: 42, tab: "activity" })` partitions the flat input into Vue Router's
-`params` and `query` records. On a cold page it resolves and fully loads the named route;
-on a warm page it uses `router.push`.
+`params` and `query` records. On a cold page it boots the application, waits for Vue
+Router's initial navigation to settle, and then uses `router.push`; warm pages use the
+same awaited push without booting again.
 
 Important caveats:
 

--- a/class-generation/base-page.ts
+++ b/class-generation/base-page.ts
@@ -7,6 +7,23 @@ import { Callout } from "./callout";
 import type { CalloutRenderer } from "./callout";
 import { Pointer, type AfterPointerClick, type AfterPointerClickInfo, type PointerRenderer } from "./pointer";
 
+const POM_ACTIVE_ACTION_REGISTRY = Symbol.for("@immense/vue-pom-generator.active-action-registry");
+
+interface PomActiveActionRecord {
+  componentName?: string;
+  methodName: string;
+  expectedTestIds: readonly string[];
+}
+
+function setPomAction(page: object, action: PomActiveActionRecord): void {
+  const globalRecord = globalThis as typeof globalThis & {
+    [POM_ACTIVE_ACTION_REGISTRY]?: WeakMap<object, PomActiveActionRecord>;
+  };
+  const registry = globalRecord[POM_ACTIVE_ACTION_REGISTRY] ?? new WeakMap<object, PomActiveActionRecord>();
+  globalRecord[POM_ACTIVE_ACTION_REGISTRY] = registry;
+  registry.set(page, { ...action, expectedTestIds: [...action.expectedTestIds] });
+}
+
 // Click instrumentation is optional for generated POMs.
 //
 // When enabled, POM click/fill helpers will wait for the app to emit
@@ -124,7 +141,7 @@ export class BasePage {
    * real `Page` at runtime.
    */
   protected get page(): Page {
-    return this._page as unknown as Page;
+    return this._page as Page;
   }
 
   /**
@@ -252,6 +269,15 @@ export class BasePage {
     }
   }
 
+  private getAfterPointerClick(wait: boolean = true): AfterPointerClick | undefined {
+    if (!REQUIRE_CLICK_EVENT || !wait) return undefined;
+
+    return async ({ testId, instrumented }: AfterPointerClickInfo) => {
+      if (!testId || !instrumented) return;
+      await this.waitForTestIdClickEventAfter(testId);
+    };
+  }
+
   protected selectorForTestId(testId: string): string {
     return `[${this.testIdAttribute}="${testId}"]`;
   }
@@ -265,12 +291,55 @@ export class BasePage {
     return this.describeLocator(this.page.locator(this.selectorForTestId(testId)), description);
   }
 
+  protected async resolveVisibleTestIdLocator(
+    testIds: readonly string[],
+    description: string,
+    methodName: string,
+    componentName?: string,
+  ): Promise<Locator> {
+    this.recordPomAction(componentName, methodName, testIds);
+    const locators = testIds.map(testId => this.locatorByTestId(testId, description));
+    if (!locators.length) {
+      throw new Error(`[pom] ${methodName} has no candidate test ids.`);
+    }
+
+    try {
+      await Promise.any(locators.map(locator => locator.waitFor({ state: "visible", timeout: 5_000 })));
+    }
+    catch (error) {
+      throw new Error(
+        `[pom] ${methodName} could not find a visible element for any generated test id: ${testIds.join(", ")}`,
+        { cause: error },
+      );
+    }
+
+    for (const locator of locators) {
+      if (await locator.isVisible()) return locator;
+    }
+    return locators[0]!;
+  }
+
+  protected recordPomAction(
+    componentName: string | undefined,
+    methodName: string,
+    expectedTestIds: readonly string[],
+  ): void {
+    setPomAction(this.page, { componentName, methodName, expectedTestIds });
+  }
+
   protected locatorWithinTestIdByLabel(
     rootTestId: string,
     label: string,
     options?: { exact?: boolean; description?: string },
   ): Locator {
-    const locator = this.locatorByTestId(rootTestId).getByLabel(label, { exact: options?.exact ?? true });
+    // Custom radio controls commonly render an invisible input beneath its visible
+    // associated <label>. getByLabel() correctly resolves the input, but clicking it
+    // then fails actionability because the label intercepts pointer events. Generated
+    // radio actions are user interactions, so click the visible labelled surface.
+    const locator = this.locatorByTestId(rootTestId)
+      .filter({ visible: true })
+      .first()
+      .getByText(label, { exact: options?.exact ?? true });
     return this.describeLocator(locator, options?.description);
   }
 
@@ -320,11 +389,11 @@ export class BasePage {
     // `getLocator` returns the narrowed `PwLocator` (so test doubles satisfy it), but each
     // value is a real Playwright `Locator` at runtime. Widen the record's value type so
     // generated keyed accessors can be passed to `expect(...)`.
-    return new Proxy({}, handler) as unknown as Record<TKey, Locator>;
+    return new Proxy({}, handler) as Record<TKey, Locator>;
   }
 
   public async getObjectId(options?: { timeoutMs?: number }): Promise<ObjectId> {
-    const timeoutMs = options?.timeoutMs ?? 10_000;
+    const timeoutMs = options?.timeoutMs ?? 5_000;
     const deadline = Date.now() + timeoutMs;
 
     while (true) {
@@ -529,25 +598,52 @@ export class BasePage {
     annotationText: string = "",
     wait: boolean = true,
     description?: string,
+    action?: { componentName?: string; methodName: string; preferAssociatedLabel?: boolean },
   ): Promise<void> {
-    const locator = this.locatorByTestId(testId, description);
-    await this.pointer.animateCursorToElement(locator, true, 200, annotationText, {
-      afterClick: async ({ testId: clickedTestId, instrumented }: AfterPointerClickInfo) => {
-        if (!wait) return;
-        if (!clickedTestId || !instrumented) return;
-        await this.waitForTestIdClickEventAfter(clickedTestId);
-      },
-    });
+    this.recordPomAction(action?.componentName, action?.methodName ?? description ?? "clickByTestId", [testId]);
+    const locator = this.locatorByTestId(testId, description).filter({ visible: true }).first();
+    let clickTarget = locator;
+    let activateWithKeyboard = false;
+    if (action?.preferAssociatedLabel) {
+      const visibleControl = locator;
+      const controlId = await visibleControl.getAttribute("id");
+      if (controlId) {
+        // Bootstrap custom controls often use an empty label whose painted ::before/::after
+        // pseudo-elements intercept the pointer. Playwright's visible filter can exclude that
+        // empty label even though its pseudo-element is the actual interaction surface, so first
+        // select the associated label by DOM presence and then choose pointer or keyboard activation.
+        const associatedLabel = this.page.locator(`label[for=${JSON.stringify(controlId)}]`).first();
+        if (await associatedLabel.count() > 0) {
+          if (await associatedLabel.isVisible()) {
+            clickTarget = associatedLabel;
+          }
+          else {
+            // An empty label can have a zero-size element box while its ::before checkbox/radio
+            // remains painted over the input. Pointer clicks cannot target either surface without
+            // force; Space is the native, actionability-checked keyboard activation for both.
+            activateWithKeyboard = true;
+          }
+        }
+      }
+      else {
+        clickTarget = visibleControl;
+      }
+    }
+    const afterClick = this.getAfterPointerClick(wait);
+    if (activateWithKeyboard) {
+      await this.pointer.animateCursorToElement(locator, false, 200, annotationText);
+      await locator.press("Space");
+      if (afterClick) {
+        await afterClick({ testId, instrumented: true });
+      }
+      return;
+    }
+    await this.pointer.animateCursorToElement(clickTarget, true, 200, annotationText, afterClick ? { afterClick } : undefined);
   }
 
   public async clickLocator(locator: PwLocator, annotationText: string = "", wait: boolean = true): Promise<void> {
-    await this.pointer.animateCursorToElement(locator, true, 200, annotationText, {
-      afterClick: async ({ testId: clickedTestId, instrumented }: AfterPointerClickInfo) => {
-        if (!wait) return;
-        if (!clickedTestId || !instrumented) return;
-        await this.waitForTestIdClickEventAfter(clickedTestId);
-      },
-    });
+    const afterClick = this.getAfterPointerClick(wait);
+    await this.pointer.animateCursorToElement(locator, true, 200, annotationText, afterClick ? { afterClick } : undefined);
   }
 
   protected async clickWithinTestIdByLabel(
@@ -555,8 +651,9 @@ export class BasePage {
     label: string,
     annotationText: string = "",
     wait: boolean = true,
-    options?: { exact?: boolean; description?: string },
+    options?: { exact?: boolean; description?: string; componentName?: string; methodName?: string },
   ): Promise<void> {
+    this.recordPomAction(options?.componentName, options?.methodName ?? options?.description ?? "clickWithinTestIdByLabel", [rootTestId]);
     const locator = this.locatorWithinTestIdByLabel(rootTestId, label, {
       exact: options?.exact,
       description: options?.description,
@@ -569,14 +666,12 @@ export class BasePage {
     text: string,
     annotationText: string = "",
     description?: string,
+    action?: { componentName?: string; methodName: string },
   ): Promise<void> {
-    const locator = this.locatorByTestId(testId, description);
-    await this.pointer.animateCursorToElementAndClickAndFill(locator, text, true, 200, annotationText, {
-      afterClick: async ({ testId: clickedTestId, instrumented }: AfterPointerClickInfo) => {
-        if (!clickedTestId || !instrumented) return;
-        await this.waitForTestIdClickEventAfter(clickedTestId);
-      },
-    });
+    this.recordPomAction(action?.componentName, action?.methodName ?? description ?? "fillInputByTestId", [testId]);
+    const locator = this.locatorByTestId(testId, description).filter({ visible: true }).first();
+    const afterClick = this.getAfterPointerClick();
+    await this.pointer.animateCursorToElementAndClickAndFill(locator, text, true, 200, annotationText, afterClick ? { afterClick } : undefined);
   }
 
   /**
@@ -586,45 +681,32 @@ export class BasePage {
   protected async selectVSelectByTestId(
     testId: string,
     value: string,
-    timeOut: number = 500,
     annotationText: string = "",
     description?: string,
+    action?: { componentName?: string; methodName: string },
   ): Promise<void> {
-    const root = this.locatorByTestId(testId, description);
+    this.recordPomAction(action?.componentName, action?.methodName ?? description ?? "selectVSelectByTestId", [testId]);
+    const root = this.locatorByTestId(testId, description).filter({ visible: true }).first();
     const input = root.locator("input");
 
     await this.pointer.animateCursorToElement(input, false, 200, annotationText);
-    await input.click({ force: true });
+    await input.click();
     await this.pointer.animateCursorToElementAndClickAndFill(input, value, false, 200, annotationText);
-    await this.page.waitForTimeout(timeOut);
 
     const option = root.locator("ul.vs__dropdown-menu li[role='option']").first();
-    if (await option.count()) {
-      await this.pointer.animateCursorToElement(option, true, 200, annotationText, {
-        afterClick: async ({ testId: clickedTestId, instrumented }: AfterPointerClickInfo) => {
-          if (!clickedTestId || !instrumented) return;
-          await this.waitForTestIdClickEventAfter(clickedTestId);
-        },
-      });
-    }
+    await option.waitFor({ state: "visible", timeout: 5_000 });
+    const afterClick = this.getAfterPointerClick();
+    await this.pointer.animateCursorToElement(option, true, 200, annotationText, afterClick ? { afterClick } : undefined);
   }
 
   public async fillInputByLocator(locator: PwLocator, text: string, annotationText: string = ""): Promise<void> {
-    await this.pointer.animateCursorToElementAndClickAndFill(locator, text, true, 200, annotationText, {
-      afterClick: async ({ testId: clickedTestId, instrumented }: AfterPointerClickInfo) => {
-        if (!clickedTestId || !instrumented) return;
-        await this.waitForTestIdClickEventAfter(clickedTestId);
-      },
-    });
+    const afterClick = this.getAfterPointerClick();
+    await this.pointer.animateCursorToElementAndClickAndFill(locator, text, true, 200, annotationText, afterClick ? { afterClick } : undefined);
   }
 
   protected async clickByAriaLabel(ariaLabel: string, annotationText: string = ""): Promise<void> {
-    await this.pointer.animateCursorToElement(`[aria-label="${ariaLabel}"]`, true, 200, annotationText, {
-      afterClick: async ({ testId: clickedTestId, instrumented }: AfterPointerClickInfo) => {
-        if (!clickedTestId || !instrumented) return;
-        await this.waitForTestIdClickEventAfter(clickedTestId);
-      },
-    });
+    const afterClick = this.getAfterPointerClick();
+    await this.pointer.animateCursorToElement(`[aria-label="${ariaLabel}"]`, true, 200, annotationText, afterClick ? { afterClick } : undefined);
   }
 
   /**
@@ -642,7 +724,7 @@ export class BasePage {
    * @returns True if the element is visible, false otherwise
    */
   protected async isVisibleByTestId(testId: string): Promise<boolean> {
-    return await this.page.isVisible(this.selectorForTestId(testId));
+    return this.locatorByTestId(testId).isVisible();
   }
 
   /**
@@ -651,18 +733,18 @@ export class BasePage {
    * @returns The text content of the element
    */
   protected async getTextByTestId(testId: string): Promise<string | null> {
-    return await this.page.textContent(this.selectorForTestId(testId));
+    return this.locatorByTestId(testId).textContent();
   }
 
   /**
    * Waits for an element with the specified data-testid to be visible
    * @param testId The data-testid of the element to wait for
    * @param options Optional timeout and other options
-   * @param options.timeout The maximum time to wait for the element to be visible (default is 3000ms)
+   * @param options.timeout The maximum time to wait for the element to be visible (default is 5000ms)
    * @returns A promise that resolves when the element is visible
    */
   protected async waitForTestId(testId: string, options?: { timeout?: number }): Promise<void> {
-    await this.page.waitForSelector(this.selectorForTestId(testId), options);
+    await this.locatorByTestId(testId).waitFor({ state: "visible", timeout: options?.timeout ?? 5_000 });
   }
 
   /**
@@ -670,9 +752,9 @@ export class BasePage {
    * @param testId The data-testid of the element to hover over
    */
   protected async hoverByTestId(testId: string): Promise<void> {
-    const selector = this.selectorForTestId(testId);
-    await this.pointer.animateCursorToElement(selector, false, 200, "");
-    await this.page.hover(selector);
+    const locator = this.locatorByTestId(testId);
+    await this.pointer.animateCursorToElement(locator, false, 200, "");
+    await locator.hover();
   }
 
   /**
@@ -681,6 +763,6 @@ export class BasePage {
    * @param value The value to select
    */
   protected async selectByTestId(testId: string, value: string): Promise<void> {
-    await this.page.selectOption(this.selectorForTestId(testId), value);
+    await this.locatorByTestId(testId).selectOption(value);
   }
 }

--- a/class-generation/diagnostics.ts
+++ b/class-generation/diagnostics.ts
@@ -1,0 +1,559 @@
+import { writeFile } from "node:fs/promises";
+import type { TestInfo } from "@playwright/test";
+import type { BrowserContext, Page } from "playwright";
+
+export const POM_FAILURE_ATTACHMENT_NAME = "vue-pom-generator.failure";
+export const POM_FAILURE_SCREENSHOT_ATTACHMENT_NAME = "vue-pom-generator.screenshot";
+
+const DEFAULT_CAPTURE_BUDGET_MS = 5_000;
+const MAX_BUFFERED_EVENTS = 100;
+const MAX_TEXT_LENGTH = 2_000;
+const MAX_HTTP_FAILURES = 20;
+const MAX_HTTP_FAILURE_BODY_LENGTH = 8_000;
+const HTTP_FAILURE_BODY_SETTLE_BUDGET_MS = 500;
+const POM_ACTIVE_ACTION_REGISTRY = Symbol.for("@immense/vue-pom-generator.active-action-registry");
+
+export interface PomManifestParameter {
+  name: string;
+  typeExpression?: string;
+  type?: string;
+  initializer?: string;
+  hasQuestionToken?: boolean;
+  isRestParameter?: boolean;
+}
+
+export interface PomManifestMethod {
+  name: string;
+  kind: "action" | "locator";
+  parameters: readonly PomManifestParameter[];
+}
+
+export interface PomManifestEntry {
+  testId: string;
+  selectorPatternKind: "static" | "parameterized";
+  generatedMethods: readonly PomManifestMethod[];
+  targetPageObjectModelClass?: string;
+}
+
+export interface PomManifestComponent {
+  componentName: string;
+  className: string;
+  sourceFile: string;
+  kind: "component" | "view";
+  entries: readonly PomManifestEntry[];
+}
+
+export type PomManifest = Readonly<Record<string, PomManifestComponent>>;
+
+export interface PomActiveAction {
+  componentName?: string;
+  methodName: string;
+  expectedTestIds: readonly string[];
+}
+
+export interface PomRenderedElement {
+  testId: string;
+  tag: string;
+  role: string | null;
+  name: string | null;
+  visible: boolean;
+  enabled: boolean;
+}
+
+export interface PomMethodAvailability {
+  methodName: string;
+  kind: "action" | "locator";
+  signature: string;
+  expectedTestIds: string[];
+  state: "present" | "hidden" | "disabled" | "absent";
+}
+
+export interface PomComponentAvailability {
+  componentName: string;
+  className: string;
+  sourceFile: string;
+  matchedTestIds: number;
+  methods: PomMethodAvailability[];
+}
+
+export interface PomPageFailureSnapshot {
+  url: string;
+  title: string | null;
+  closed: boolean;
+  ariaSnapshot: string | null;
+  ariaSnapshotError?: string;
+  renderedElements: PomRenderedElement[];
+  component: PomComponentAvailability | null;
+  routerNavigation?: PomRouterNavigationSnapshot | null;
+  screenshotPath?: string;
+  captureErrors: string[];
+}
+
+export interface PomRouterNavigationSnapshot {
+  id: number;
+  status: "pending" | "succeeded" | "failed";
+  stage: "waiting-for-router-ready" | "pushing-route" | "complete";
+  targetName: string;
+  error?: string;
+}
+
+export interface PomFailureDiagnostics {
+  schemaVersion: 1;
+  capturedAt: string;
+  captureBudgetMs: number;
+  activeAction: PomActiveAction | null;
+  pages: PomPageFailureSnapshot[];
+  console: string[];
+  pageErrors: string[];
+  networkFailures: string[];
+  httpFailures?: PomHttpFailure[];
+  pendingRequests?: string[];
+  jsonPath: string;
+}
+
+export interface PomHttpFailure {
+  status: number;
+  method: string;
+  url: string;
+  contentType: string | null;
+  body?: string;
+  bodyCaptureError?: string;
+}
+
+export type PomDiagnosticsTestInfo = Pick<TestInfo, "attach" | "outputPath">;
+
+export interface PomFailureDiagnosticsOptions {
+  captureBudgetMs?: number;
+  testIdAttribute?: string;
+}
+
+export interface PomFailureDiagnosticsCapture {
+  capture: () => Promise<PomFailureDiagnostics>;
+}
+
+interface EventBuffers {
+  console: string[];
+  pageErrors: string[];
+  networkFailures: string[];
+  httpFailures: PomHttpFailure[];
+  httpFailureBodyCaptures: Set<Promise<void>>;
+  pendingRequests: Map<object, { method: string; resourceType: string; startedAt: number; url: string }>;
+}
+
+function pushBounded(buffer: string[], value: string): void {
+  buffer.push(value.slice(0, MAX_TEXT_LENGTH));
+  if (buffer.length > MAX_BUFFERED_EVENTS) {
+    buffer.splice(0, buffer.length - MAX_BUFFERED_EVENTS);
+  }
+}
+
+function pushHttpFailureBounded(buffer: PomHttpFailure[], value: PomHttpFailure): void {
+  buffer.push(value);
+  if (buffer.length > MAX_HTTP_FAILURES) {
+    buffer.splice(0, buffer.length - MAX_HTTP_FAILURES);
+  }
+}
+
+function truncateText(value: string, maximum: number): string {
+  if (value.length <= maximum) return value;
+  return `${value.slice(0, maximum)}\n… truncated ${value.length - maximum} characters …`;
+}
+
+function formatNetworkUrl(value: string): string {
+  if (value.length <= 500) return value;
+
+  try {
+    const parsed = new URL(value);
+    return `${parsed.origin}${parsed.pathname}${parsed.search ? "?…" : ""}`;
+  }
+  catch {
+    return `${value.slice(0, 497)}…`;
+  }
+}
+
+function errorMessage<T>(error: T): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function patternToRegExp(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^${escaped.replace(/\\\$\\\{[^}]+\\\}/g, ".+")}$`);
+}
+
+function matchesTestId(pattern: string, actual: string): boolean {
+  return pattern.includes("${") ? patternToRegExp(pattern).test(actual) : pattern === actual;
+}
+
+function formatMethodSignature(method: PomManifestMethod): string {
+  const parameters = method.parameters.map((parameter) => {
+    const rest = parameter.isRestParameter ? "..." : "";
+    const optional = parameter.hasQuestionToken ? "?" : "";
+    // Normalized manifest parameters retain the original typeExpression for
+    // provenance, but it may also contain the initializer (for example
+    // `string = ""`). Prefer the split type to avoid printing it twice.
+    const type = parameter.type ?? parameter.typeExpression ?? "unknown";
+    const initializer = parameter.initializer === undefined ? "" : ` = ${parameter.initializer}`;
+    return `${rest}${parameter.name}${optional}: ${type}${initializer}`;
+  });
+  return `${method.name}(${parameters.join(", ")})`;
+}
+
+function availabilityState(elements: readonly PomRenderedElement[]): PomMethodAvailability["state"] {
+  if (!elements.length) return "absent";
+  if (!elements.some(element => element.visible)) return "hidden";
+  if (!elements.some(element => element.visible && element.enabled)) return "disabled";
+  return "present";
+}
+
+function buildComponentAvailability(
+  manifest: PomManifest,
+  renderedElements: readonly PomRenderedElement[],
+  activeComponentName?: string,
+): PomComponentAvailability | null {
+  const renderedTestIds = Array.from(new Set(renderedElements.map(element => element.testId)));
+  const candidates = Object.values(manifest).map((component) => ({
+    component,
+    matchedTestIds: renderedTestIds.filter(actual => component.entries.some(entry => matchesTestId(entry.testId, actual))).length,
+  }));
+  candidates.sort((a, b) => b.matchedTestIds - a.matchedTestIds
+    || Number(b.component.kind === "view") - Number(a.component.kind === "view")
+    || a.component.componentName.localeCompare(b.component.componentName));
+
+  const activeCandidate = candidates.find(candidate => candidate.component.componentName === activeComponentName);
+  const selected = activeCandidate ?? candidates[0];
+  if (!selected || (selected.matchedTestIds === 0 && !activeCandidate)) return null;
+
+  const methods = new Map<string, { method: PomManifestMethod; testIds: Set<string> }>();
+  for (const entry of selected.component.entries) {
+    for (const method of entry.generatedMethods) {
+      const key = `${method.kind}:${method.name}`;
+      const current = methods.get(key) ?? { method, testIds: new Set<string>() };
+      current.testIds.add(entry.testId);
+      methods.set(key, current);
+    }
+  }
+
+  return {
+    componentName: selected.component.componentName,
+    className: selected.component.className,
+    sourceFile: selected.component.sourceFile,
+    matchedTestIds: selected.matchedTestIds,
+    methods: Array.from(methods.values())
+      .map(({ method, testIds }) => {
+        const expectedTestIds = Array.from(testIds).sort((a, b) => a.localeCompare(b));
+        const matchingElements = renderedElements.filter(element => expectedTestIds.some(pattern => matchesTestId(pattern, element.testId)));
+        return {
+          methodName: method.name,
+          kind: method.kind,
+          signature: formatMethodSignature(method),
+          expectedTestIds,
+          state: availabilityState(matchingElements),
+        } satisfies PomMethodAvailability;
+      })
+      .sort((a, b) => a.methodName.localeCompare(b.methodName)),
+  };
+}
+
+function remainingMilliseconds(deadline: number): number {
+  return Math.max(0, deadline - Date.now());
+}
+
+async function withinBudget<T>(deadline: number, operation: () => Promise<T>): Promise<T> {
+  const remaining = remainingMilliseconds(deadline);
+  if (remaining <= 0) throw new Error("diagnostic capture budget exhausted");
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation(),
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error("diagnostic capture budget exhausted")), remaining);
+      }),
+    ]);
+  }
+  finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function installPageListeners(page: Page, buffers: EventBuffers): void {
+  page.on("console", message => pushBounded(buffers.console, `[${message.type()}] ${message.text()}`));
+  page.on("pageerror", error => pushBounded(buffers.pageErrors, errorMessage(error)));
+  page.on("request", (request) => {
+    buffers.pendingRequests.set(request, {
+      method: request.method(),
+      resourceType: request.resourceType(),
+      startedAt: Date.now(),
+      url: request.url(),
+    });
+  });
+  page.on("requestfinished", request => buffers.pendingRequests.delete(request));
+  page.on("requestfailed", (request) => {
+    buffers.pendingRequests.delete(request);
+    const failure = request.failure()?.errorText ?? "request failed";
+    pushBounded(buffers.networkFailures, `${request.method()} ${formatNetworkUrl(request.url())} — ${failure}`);
+  });
+  page.on("response", (response) => {
+    if (response.status() >= 400) {
+      pushBounded(buffers.networkFailures, `${response.status()} ${response.request().method()} ${formatNetworkUrl(response.url())}`);
+      const failure: PomHttpFailure = {
+        status: response.status(),
+        method: response.request().method(),
+        url: formatNetworkUrl(response.url()),
+        contentType: response.headers()["content-type"] ?? null,
+      };
+      pushHttpFailureBounded(buffers.httpFailures, failure);
+
+      const capture: Promise<void> = response.text()
+        .then((body) => {
+          if (body) failure.body = truncateText(body, MAX_HTTP_FAILURE_BODY_LENGTH);
+        })
+        .catch((error) => {
+          failure.bodyCaptureError = errorMessage(error);
+        })
+        .finally(() => buffers.httpFailureBodyCaptures.delete(capture));
+      buffers.httpFailureBodyCaptures.add(capture);
+    }
+  });
+}
+
+async function settleHttpFailureBodies(buffers: EventBuffers, deadline: number): Promise<void> {
+  const captures = Array.from(buffers.httpFailureBodyCaptures);
+  if (!captures.length) return;
+
+  const waitMs = Math.min(HTTP_FAILURE_BODY_SETTLE_BUDGET_MS, remainingMilliseconds(deadline));
+  if (waitMs <= 0) return;
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      Promise.allSettled(captures),
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, waitMs);
+      }),
+    ]);
+  }
+  finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function captureRenderedElements(
+  page: Page,
+  testIdAttribute: string,
+): Promise<{ title: string; elements: PomRenderedElement[]; routerNavigation: PomRouterNavigationSnapshot | null }> {
+  return page.evaluate(({ attribute, routerGlobalName }) => {
+    const elements = Array.from(document.querySelectorAll(`[${CSS.escape(attribute)}]`));
+    const isVisibleElement = (candidate: HTMLElement) => {
+      const style = getComputedStyle(candidate);
+      const rect = candidate.getBoundingClientRect();
+      return style.display !== "none"
+        && style.visibility !== "hidden"
+        && Number.parseFloat(style.opacity || "1") > 0
+        && rect.width > 0
+        && rect.height > 0;
+    };
+    const rendered = elements.map((element) => {
+      const htmlElement = element as HTMLElement;
+      const disabled = ("disabled" in htmlElement && Boolean((htmlElement as HTMLButtonElement).disabled))
+        || htmlElement.getAttribute("aria-disabled") === "true";
+      const text = htmlElement.textContent?.replace(/\s+/g, " ").trim();
+      const inputType = htmlElement instanceof HTMLInputElement ? htmlElement.type.toLowerCase() : "";
+      const labels = htmlElement instanceof HTMLInputElement ? Array.from(htmlElement.labels ?? []) : [];
+      const labelText = labels.length
+        ? labels
+          .map(label => label.textContent?.replace(/\s+/g, " ").trim())
+          .filter((value): value is string => Boolean(value))
+          .join(" ")
+        : "";
+      const visible = isVisibleElement(htmlElement)
+        || ((inputType === "checkbox" || inputType === "radio") && labels.some(label => isVisibleElement(label)));
+      const role = htmlElement.getAttribute("role")
+        ?? (htmlElement.tagName === "BUTTON" ? "button" : null)
+        ?? (htmlElement.tagName === "A" && htmlElement.hasAttribute("href") ? "link" : null)
+        ?? (inputType === "checkbox" || inputType === "radio" ? inputType : null)
+        ?? (htmlElement.tagName === "TEXTAREA" || (htmlElement.tagName === "INPUT" && inputType !== "hidden") ? "textbox" : null)
+        ?? (htmlElement.tagName === "SELECT" ? "combobox" : null);
+      const name = htmlElement.getAttribute("aria-label")
+        ?? htmlElement.getAttribute("title")
+        ?? (labelText || null)
+        ?? (text ? text.slice(0, 160) : null);
+      return {
+        testId: htmlElement.getAttribute(attribute) ?? "",
+        tag: htmlElement.tagName.toLowerCase(),
+        role,
+        name,
+        visible,
+        enabled: !disabled,
+      };
+    }).filter(element => element.testId.length > 0);
+
+    const routerBridge = Reflect.get(globalThis, routerGlobalName) as
+      | { navigation?: PomRouterNavigationSnapshot }
+      | undefined;
+    const rawNavigation = routerBridge?.navigation;
+    const routerNavigation = rawNavigation
+      ? {
+          id: rawNavigation.id,
+          status: rawNavigation.status,
+          stage: rawNavigation.stage,
+          targetName: rawNavigation.targetName,
+          ...(rawNavigation.error ? { error: rawNavigation.error } : {}),
+        }
+      : null;
+
+    return { title: document.title, elements: rendered, routerNavigation };
+  }, { attribute: testIdAttribute, routerGlobalName: "__vuePomGeneratorRouter" });
+}
+
+async function capturePage(
+  page: Page,
+  pageIndex: number,
+  manifest: PomManifest,
+  testInfo: PomDiagnosticsTestInfo,
+  testIdAttribute: string,
+  deadline: number,
+  activeAction: PomActiveAction | null,
+): Promise<PomPageFailureSnapshot> {
+  const captureErrors: string[] = [];
+  const snapshot: PomPageFailureSnapshot = {
+    url: page.url(),
+    title: null,
+    closed: page.isClosed(),
+    ariaSnapshot: null,
+    renderedElements: [],
+    component: null,
+    routerNavigation: null,
+    captureErrors,
+  };
+  if (snapshot.closed) return snapshot;
+
+  try {
+    const rendered = await withinBudget(deadline, () => captureRenderedElements(page, testIdAttribute));
+    snapshot.title = rendered.title;
+    snapshot.renderedElements = rendered.elements;
+    snapshot.component = buildComponentAvailability(manifest, rendered.elements, activeAction?.componentName);
+    snapshot.routerNavigation = rendered.routerNavigation;
+  }
+  catch (error) {
+    captureErrors.push(`DOM inventory: ${errorMessage(error)}`);
+  }
+
+  try {
+    snapshot.ariaSnapshot = await withinBudget(deadline, () => page.locator("body").ariaSnapshot({
+      timeout: remainingMilliseconds(deadline),
+    }));
+  }
+  catch (error) {
+    snapshot.ariaSnapshotError = errorMessage(error);
+  }
+
+  if (pageIndex === 0 && remainingMilliseconds(deadline) > 0) {
+    const screenshotPath = testInfo.outputPath("vue-pom-generator-failure.png");
+    try {
+      await withinBudget(deadline, () => page.screenshot({
+        path: screenshotPath,
+        fullPage: true,
+        timeout: remainingMilliseconds(deadline),
+      }));
+      await testInfo.attach(POM_FAILURE_SCREENSHOT_ATTACHMENT_NAME, { path: screenshotPath, contentType: "image/png" });
+      snapshot.screenshotPath = screenshotPath;
+    }
+    catch (error) {
+      captureErrors.push(`Screenshot: ${errorMessage(error)}`);
+    }
+  }
+
+  return snapshot;
+}
+
+export function recordPomAction(page: object, action: PomActiveAction): void {
+  const globalRecord = globalThis as typeof globalThis & {
+    [POM_ACTIVE_ACTION_REGISTRY]?: WeakMap<object, PomActiveAction>;
+  };
+  const registry = globalRecord[POM_ACTIVE_ACTION_REGISTRY] ?? new WeakMap<object, PomActiveAction>();
+  globalRecord[POM_ACTIVE_ACTION_REGISTRY] = registry;
+  registry.set(page, {
+    ...action,
+    expectedTestIds: [...action.expectedTestIds],
+  });
+}
+
+export function getActivePomAction(page: object): PomActiveAction | null {
+  const globalRecord = globalThis as typeof globalThis & {
+    [POM_ACTIVE_ACTION_REGISTRY]?: WeakMap<object, PomActiveAction>;
+  };
+  return globalRecord[POM_ACTIVE_ACTION_REGISTRY]?.get(page) ?? null;
+}
+
+export function installPomFailureDiagnostics(
+  page: Page,
+  manifest: PomManifest,
+  testInfo: PomDiagnosticsTestInfo,
+  options: PomFailureDiagnosticsOptions = {},
+): PomFailureDiagnosticsCapture {
+  const context: BrowserContext = page.context();
+  const pages = new Set<Page>();
+  const buffers: EventBuffers = {
+    console: [],
+    pageErrors: [],
+    networkFailures: [],
+    httpFailures: [],
+    httpFailureBodyCaptures: new Set(),
+    pendingRequests: new Map(),
+  };
+  let captured: Promise<PomFailureDiagnostics> | null = null;
+
+  const registerPage = (candidate: Page) => {
+    if (pages.has(candidate)) return;
+    pages.add(candidate);
+    installPageListeners(candidate, buffers);
+  };
+  for (const existingPage of context.pages()) registerPage(existingPage);
+  context.on("page", registerPage);
+
+  return {
+    capture() {
+      if (captured) return captured;
+      captured = (async () => {
+        const captureBudgetMs = options.captureBudgetMs ?? DEFAULT_CAPTURE_BUDGET_MS;
+        const deadline = Date.now() + captureBudgetMs;
+        await settleHttpFailureBodies(buffers, deadline);
+        const activeAction = getActivePomAction(page);
+        const pageSnapshots: PomPageFailureSnapshot[] = [];
+        for (const [index, candidate] of Array.from(pages).entries()) {
+          pageSnapshots.push(await capturePage(
+            candidate,
+            index,
+            manifest,
+            testInfo,
+            options.testIdAttribute ?? "data-testid",
+            deadline,
+            activeAction,
+          ));
+        }
+
+        const jsonPath = testInfo.outputPath("vue-pom-generator-failure.json");
+        const diagnostics: PomFailureDiagnostics = {
+          schemaVersion: 1,
+          capturedAt: new Date().toISOString(),
+          captureBudgetMs,
+          activeAction,
+          pages: pageSnapshots,
+          console: [...buffers.console],
+          pageErrors: [...buffers.pageErrors],
+          networkFailures: [...buffers.networkFailures],
+          httpFailures: buffers.httpFailures.map(failure => ({ ...failure })),
+          pendingRequests: Array.from(buffers.pendingRequests.values())
+            .map(request => `${request.method} ${request.resourceType} ${formatNetworkUrl(request.url)} — pending ${Date.now() - request.startedAt}ms`)
+            .slice(-MAX_BUFFERED_EVENTS),
+          jsonPath,
+        };
+        await writeFile(jsonPath, `${JSON.stringify(diagnostics, null, 2)}\n`, "utf8");
+        await testInfo.attach(POM_FAILURE_ATTACHMENT_NAME, { path: jsonPath, contentType: "application/json" });
+        return diagnostics;
+      })();
+      return captured;
+    },
+  };
+}

--- a/class-generation/index.ts
+++ b/class-generation/index.ts
@@ -9,6 +9,8 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { generateViewObjectModelMembers, generateViewObjectModelMethodContent } from "../method-generation";
+import { generatePomManifestModule } from "../manifest-generator";
+import type { ElementMetadata } from "../metadata-collector";
 import {
   createPomMethodSignature,
   createPomParameterSpec,
@@ -469,12 +471,14 @@ function generateGoToMethod(componentName: string, routeMeta: RouteMeta | null):
         parameters: hasQuery ? [{ name: "params", type: paramType, hasQuestionToken: true }] : [],
         statements: route.name !== null
           ? createRouterNavigationWriter({
+              componentName,
               routeName: { kind: "single", target: route.name },
               input: hasQuery ? { identifier: "params", optional: true } : undefined,
               pathParamNames: [],
               queryNames: route.query,
             })
           : createUrlNavigationWriter({
+              componentName,
               routeTemplate: { kind: "single", target: route.template },
               input: hasQuery ? { identifier: "params", optional: true } : undefined,
               pathParams: [],
@@ -499,12 +503,14 @@ function generateGoToMethod(componentName: string, routeMeta: RouteMeta | null):
         parameters: [{ name: "params", type: paramType, hasQuestionToken: allOptional }],
         statements: route.name !== null
           ? createRouterNavigationWriter({
+              componentName,
               routeName: { kind: "single", target: route.name },
               input: { identifier: "params", optional: allOptional },
               pathParamNames: route.params.map(param => param.name),
               queryNames: route.query,
             })
           : createUrlNavigationWriter({
+              componentName,
               routeTemplate: { kind: "single", target: route.template },
               input: { identifier: "params", optional: allOptional },
               pathParams: route.params,
@@ -542,6 +548,7 @@ function generateGoToMethod(componentName: string, routeMeta: RouteMeta | null):
       parameters: [{ name: "params", type: implementationType, hasQuestionToken: true }],
       statements: usePush
         ? createRouterNavigationWriter({
+            componentName,
             routeName: {
               kind: "dual",
               parametrizedTarget: requireRouteName(parametrizedRoute),
@@ -553,6 +560,7 @@ function generateGoToMethod(componentName: string, routeMeta: RouteMeta | null):
             queryNames: hasQuery ? queryNames : [],
           })
         : createUrlNavigationWriter({
+            componentName,
             routeTemplate: {
               kind: "dual",
               parametrizedTarget: parametrizedRoute.template,
@@ -611,7 +619,7 @@ function generateExtraClickMethodMembers(spec: PomExtraClickMethodSpec, componen
           for (const statement of testIdBinding.setupStatements) {
             writer.writeLine(statement);
           }
-          writer.writeLine(`await this.clickByTestId(${testIdBinding.expression}, ${annotationArg}, ${waitArg}, ${locatorDescription});`);
+          writer.writeLine(`await this.clickByTestId(${testIdBinding.expression}, ${annotationArg}, ${waitArg}, ${locatorDescription}, { componentName: ${JSON.stringify(componentName)}, methodName: ${JSON.stringify(spec.name)} });`);
         },
       }),
     ];
@@ -634,7 +642,7 @@ function generateExtraClickMethodMembers(spec: PomExtraClickMethodSpec, componen
         for (const statement of labelBinding.setupStatements) {
           writer.writeLine(statement);
         }
-        writer.writeLine(`await this.clickWithinTestIdByLabel(${rootBinding.expression}, ${labelBinding.expression}, ${annotationArg}, ${waitArg}, { description: ${locatorDescription} });`);
+        writer.writeLine(`await this.clickWithinTestIdByLabel(${rootBinding.expression}, ${labelBinding.expression}, ${annotationArg}, ${waitArg}, { description: ${locatorDescription}, componentName: ${JSON.stringify(componentName)}, methodName: ${JSON.stringify(spec.name)} });`);
       },
     }),
   ];
@@ -808,6 +816,9 @@ export interface GenerateFilesOptions {
   layoutDirs?: string[];
 
   routeMetaByComponent?: Record<string, RouteMeta>;
+
+  /** Metadata used by the generated Node-importable POM discoverability manifest. */
+  elementMetadata?: Map<string, Map<string, ElementMetadata>>;
 }
 
 interface BaseGenerateContentOptions {
@@ -872,6 +883,7 @@ export async function generateFiles(
     componentDirs,
     layoutDirs,
     routeMetaByComponent: routeMetaByComponentOverride,
+    elementMetadata = new Map<string, Map<string, ElementMetadata>>(),
   } = options;
 
   const emitLanguages: Array<"ts" | "csharp"> = emitLanguagesOverride?.length
@@ -925,13 +937,15 @@ export async function generateFiles(
       writeGeneratedFile(file);
     }
 
-    const fixtureRegistryFile = maybeGenerateFixtureRegistry(emittableComponentHierarchyMap, {
+    const fixtureRegistryFiles = maybeGenerateFixtureRegistry(emittableComponentHierarchyMap, {
       generateFixtures,
       pomOutDir: outDir,
       projectRoot,
       customPomDir,
+      elementMetadata,
+      testIdAttribute,
     });
-    if (fixtureRegistryFile) {
+    for (const fixtureRegistryFile of fixtureRegistryFiles) {
       writeGeneratedFile(fixtureRegistryFile);
     }
   }
@@ -1540,11 +1554,13 @@ function maybeGenerateFixtureRegistry(
     pomOutDir: string;
     projectRoot?: string;
     customPomDir?: string;
+    elementMetadata: Map<string, Map<string, ElementMetadata>>;
+    testIdAttribute?: string;
   },
-): GeneratedFileOutput | null {
+): GeneratedFileOutput[] {
   const { generateFixtures, pomOutDir } = options;
   if (!generateFixtures)
-    return null;
+    return [];
 
   // generateFixtures accepts:
   // - true: enable fixtures with defaults
@@ -1576,6 +1592,10 @@ function maybeGenerateFixtureRegistry(
   const pomDirAbs = path.isAbsolute(pomOutDir) ? pomOutDir : path.resolve(root, pomOutDir);
 
   const pomImport = toPosixRelativePath(fixtureOutDirAbs, pomDirAbs);
+  const diagnosticsImport = stripExtension(toPosixRelativePath(
+    fixtureOutDirAbs,
+    path.join(pomDirAbs, "_pom-runtime", "class-generation", "diagnostics.ts"),
+  ));
 
   const viewClassNames = Array.from(componentHierarchyMap.entries())
     .filter(([, deps]) => !!deps.isView)
@@ -1591,6 +1611,7 @@ function maybeGenerateFixtureRegistry(
     "request",
     // Our own fixtureOptions
     "animation",
+    "pomDiagnostics",
   ]);
 
   const viewFixtureNames = new Set(viewClassNames.map(name => lowerFirst(name)));
@@ -1653,12 +1674,26 @@ function maybeGenerateFixtureRegistry(
       namedImports: [
         { name: "Page", alias: "PwPage" },
         "PlaywrightTestArgs",
+        "TestInfo",
         "TestType",
       ],
+    });
+    addNamedImport(sourceFile, {
+      moduleSpecifier: diagnosticsImport,
+      namedImports: ["installPomFailureDiagnostics"],
+    });
+    addNamedImport(sourceFile, {
+      moduleSpecifier: diagnosticsImport,
+      isTypeOnly: true,
+      namedImports: ["PomFailureDiagnosticsOptions"],
     });
     sourceFile.addImportDeclaration({
       namespaceImport: "Pom",
       moduleSpecifier: pomImport,
+    });
+    addNamedImport(sourceFile, {
+      moduleSpecifier: "./pom-manifest.g",
+      namedImports: ["pomManifest"],
     });
     for (const entry of overrideCtorEntries) {
       addNamedImport(sourceFile, {
@@ -1673,6 +1708,9 @@ function maybeGenerateFixtureRegistry(
       properties: [{
         name: "animation",
         type: "Pom.PlaywrightAnimationOptions",
+      }, {
+        name: "pomDiagnostics",
+        type: "PomFailureDiagnosticsOptions",
       }],
     });
     sourceFile.addTypeAlias({
@@ -1698,6 +1736,10 @@ function maybeGenerateFixtureRegistry(
     sourceFile.addTypeAlias({
       name: "PomFactoryFixture",
       type: "{ pomFactory: PomFactory }",
+    });
+    sourceFile.addTypeAlias({
+      name: "PomDiagnosticsSetupFixture",
+      type: "{ pomDiagnosticsSetup: void }",
     });
 
     sourceFile.addVariableStatement({
@@ -1748,7 +1790,7 @@ function maybeGenerateFixtureRegistry(
         description: "Every fixture contributed by the generator: the `animation` option, the internal\n"
           + "`pomSetup`/`pomFactory` fixtures, and one fixture per generated page/component POM.",
       }],
-      type: "PlaywrightOptions & PomSetupFixture & PomFactoryFixture & GeneratedPageFixtures & GeneratedComponentFixtures",
+      type: "PlaywrightOptions & PomSetupFixture & PomFactoryFixture & PomDiagnosticsSetupFixture & GeneratedPageFixtures & GeneratedComponentFixtures",
     });
 
     sourceFile.addFunction({
@@ -1802,10 +1844,12 @@ function maybeGenerateFixtureRegistry(
         writer.block(() => {
           writer.writeLine("animation: [{");
           writer.indent(() => {
+            writer.writeLine("enabled: false,");
             writer.writeLine('pointer: { durationMilliseconds: 250, transitionStyle: "ease-in-out", clickDelayMilliseconds: 0 },');
             writer.writeLine("keyboard: { typeDelayMilliseconds: 100 },");
           });
           writer.writeLine("}, { option: true }],");
+          writer.writeLine(`pomDiagnostics: [{ captureBudgetMs: 5_000, testIdAttribute: ${JSON.stringify(options.testIdAttribute ?? "data-testid")} }, { option: true }],`);
           // The fixture callbacks are annotated explicitly rather than relying on
           // contextual typing: `base` is generic here, so TypeScript cannot resolve
           // Playwright's `Fixtures<...>` parameter types and the callbacks would
@@ -1814,6 +1858,20 @@ function maybeGenerateFixtureRegistry(
           writer.indent(() => {
             writer.writeLine("Pom.setPlaywrightAnimationOptions(animation);");
             writer.writeLine("await use();");
+          });
+          writer.writeLine("}, { auto: true }],");
+          writer.writeLine("pomDiagnosticsSetup: [async ({ page, pomDiagnostics }: { page: PwPage; pomDiagnostics: PomFailureDiagnosticsOptions }, use: (r: void) => Promise<void>, testInfo: TestInfo) => {");
+          writer.indent(() => {
+            writer.writeLine("const capture = installPomFailureDiagnostics(page, pomManifest, testInfo, pomDiagnostics);");
+            writer.writeLine("try {");
+            writer.indent(() => writer.writeLine("await use();"));
+            writer.writeLine("} finally {");
+            writer.indent(() => {
+              writer.writeLine("if (testInfo.status !== undefined && testInfo.status !== testInfo.expectedStatus) {");
+              writer.indent(() => writer.writeLine("await capture.capture().catch(() => undefined);"));
+              writer.writeLine("}");
+            });
+            writer.writeLine("}");
           });
           writer.writeLine("}, { auto: true }],");
           writer.writeLine("pomFactory: async ({ page }: { page: PwPage }, use: (r: PomFactory) => Promise<void>) => {");
@@ -1847,10 +1905,32 @@ function maybeGenerateFixtureRegistry(
     }),
   });
 
-  return {
-    filePath: path.resolve(fixtureOutDirAbs, fixtureFileName),
-    content: fixturesContent,
-  };
+  const manifestFileName = "pom-manifest.g.ts";
+  const manifestContent = generatePomManifestModule(
+    componentHierarchyMap,
+    options.elementMetadata,
+    manifestFileName,
+  );
+  const [diagnosticsRuntimeFile] = buildRuntimeGeneratedFilesFromSpecs([{
+    absolutePath: resolvePluginAsset("../class-generation/diagnostics.ts"),
+    description: "diagnostics.ts",
+    outputPath: path.join(pomDirAbs, "_pom-runtime", "class-generation", "diagnostics.ts"),
+  }]);
+  if (!diagnosticsRuntimeFile) {
+    throw new Error("[vue-pom-generator] Failed to generate the Playwright diagnostics runtime.");
+  }
+
+  return [
+    {
+      filePath: path.resolve(fixtureOutDirAbs, fixtureFileName),
+      content: fixturesContent,
+    },
+    {
+      filePath: path.resolve(fixtureOutDirAbs, manifestFileName),
+      content: manifestContent,
+    },
+    diagnosticsRuntimeFile,
+  ];
 
   // No pomFixture is generated; goToSelf is emitted directly on each view POM.
 }
@@ -1895,6 +1975,33 @@ function prepareViewObjectModelClass(
     return match;
   };
 
+  const hasGeneratedPomSurface = (value: string, seen = new Set<string>()): boolean => {
+    const resolvedRef = resolveTrackedComponentRef(value);
+    if (!resolvedRef || seen.has(resolvedRef)) {
+      return false;
+    }
+
+    const resolvedDependencies = componentHierarchyMap.get(resolvedRef);
+    if (!resolvedDependencies) {
+      return false;
+    }
+
+    if (
+      resolvedDependencies.dataTestIdSet.size > 0
+      || (resolvedDependencies.pomExtraMethods?.length ?? 0) > 0
+      || (resolvedDependencies.generatedMethods?.size ?? 0) > 0
+    ) {
+      return true;
+    }
+
+    const nextSeen = new Set(seen);
+    nextSeen.add(resolvedRef);
+    const nestedRefs = resolvedDependencies.usedComponentSet?.size
+      ? resolvedDependencies.usedComponentSet
+      : resolvedDependencies.childrenComponentSet;
+    return Array.from(nestedRefs).some(child => hasGeneratedPomSurface(child, nextSeen));
+  };
+
   const rawComponentRefsForInstances = usedComponentSet?.size
     ? usedComponentSet
     : childrenComponentSet;
@@ -1913,8 +2020,7 @@ function prepareViewObjectModelClass(
     if (isSelfReference(resolvedRef)) {
       continue;
     }
-    const resolvedDependencies = componentHierarchyMap.get(resolvedRef);
-    if (!resolvedDependencies?.dataTestIdSet.size) {
+    if (!hasGeneratedPomSurface(resolvedRef, new Set([componentName]))) {
       continue;
     }
     componentRefsForInstances.add(resolvedRef);
@@ -1973,7 +2079,6 @@ function prepareViewObjectModelClass(
 
   const className = toPascalCaseLocal(componentName);
   const childInstancePropertyNames = Array.from(componentRefsForInstances)
-    .filter(child => componentHierarchyMap.has(child) && componentHierarchyMap.get(child)?.dataTestIdSet.size)
     .map(child => child.split(".vue")[0]);
   const blockedViewPassthroughMethodNames = new Set(
     attachmentsForThisClass
@@ -2107,10 +2212,7 @@ function generateViewObjectModelContent(
 
   for (const child of prepared.componentRefsForInstances) {
     const childName = child.endsWith(".vue") ? child.slice(0, -4) : child;
-    const childDeps = componentHierarchyMap.get(child) ?? componentHierarchyMap.get(childName);
-    if (childDeps?.dataTestIdSet.size) {
-      addGeneratedImport(childName);
-    }
+    addGeneratedImport(childName);
   }
 
   const targetClassNames = Array.from(
@@ -2565,7 +2667,7 @@ function getRuntimeGeneratedAssetSpecs(baseDir: string, basePageClassPath: strin
   const runtimeClassGenSourceDir = resolvePluginAsset("../class-generation");
   const runtimeClassGenFiles = fs.readdirSync(runtimeClassGenSourceDir)
     .filter(file => file.endsWith(".ts"))
-    .filter(file => file !== "base-page.ts" && file !== "index.ts")
+    .filter(file => file !== "base-page.ts" && file !== "diagnostics.ts" && file !== "index.ts")
     .sort((left, right) => left.localeCompare(right));
 
   return [
@@ -3154,7 +3256,7 @@ function getComponentInstances(
   }
 
   childrenComponent.forEach((child) => {
-    if (componentHierarchyMap.has(child) && componentHierarchyMap.get(child)?.dataTestIdSet.size) {
+    if (componentHierarchyMap.has(child)) {
       const childName = child.split(".vue")[0];
       declarations.push(createClassProperty({
         name: childName,
@@ -3191,7 +3293,7 @@ function getConstructor(
       }
 
       childrenComponent.forEach((child) => {
-        if (componentHierarchyMap.has(child) && componentHierarchyMap.get(child)?.dataTestIdSet.size) {
+        if (componentHierarchyMap.has(child)) {
           const childName = child.split(".vue")[0];
           writer.writeLine(`this.${childName} = new ${childName}(page);`);
         }

--- a/class-generation/playwright-types.ts
+++ b/class-generation/playwright-types.ts
@@ -70,7 +70,12 @@ export interface BasePageLocator {
     options?: { force?: boolean; noWaitAfter?: boolean; timeout?: number },
   ): Promise<string[]>;
   type(text: string, options?: { delay?: number; noWaitAfter?: boolean; timeout?: number }): Promise<void>;
-  evaluate<R>(pageFunction: (element: { tagName: string; isContentEditable?: boolean }) => R | Promise<R>): Promise<R>;
+  evaluate<R>(pageFunction: (element: {
+    tagName: string;
+    isContentEditable?: boolean;
+    parentElement?: Element | null;
+    getAnimations?: () => Animation[];
+  }) => R | Promise<R>): Promise<R>;
 }
 
 /**
@@ -88,17 +93,8 @@ export interface BasePageLocator {
  */
 export interface BasePagePage {
   url(): string;
-  goto(url: string, options?: { referer?: string; timeout?: number; waitUntil?: "load" | "domcontentloaded" | "networkidle" | "commit" }): Promise<Response | null>;
+  goto(url: string, options?: { referer?: string; timeout?: number; waitUntil?: "load" | "domcontentloaded" | "commit" }): Promise<Response | null>;
   locator(selector: string, options?: { has?: BasePageLocator; hasNot?: BasePageLocator; hasNotText?: string | RegExp; hasText?: string | RegExp }): BasePageLocator;
-  isVisible(selector: string, options?: { strict?: boolean; timeout?: number }): Promise<boolean>;
-  textContent(selector: string, options?: { strict?: boolean; timeout?: number }): Promise<string | null>;
-  waitForSelector(selector: string, options?: { state?: "attached" | "detached" | "visible" | "hidden"; timeout?: number; strict?: boolean }): Promise<unknown>;
-  hover(selector: string, options?: { force?: boolean; noWaitAfter?: boolean; position?: { x: number; y: number }; strict?: boolean; timeout?: number; trial?: boolean }): Promise<void>;
-  selectOption(
-    selector: string,
-    values: null | string | ReadonlyArray<string> | { value?: string; label?: string; index?: number } | ReadonlyArray<{ value?: string; label?: string; index?: number }>,
-    options?: { force?: boolean; noWaitAfter?: boolean; strict?: boolean; timeout?: number },
-  ): Promise<string[]>;
   waitForTimeout(timeout: number): Promise<void>;
   evaluate<R, Arg = never>(pageFunction: string | ((arg: Arg) => R | Promise<R>), arg?: Arg): Promise<R>;
   readonly keyboard: Keyboard;

--- a/class-generation/pointer.ts
+++ b/class-generation/pointer.ts
@@ -56,7 +56,7 @@ export interface PointerRenderer {
 export interface PlaywrightAnimationOptions {
 	/**
 	 * Set to false to disable all animations and delays. Clicks/fills still happen.
-	 * Default: true
+	 * Default: false
 	 */
 	enabled?: boolean;
 
@@ -99,7 +99,7 @@ export interface PlaywrightAnimationOptions {
 }
 
 let animationOptions: PlaywrightAnimationOptions = {
-	enabled: true,
+	enabled: false,
 	extraDelayMs: 0,
 	pointer: { durationMilliseconds: 250, transitionStyle: "ease-in-out", clickDelayMilliseconds: 0 },
 	keyboard: { typeDelayMilliseconds: 100 },
@@ -107,7 +107,7 @@ let animationOptions: PlaywrightAnimationOptions = {
 
 export function setPlaywrightAnimationOptions(options: PlaywrightAnimationOptions): void {
 	animationOptions = {
-		enabled: options?.enabled ?? true,
+		enabled: options?.enabled ?? false,
 		extraDelayMs: options?.extraDelayMs ?? 0,
 		pointer: {
 			durationMilliseconds: options?.pointer?.durationMilliseconds ?? 250,
@@ -259,6 +259,47 @@ export class Pointer {
 		return trimmed || undefined;
 	}
 
+	/**
+	 * Playwright waits for an element's box to be stable, but a component library can
+	 * still suppress pointer handlers while an ancestor overlay is finishing a CSS
+	 * transition. Wait for finite animations on the target's ancestor chain so the
+	 * generated action observes the same ready state a user sees. Infinite decorative
+	 * animations are ignored, and a stuck finite animation fails within the shared 5s
+	 * interaction budget instead of encouraging consumer-side sleeps.
+	 */
+	private async waitForFiniteAncestorAnimations(locator: PwLocator): Promise<void> {
+		await locator.first().evaluate(async (element) => {
+			const timeoutMs = 5_000;
+			const animations = new Set<Animation>();
+			for (let current: typeof element | Element | null = element; current; current = current.parentElement ?? null) {
+				if (typeof current.getAnimations !== "function") continue;
+				for (const animation of current.getAnimations()) {
+					const iterations = Number(animation.effect?.getComputedTiming().iterations ?? 1);
+					if (animation.playState === "running" && Number.isFinite(iterations)) {
+						animations.add(animation);
+					}
+				}
+			}
+
+			if (animations.size === 0) return;
+
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			try {
+				await Promise.race([
+					Promise.allSettled([...animations].map(animation => animation.finished)),
+					new Promise<never>((_resolve, reject) => {
+						timer = setTimeout(() => {
+							reject(new Error(`[vue-pom-generator] Timed out after ${timeoutMs}ms waiting for click-target animations to finish.`));
+						}, timeoutMs);
+					}),
+				]);
+			}
+			finally {
+				if (timer !== undefined) clearTimeout(timer);
+			}
+		});
+	}
+
 	private async isEditableElement(locator: PwLocator): Promise<boolean> {
 		try {
 			return await locator.first().evaluate((element) => {
@@ -309,32 +350,29 @@ export class Pointer {
 		const locator = this.toLocator(target);
 		const trimmedAnnotationText = annotationText.trim();
 
-		try {
-			await locator.first().scrollIntoViewIfNeeded();
-		}
-		catch {
-			// Element may detach during navigation; let the subsequent action surface the error.
-		}
-
 		const opts = animationOptions;
 		const animEnabled = opts.enabled !== false;
+		if (executeClick) {
+			await this.waitForFiniteAncestorAnimations(locator);
+		}
 
 		if (!animEnabled) {
 			if (trimmedAnnotationText) {
 				await this.callout.showForElement(locator, trimmedAnnotationText);
 			}
-			else {
-				await this.callout.hide();
-			}
 
-			// Fast path: no animations.
+			// Fast path: no animation or presentation DOM work. In ordinary test runs
+			// annotationText is empty, so touching the callout would add a page.evaluate
+			// that can outlive a navigation and obscure the real Playwright failure.
 			const extraDelay = Math.max(0, opts.extraDelayMs ?? 0);
 			if (extraDelay > 0) await this.page.waitForTimeout(extraDelay);
 
 			let clickedTestId: string | undefined;
 			if (executeClick) {
-				try { clickedTestId = await this.getTestId(locator); } catch { /* noop */ }
-				await locator.first().click({ force: true });
+				if (options?.afterClick) {
+					try { clickedTestId = await this.getTestId(locator); } catch { /* noop */ }
+				}
+				await locator.first().click();
 			}
 			if (options?.afterClick) {
 				await options.afterClick({ testId: clickedTestId, instrumented: Boolean(clickedTestId) });
@@ -343,6 +381,13 @@ export class Pointer {
 		}
 
 		// --- Animated path ---
+		try {
+			await locator.first().scrollIntoViewIfNeeded();
+		}
+		catch {
+			// Element may detach during navigation; let the subsequent action surface the error.
+		}
+
 		const moveDurationMs = opts.pointer?.durationMilliseconds ?? 250;
 		const transitionStyle = opts.pointer?.transitionStyle ?? "ease-in-out";
 		const clickDelayMs = opts.pointer?.clickDelayMilliseconds ?? 0;
@@ -404,8 +449,10 @@ export class Pointer {
 				await this.renderer.press(this.page, { durationMilliseconds: pressDur });
 			}
 
-			try { clickedTestId = await this.getTestId(locator); } catch { /* noop */ }
-			await locator.first().click({ delay: clickDelayMs, force: true });
+			if (options?.afterClick) {
+				try { clickedTestId = await this.getTestId(locator); } catch { /* noop */ }
+			}
+			await locator.first().click({ delay: clickDelayMs });
 		}
 
 		if (options?.afterClick) {

--- a/eslint/index.ts
+++ b/eslint/index.ts
@@ -1,5 +1,6 @@
 import type { Rule } from "eslint";
 import type { CallExpression, Expression, MemberExpression } from "estree";
+import playwrightEslint from "eslint-plugin-playwright";
 
 import { noDataTestIdInSpecsRule } from "./no-data-testid-in-specs";
 import { noPageFixtureInSpecsRule } from "./no-page-fixture-in-specs";
@@ -26,7 +27,10 @@ const LOCATOR_ACTIONS = new Set([
 	"dispatchEvent",
 	"press",
 	"selectText",
+	"scrollIntoViewIfNeeded",
 ]);
+
+const RAW_POM_ACTION_HELPERS = new Set(["clickByTestId", "clickLocator"]);
 
 /**
  * Locator chain methods that are transparent for the purposes of this rule —
@@ -78,6 +82,8 @@ export const noRawLocatorActionRule: Rule.RuleModule = {
 			noRawAction:
 				"Use the generated POM method instead of `{{getter}}.{{method}}()`. "
 				+ "Call `click{{getter}}()` / `type{{getter}}(text)` or similar.",
+			noRawPomActionHelper:
+				"Use the generated POM action instead of the low-level `{{method}}()` helper.",
 		},
 		schema: [],
 	},
@@ -89,6 +95,14 @@ export const noRawLocatorActionRule: Rule.RuleModule = {
 				if (callee.computed || callee.property.type !== "Identifier") return;
 
 				const methodName = callee.property.name;
+				if (RAW_POM_ACTION_HELPERS.has(methodName)) {
+					context.report({
+						node,
+						messageId: "noRawPomActionHelper",
+						data: { method: methodName },
+					});
+					return;
+				}
 				if (!LOCATOR_ACTIONS.has(methodName)) return;
 
 				const getterName = getPomGetterName(callee.object as Expression);
@@ -104,15 +118,59 @@ export const noRawLocatorActionRule: Rule.RuleModule = {
 	},
 };
 
-export const plugin = {
-	rules: {
-		"no-data-testid-in-specs": noDataTestIdInSpecsRule,
-		"no-page-fixture-in-specs": noPageFixtureInSpecsRule,
-		"no-raw-locator-action": noRawLocatorActionRule,
-		"no-raw-playwright-apis": noRawPlaywrightApisRule,
-		"remove-existing-test-id-attributes": removeExistingTestIdAttributesRule,
+const rules = {
+	"no-data-testid-in-specs": noDataTestIdInSpecsRule,
+	"no-page-fixture-in-specs": noPageFixtureInSpecsRule,
+	"no-raw-locator-action": noRawLocatorActionRule,
+	"no-raw-playwright-apis": noRawPlaywrightApisRule,
+	"remove-existing-test-id-attributes": removeExistingTestIdAttributesRule,
+};
+
+type FlatConfig = {
+	files?: string[];
+	languageOptions?: Record<string, unknown>;
+	plugins?: Record<string, unknown>;
+	rules?: Record<string, unknown>;
+};
+
+export const plugin: {
+	rules: typeof rules;
+	configs: Record<string, FlatConfig[]>;
+} = {
+	rules,
+	configs: {},
+};
+
+const playwrightRecommended = playwrightEslint.configs["flat/recommended"] as FlatConfig;
+const playwrightFiles = ["**/tests/playwright/**/*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}"];
+
+plugin.configs["flat/recommended"] = [
+	{
+		...playwrightRecommended,
+		files: playwrightFiles,
+		rules: {
+			"playwright/no-force-option": "error",
+			"playwright/no-networkidle": "error",
+			"playwright/no-wait-for-selector": "error",
+			"playwright/no-wait-for-timeout": "error",
+			"playwright/prefer-web-first-assertions": "error",
+		},
 	},
-} satisfies { rules: Record<string, Rule.RuleModule> };
+	{
+		files: playwrightFiles,
+		plugins: {
+			"@immense/vue-pom-generator": plugin,
+		},
+		rules: {
+			"@immense/vue-pom-generator/no-data-testid-in-specs": "error",
+			"@immense/vue-pom-generator/no-page-fixture-in-specs": "error",
+			"@immense/vue-pom-generator/no-raw-locator-action": "error",
+			"@immense/vue-pom-generator/no-raw-playwright-apis": "error",
+		},
+	},
+];
+
+export const recommendedPlaywrightConfig = plugin.configs["flat/recommended"];
 
 export { noPageFixtureInSpecsRule };
 export { noDataTestIdInSpecsRule };

--- a/manifest-generator.ts
+++ b/manifest-generator.ts
@@ -7,11 +7,12 @@ import type { AccessibilityAuditResult } from "./accessibility-audit";
 import { buildAccessibilityAudit } from "./accessibility-audit";
 import type { ElementMetadata } from "./metadata-collector";
 import { buildPomLocatorDescription, humanizePomMethodName } from "./pom-discoverability";
+import type { PomParameterSpec } from "./pom-params";
 import type { IComponentDependencies, IDataTestId, PomExtraClickMethodSpec, PomPrimarySpec } from "./utils";
 import { buildPomGeneratedActionName, buildPomGeneratedPropertyName } from "./utils";
 import { renderSourceFile, VariableDeclarationKind, type WriterFunction } from "./typescript-codegen";
 
-type PomManifestEntry = {
+export type PomManifestEntry = {
   testId: string;
   selectorPatternKind: "static" | "parameterized";
   semanticName: string;
@@ -21,6 +22,11 @@ type PomManifestEntry = {
   generatedPropertyName: string | null;
   generatedActionName: string | null;
   generatedActionNames: string[];
+  generatedMethods: Array<{
+    name: string;
+    kind: "action" | "locator";
+    parameters: PomParameterSpec[];
+  }>;
   emitPrimary: boolean;
   targetPageObjectModelClass?: string;
   sourceTag?: string;
@@ -35,7 +41,7 @@ type PomManifestEntry = {
   hasDynamicText?: boolean;
 };
 
-type PomManifestComponent = {
+export type PomManifestComponent = {
   componentName: string;
   className: string;
   sourceFile: string;
@@ -44,7 +50,7 @@ type PomManifestComponent = {
   entries: PomManifestEntry[];
 };
 
-type PomManifest = Record<string, PomManifestComponent>;
+export type PomManifest = Record<string, PomManifestComponent>;
 
 function matchesPrimarySelector(extraMethod: PomExtraClickMethodSpec, pom: PomPrimarySpec): boolean {
   if (extraMethod.selector.kind !== "testId") {
@@ -76,6 +82,19 @@ function getManifestEntry(
     ...(generatedActionName ? [generatedActionName] : []),
     ...extraActionNames.filter(name => name !== generatedActionName),
   ]));
+  const generatedMethods = [
+    ...(pom && generatedActionName
+      ? [{ name: generatedActionName, kind: "action" as const, parameters: pom.parameters }]
+      : []),
+    ...(pom
+      ? extraMethods
+        .filter(extraMethod => matchesPrimarySelector(extraMethod, pom))
+        .map(extraMethod => ({ name: extraMethod.name, kind: "action" as const, parameters: extraMethod.parameters }))
+      : []),
+    ...(pom
+      ? [{ name: buildPomGeneratedPropertyName(pom), kind: "locator" as const, parameters: pom.parameters }]
+      : []),
+  ].filter((method, index, methods) => methods.findIndex(candidate => candidate.name === method.name && candidate.kind === method.kind) === index);
   const accessibility = buildAccessibilityAudit(metadata, pom?.nativeRole ?? null);
 
   return {
@@ -94,6 +113,7 @@ function getManifestEntry(
     generatedPropertyName: pom ? buildPomGeneratedPropertyName(pom) : null,
     generatedActionName,
     generatedActionNames,
+    generatedMethods,
     emitPrimary: pom?.emitPrimary !== false,
     ...(entry.targetPageObjectModelClass ? { targetPageObjectModelClass: entry.targetPageObjectModelClass } : {}),
     ...(metadata?.tag ? { sourceTag: metadata.tag } : {}),
@@ -215,11 +235,12 @@ export function generateTestIdsModule(
 export function generatePomManifestModule(
   componentHierarchyMap: Map<string, IComponentDependencies>,
   elementMetadata: Map<string, Map<string, ElementMetadata>>,
+  fileName: string = "virtual-pom-manifest.ts",
 ): string {
   const pomManifest = buildPomManifest(componentHierarchyMap, elementMetadata);
 
-  return renderSourceFile("virtual-pom-manifest.ts", (sourceFile) => {
-    sourceFile.addStatements("// Virtual module: richer POM discoverability manifest");
+  return renderSourceFile(fileName, (sourceFile) => {
+    sourceFile.addStatements("// Rich POM discoverability manifest.");
     sourceFile.addVariableStatement({
       declarationKind: VariableDeclarationKind.Const,
       isExported: true,

--- a/method-generation.ts
+++ b/method-generation.ts
@@ -36,6 +36,15 @@ function upperFirst(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
+function generatedActionMetadata(
+  componentName: string | undefined,
+  methodName: string,
+  options: { preferAssociatedLabel?: boolean } = {},
+): string {
+  const preferAssociatedLabel = options.preferAssociatedLabel ? ", preferAssociatedLabel: true" : "";
+  return `{ componentName: ${JSON.stringify(componentName)}, methodName: ${JSON.stringify(methodName)}${preferAssociatedLabel} }`;
+}
+
 function createParameters(params: readonly PomParameterSpec[]): OptionalKind<ParameterDeclarationStructure>[] {
   return toTypeScriptPomParameterStructures(params);
 }
@@ -78,6 +87,7 @@ function createAsyncMethod(
 function generateClickMethod(
   componentName: string | undefined,
   methodName: string,
+  nativeRole: string,
   selector: PomStringPattern,
   alternateSelectors: PomStringPattern[] | undefined,
   parameters: PomParameterSpec[],
@@ -95,6 +105,9 @@ function generateClickMethod(
   const argsForForward = getPomParameterNames(selectorParams).join(", ");
   const alternates = uniquePomStringPatterns(selector, alternateSelectors).slice(1);
   const primaryTestIdExpr = toTypeScriptPomPatternExpression(selector);
+  const actionMetadata = generatedActionMetadata(componentName, name, {
+    preferAssociatedLabel: nativeRole === "checkbox",
+  });
 
   if (alternates.length > 0) {
     const candidatesExpr = [primaryTestIdExpr, ...alternates.map(id => toTypeScriptPomPatternExpression(id))].join(", ");
@@ -112,20 +125,8 @@ function generateClickMethod(
           ],
         (writer) => {
           writer.writeLine(`const candidates = [${candidatesExpr}] as const;`);
-          writer.writeLine("let lastError: unknown;");
-          writer.write("for (const testId of candidates) ").block(() => {
-            writer.writeLine(`const locator = this.locatorByTestId(testId, ${locatorDescription});`);
-            writer.write("try ").block(() => {
-              writer.write("if (await locator.count()) ").block(() => {
-                writer.writeLine("await this.clickLocator(locator, annotationText, wait);");
-                writer.writeLine("return;");
-              });
-            });
-            writer.write("catch (e) ").block(() => {
-              writer.writeLine("lastError = e;");
-            });
-          });
-          writer.writeLine(`throw (lastError instanceof Error) ? lastError : new Error("[pom] Failed to click any candidate locator for ${name}.");`);
+          writer.writeLine(`const locator = await this.resolveVisibleTestIdLocator(candidates, ${locatorDescription}, ${JSON.stringify(name)}, ${JSON.stringify(componentName)});`);
+          writer.writeLine("await this.clickLocator(locator, annotationText, wait);");
         },
     );
 
@@ -153,7 +154,7 @@ function generateClickMethod(
           createInlineParameter("annotationText", { type: "string", initializer: "\"\"" }),
         ],
         (writer) => {
-          writer.writeLine(`await this.clickByTestId(${primaryTestIdExpr}, annotationText, wait, ${locatorDescription});`);
+          writer.writeLine(`await this.clickByTestId(${primaryTestIdExpr}, annotationText, wait, ${locatorDescription}, ${actionMetadata});`);
         },
       ),
       createAsyncMethod(
@@ -174,7 +175,7 @@ function generateClickMethod(
         createInlineParameter("annotationText", { type: "string", initializer: "\"\"" }),
       ],
       (writer) => {
-        writer.writeLine(`await this.clickByTestId(${primaryTestIdExpr}, annotationText, wait, ${locatorDescription});`);
+        writer.writeLine(`await this.clickByTestId(${primaryTestIdExpr}, annotationText, wait, ${locatorDescription}, ${actionMetadata});`);
       },
     ),
     createAsyncMethod(
@@ -205,7 +206,7 @@ function generateRadioMethod(
 
   return [
     createAsyncMethod(name, methodParameters, (writer) => {
-      writer.writeLine(`await this.clickByTestId(${testIdExpr}, annotationText, true, ${locatorDescription});`);
+      writer.writeLine(`await this.clickByTestId(${testIdExpr}, annotationText, true, ${locatorDescription}, ${generatedActionMetadata(componentName, name, { preferAssociatedLabel: true })});`);
     }),
   ];
 }
@@ -231,7 +232,8 @@ function generateSelectMethod(
       createParameters(selectorParams),
       (writer) => {
         writer.writeLine(`const testId = ${testIdExpr};`);
-        writer.writeLine(`const locator = this.locatorByTestId(testId, ${locatorDescription});`);
+        writer.writeLine(`this.recordPomAction(${JSON.stringify(componentName)}, ${JSON.stringify(name)}, [testId]);`);
+        writer.writeLine(`const locator = this.locatorByTestId(testId, ${locatorDescription}).filter({ visible: true }).first();`);
         writer.writeLine("await this.animateCursorToElement(locator, false, 500, annotationText);");
         writer.writeLine("await locator.selectOption(value);");
       },
@@ -251,14 +253,15 @@ function generateVSelectMethod(
     methodName,
     nativeRole: "vselect",
   }));
-  const selectorParams = orderPomPatternParameters(parameters, [selector]);
+  const selectorParams = orderPomPatternParameters(parameters, [selector])
+    .filter(parameter => parameter.name !== "timeOut" && parameter.name !== "timeout");
 
   return [
     createAsyncMethod(
       name,
       createParameters(selectorParams),
       (writer) => {
-        writer.writeLine(`await this.selectVSelectByTestId(${toTypeScriptPomPatternExpression(selector)}, value, timeOut, annotationText, ${locatorDescription});`);
+        writer.writeLine(`await this.selectVSelectByTestId(${toTypeScriptPomPatternExpression(selector)}, value, annotationText, ${locatorDescription}, ${generatedActionMetadata(componentName, name)});`);
       },
     ),
   ];
@@ -283,7 +286,7 @@ function generateTypeMethod(
       name,
       createParameters(selectorParams),
       (writer) => {
-        writer.writeLine(`await this.fillInputByTestId(${toTypeScriptPomPatternExpression(selector)}, text, annotationText, ${locatorDescription});`);
+        writer.writeLine(`await this.fillInputByTestId(${toTypeScriptPomPatternExpression(selector)}, text, annotationText, ${locatorDescription}, ${generatedActionMetadata(componentName, name)});`);
       },
     ),
   ];
@@ -392,20 +395,9 @@ function generateNavigationMethod(args: {
         statements: (writer) => {
           writer.write("return this.fluent(async () => ").block(() => {
             writer.writeLine(`const candidates = [${candidatesExpr}] as const;`);
-            writer.writeLine("let lastError: unknown;");
-            writer.write("for (const testId of candidates) ").block(() => {
-              writer.writeLine(`const locator = this.locatorByTestId(testId, ${locatorDescription});`);
-              writer.write("try ").block(() => {
-                writer.write("if (await locator.count()) ").block(() => {
-                  writer.writeLine("await this.clickLocator(locator);");
-                  writer.writeLine(`return new ${target}(this.page);`);
-                });
-              });
-              writer.write("catch (e) ").block(() => {
-                writer.writeLine("lastError = e;");
-              });
-            });
-            writer.writeLine(`throw (lastError instanceof Error) ? lastError : new Error("[pom] Failed to navigate using any candidate locator for ${methodName}.");`);
+            writer.writeLine(`const locator = await this.resolveVisibleTestIdLocator(candidates, ${locatorDescription}, ${JSON.stringify(methodName)}, ${JSON.stringify(componentName)});`);
+            writer.writeLine("await this.clickLocator(locator);");
+            writer.writeLine(`return new ${target}(this.page);`);
           });
           writer.writeLine(");");
         },
@@ -419,9 +411,10 @@ function generateNavigationMethod(args: {
       parameters: methodParameters,
       returnType: `Fluent<${target}>`,
       statements: (writer) => {
-        writer.write("return this.fluent(async () => ").block(() => {
-          writer.writeLine(`const locator = this.locatorByTestId(${toTypeScriptPomPatternExpression(selector)}, ${locatorDescription});`);
-          writer.writeLine("await this.clickLocator(locator);");
+          writer.write("return this.fluent(async () => ").block(() => {
+            writer.writeLine(`const locator = this.locatorByTestId(${toTypeScriptPomPatternExpression(selector)}, ${locatorDescription});`);
+            writer.writeLine(`this.recordPomAction(${JSON.stringify(componentName)}, ${JSON.stringify(methodName)}, [${toTypeScriptPomPatternExpression(selector)}]);`);
+            writer.writeLine("await this.clickLocator(locator);");
           writer.writeLine(`return new ${target}(this.page);`);
         });
         writer.writeLine(");");
@@ -481,7 +474,7 @@ export function generateViewObjectModelMembers(
     return [...members, ...generateRadioMethod(componentName, baseMethodName || "Radio", selector, parameters)];
   }
 
-  return [...members, ...generateClickMethod(componentName, baseMethodName, selector, alternateSelectors, parameters)];
+  return [...members, ...generateClickMethod(componentName, baseMethodName, nativeRole, selector, alternateSelectors, parameters)];
 }
 
 export function generateViewObjectModelMethodContent(

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",
+        "eslint-plugin-playwright": "^2.11.0",
         "ts-morph": "^27.0.2"
       },
       "devDependencies": {
@@ -35,6 +36,7 @@
       },
       "peerDependencies": {
         "@babel/parser": ">=7",
+        "@playwright/test": ">=1.61.0 <2",
         "@vitejs/plugin-vue": ">=5",
         "@vue/compiler-core": ">=3.5",
         "@vue/compiler-dom": ">=3.5",
@@ -953,7 +955,6 @@
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
       "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
@@ -972,7 +973,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -985,7 +985,6 @@
       "version": "4.12.2",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1016,7 +1015,6 @@
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
       "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
@@ -1031,7 +1029,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1042,7 +1039,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1055,7 +1051,6 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
       "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^0.17.0"
@@ -1068,7 +1063,6 @@
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
       "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -1081,7 +1075,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
       "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -1105,7 +1098,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1116,7 +1108,6 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1129,7 +1120,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -1139,7 +1129,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1152,7 +1141,6 @@
       "version": "9.39.2",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
       "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1189,7 +1177,6 @@
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
       "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1199,7 +1186,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
       "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^0.17.0",
@@ -1431,7 +1417,6 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
@@ -1441,7 +1426,6 @@
       "version": "0.16.7",
       "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.1",
@@ -1455,7 +1439,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -1469,7 +1452,6 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
@@ -2596,7 +2578,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mdast": {
@@ -3253,7 +3234,6 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3266,7 +3246,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -3286,7 +3265,6 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -3303,7 +3281,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3339,7 +3316,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
@@ -3378,7 +3354,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -3492,7 +3467,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3544,7 +3518,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -3624,7 +3597,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3637,7 +3609,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/comment-parser": {
@@ -3654,7 +3625,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/confbox": {
@@ -3682,7 +3652,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3771,7 +3740,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3810,7 +3778,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dequal": {
@@ -3964,7 +3931,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3977,7 +3943,6 @@
       "version": "9.39.2",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
@@ -4356,6 +4321,33 @@
         "eslint": ">=8.45.0"
       }
     },
+    "node_modules/eslint-plugin-playwright": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.11.0.tgz",
+      "integrity": "sha512-zOIEYyv1TSn2izXkyg/yj0LXc4YBQI6pl3xIFWwMCcXt/dgQCz8dBqXiXFMoM3xc/GqZThAtaGYo8aPu/vBd+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "globals": "^17.3.0"
+      },
+      "engines": {
+        "node": ">=16.9.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/eslint-plugin-playwright/node_modules/globals": {
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint-plugin-pnpm": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-pnpm/-/eslint-plugin-pnpm-1.5.0.tgz",
@@ -4622,7 +4614,6 @@
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
       "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -4639,7 +4630,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4652,7 +4642,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4663,7 +4652,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -4673,7 +4661,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -4686,7 +4673,6 @@
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
       "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.15.0",
@@ -4704,7 +4690,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -4717,7 +4702,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -4730,7 +4714,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -4747,7 +4730,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4774,7 +4756,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -4811,14 +4792,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fastq": {
@@ -4876,7 +4855,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^4.0.0"
@@ -4902,7 +4880,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -4932,7 +4909,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
@@ -4946,7 +4922,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/format": {
@@ -5012,7 +4987,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -5059,7 +5033,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5127,7 +5100,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -5144,7 +5116,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -5183,7 +5154,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5193,7 +5163,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -5223,7 +5192,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -5286,7 +5254,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5398,21 +5365,18 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonc-eslint-parser": {
@@ -5469,7 +5433,6 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -5562,7 +5525,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -5594,7 +5556,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -5617,7 +5578,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/longest-streak": {
@@ -6648,7 +6608,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -6673,7 +6632,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-orderby": {
@@ -6721,7 +6679,6 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -6771,7 +6728,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -6787,7 +6743,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -6810,7 +6765,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -6882,7 +6836,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6892,7 +6845,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7043,7 +6995,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -7053,7 +7004,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7174,7 +7124,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7314,7 +7263,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7327,7 +7275,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7436,7 +7383,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7449,7 +7395,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -7684,7 +7629,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -7815,7 +7759,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -8668,7 +8611,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8701,7 +8643,6 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8796,7 +8737,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,11 @@
       "types": "./dist/router-bridge.d.ts",
       "import": "./dist/router.mjs",
       "require": "./dist/router.cjs"
+    },
+    "./playwright/reporter": {
+      "types": "./dist/playwright/reporter.d.ts",
+      "import": "./dist/playwright/reporter.mjs",
+      "require": "./dist/playwright/reporter.cjs"
     }
   },
   "files": [
@@ -62,6 +67,7 @@
   },
   "peerDependencies": {
     "@babel/parser": ">=7",
+    "@playwright/test": ">=1.61.0 <2",
     "@vitejs/plugin-vue": ">=5",
     "@vue/compiler-core": ">=3.5",
     "@vue/compiler-dom": ">=3.5",
@@ -77,6 +83,7 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.7.4",
+    "eslint-plugin-playwright": "^2.11.0",
     "ts-morph": "^27.0.2"
   },
   "devDependencies": {

--- a/playwright/reporter.ts
+++ b/playwright/reporter.ts
@@ -1,0 +1,208 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import type {
+  Reporter,
+  TestCase,
+  TestResult,
+} from "@playwright/test/reporter";
+
+import {
+  POM_FAILURE_ATTACHMENT_NAME,
+  type PomFailureDiagnostics,
+  type PomPageFailureSnapshot,
+} from "../class-generation/diagnostics";
+
+const DEFAULT_MAX_OUTPUT_CHARACTERS = 32_000;
+const DEFAULT_MAX_METHODS = 80;
+const DEFAULT_MAX_ELEMENTS = 80;
+const DEFAULT_MAX_EVENTS = 30;
+const DEFAULT_MAX_ARIA_CHARACTERS = 8_000;
+
+export interface PomFailureReporterOptions {
+  maxOutputCharacters?: number;
+}
+
+function shellQuote(value: string): string {
+  let quoted = "'";
+  for (const character of value) {
+    quoted += character === "'" ? `'"'"'` : character;
+  }
+  return `${quoted}'`;
+}
+
+function readDiagnostics(result: TestResult): PomFailureDiagnostics | null {
+  const attachment = result.attachments.find(candidate => candidate.name === POM_FAILURE_ATTACHMENT_NAME);
+  if (!attachment) return null;
+
+  try {
+    if (attachment.body) return JSON.parse(attachment.body.toString("utf8")) as PomFailureDiagnostics;
+    if (attachment.path) return JSON.parse(readFileSync(attachment.path, "utf8")) as PomFailureDiagnostics;
+  }
+  catch {
+    return null;
+  }
+  return null;
+}
+
+function appendLimited(lines: string[], heading: string, values: readonly string[], limit: number): void {
+  if (!values.length) return;
+  lines.push(heading);
+  for (const value of values.slice(-limit)) lines.push(`  ${value}`);
+  const omitted = Math.max(0, values.length - limit);
+  if (omitted) lines.push(`  … ${omitted} earlier entries omitted`);
+}
+
+function formatPage(lines: string[], page: PomPageFailureSnapshot, index: number): void {
+  lines.push(`Page ${index + 1}: ${page.url || "<no URL>"}`);
+  if (page.title) lines.push(`Title: ${page.title}`);
+  if (page.closed) lines.push("State: page was already closed");
+  if (page.routerNavigation) {
+    lines.push(
+      `Generated router navigation: ${page.routerNavigation.status} at ${page.routerNavigation.stage} -> ${page.routerNavigation.targetName}`,
+    );
+    if (page.routerNavigation.error) lines.push(`Router error: ${page.routerNavigation.error}`);
+  }
+
+  if (page.component) {
+    const available = page.component.methods.filter(method => method.state === "present").length;
+    lines.push(
+      `Generated POM match: ${page.component.className} (${page.component.matchedTestIds} rendered test ids; ${available}/${page.component.methods.length} methods currently present)`,
+    );
+    lines.push(`Vue source: ${page.component.sourceFile}`);
+    for (const method of page.component.methods.slice(0, DEFAULT_MAX_METHODS)) {
+      lines.push(`  [${method.state}] ${method.signature} <- ${method.expectedTestIds.join(" | ")}`);
+    }
+    const omittedMethods = Math.max(0, page.component.methods.length - DEFAULT_MAX_METHODS);
+    if (omittedMethods) lines.push(`  … ${omittedMethods} generated methods omitted; see JSON`);
+    lines.push("  Availability describes the current page state; an unavailable method is not inherently an error.");
+  }
+  else {
+    lines.push("Generated POM match: no active page POM identified from rendered test ids");
+  }
+
+  if (page.renderedElements.length) {
+    lines.push("Rendered generated elements:");
+    for (const element of page.renderedElements.slice(0, DEFAULT_MAX_ELEMENTS)) {
+      const state = `${element.visible ? "visible" : "hidden"}/${element.enabled ? "enabled" : "disabled"}`;
+      const semantics = [element.role ? `role=${element.role}` : null, element.name ? `name=${JSON.stringify(element.name)}` : null]
+        .filter(Boolean)
+        .join(" ");
+      lines.push(`  ${element.testId} <${element.tag}> ${state}${semantics ? ` ${semantics}` : ""}`);
+    }
+    const omittedElements = Math.max(0, page.renderedElements.length - DEFAULT_MAX_ELEMENTS);
+    if (omittedElements) lines.push(`  … ${omittedElements} rendered elements omitted; see JSON`);
+  }
+
+  if (page.ariaSnapshot) {
+    const aria = page.ariaSnapshot.slice(0, DEFAULT_MAX_ARIA_CHARACTERS);
+    lines.push("Accessibility snapshot:", aria);
+    if (aria.length < page.ariaSnapshot.length) {
+      lines.push(`  … ${page.ariaSnapshot.length - aria.length} accessibility-snapshot characters omitted; see JSON`);
+    }
+  }
+  else if (page.ariaSnapshotError) {
+    lines.push(`Accessibility snapshot unavailable: ${page.ariaSnapshotError}`);
+  }
+
+  appendLimited(lines, "Capture warnings:", page.captureErrors, DEFAULT_MAX_EVENTS);
+}
+
+function formatErrors(result: TestResult): string[] {
+  if (!result.errors.length) return ["Playwright error: failure did not include an Error object"];
+  return result.errors.map((error, index) => {
+    const value = error.stack ?? error.message ?? error.value ?? "Unknown error";
+    return `Error ${index + 1}:\n${String(value).slice(0, 6_000)}`;
+  });
+}
+
+function isolatedCommand(test: TestCase): string {
+  const location = `${path.relative(process.cwd(), test.location.file)}:${test.location.line}`;
+  return `npx playwright test ${shellQuote(location)} --project=${shellQuote(test.parent.project()?.name ?? "chromium")} --max-failures=1`;
+}
+
+function boundOutput(lines: string[], footer: string[], maximum: number): string {
+  const full = [...lines, ...footer].join("\n");
+  if (full.length <= maximum) return full;
+
+  const footerText = footer.join("\n");
+  const marker = `\n… report truncated by ${full.length - maximum} characters; use the JSON artifact for complete structured diagnostics …\n`;
+  const available = Math.max(0, maximum - footerText.length - marker.length - 1);
+  return `${lines.join("\n").slice(0, available)}${marker}${footerText}`;
+}
+
+export function formatPomFailureReport(
+  test: TestCase,
+  result: TestResult,
+  diagnostics: PomFailureDiagnostics | null,
+  options: PomFailureReporterOptions = {},
+): string {
+  const title = test.titlePath().join(" › ");
+  const lines = [
+    "================ VUE POM FAILURE DIAGNOSTICS ================",
+    `Test: ${title}`,
+    `Location: ${test.location.file}:${test.location.line}:${test.location.column}`,
+    `Attempt: ${result.retry + 1}`,
+    `Status: ${result.status} (expected ${test.expectedStatus})`,
+    ...formatErrors(result),
+  ];
+
+  if (diagnostics) {
+    if (diagnostics.activeAction) {
+      lines.push(
+        `Active generated action: ${diagnostics.activeAction.componentName ? `${diagnostics.activeAction.componentName}.` : ""}${diagnostics.activeAction.methodName}`,
+      );
+      if (diagnostics.activeAction.expectedTestIds.length) {
+        lines.push(`Expected generated test ids: ${diagnostics.activeAction.expectedTestIds.join(" | ")}`);
+      }
+    }
+    else {
+      lines.push("Active generated action: none recorded");
+    }
+    diagnostics.pages.forEach((page, index) => formatPage(lines, page, index));
+    appendLimited(lines, "Browser console:", diagnostics.console, DEFAULT_MAX_EVENTS);
+    appendLimited(lines, "Page errors:", diagnostics.pageErrors, DEFAULT_MAX_EVENTS);
+    appendLimited(lines, "Network failures:", diagnostics.networkFailures, DEFAULT_MAX_EVENTS);
+    appendLimited(
+      lines,
+      "HTTP error responses:",
+      (diagnostics.httpFailures ?? []).map((failure) => {
+        const heading = `${failure.status} ${failure.method} ${failure.url}${failure.contentType ? ` (${failure.contentType})` : ""}`;
+        if (failure.body) return `${heading}\nResponse body:\n${failure.body}`;
+        if (failure.bodyCaptureError) return `${heading}\nResponse body unavailable: ${failure.bodyCaptureError}`;
+        return heading;
+      }),
+      DEFAULT_MAX_EVENTS,
+    );
+    appendLimited(lines, "Requests still pending at failure:", diagnostics.pendingRequests ?? [], DEFAULT_MAX_EVENTS);
+  }
+  else {
+    lines.push(
+      "Browser diagnostics: unavailable. The test did not initialize generated POM fixtures, the page closed before capture, or capture itself failed.",
+    );
+  }
+
+  const footer = [
+    diagnostics ? `Structured diagnostics: ${diagnostics.jsonPath}` : "Structured diagnostics: unavailable",
+    `Isolated rerun: ${isolatedCommand(test)}`,
+    "=============================================================",
+  ];
+  return boundOutput(lines, footer, options.maxOutputCharacters ?? DEFAULT_MAX_OUTPUT_CHARACTERS);
+}
+
+export default class PomFailureReporter implements Reporter {
+  private readonly options: PomFailureReporterOptions;
+
+  public constructor(options: PomFailureReporterOptions = {}) {
+    this.options = options;
+  }
+
+  public onTestEnd(test: TestCase, result: TestResult): void {
+    if (result.status === test.expectedStatus || result.status === "skipped") return;
+    const diagnostics = readDiagnostics(result);
+    process.stdout.write(`${formatPomFailureReport(test, result, diagnostics, this.options)}\n`);
+  }
+
+  public printsToStdio(): boolean {
+    return true;
+  }
+}

--- a/plugin/internal-plugins.ts
+++ b/plugin/internal-plugins.ts
@@ -98,6 +98,7 @@ export function createInternalPlugins(options: InternalPluginFactoryOptions): Pl
 
   const tsProcessor = createBuildProcessorPlugin({
     componentHierarchyMap,
+    elementMetadata,
     crossFileKeyRegistry,
     vueFilesPathMap,
     getPageDirs,
@@ -118,6 +119,7 @@ export function createInternalPlugins(options: InternalPluginFactoryOptions): Pl
   });
 
   const devProcessor = createDevProcessorPlugin({
+    elementMetadata,
     nativeWrappers,
     optionKeyAttribute,
     excludedComponents,

--- a/plugin/internal/build-plugin.ts
+++ b/plugin/internal/build-plugin.ts
@@ -8,6 +8,7 @@ import { compileScript, parse as parseSfc } from "@vue/compiler-sfc";
 import type { PluginOption } from "vite";
 
 import { generateFiles } from "../../class-generation";
+import type { ElementMetadata } from "../../metadata-collector";
 import { introspectNuxtPages, parseRouterFileFromCwd } from "../../router-introspection";
 import { createTestIdTransform } from "../../transform";
 import type { IComponentDependencies, NativeWrappersMap, RouterIntrospectionResult } from "../../utils";
@@ -19,6 +20,7 @@ import { resolveExistingIdBehavior } from "../vue-plugin";
 
 interface BuildProcessorOptions {
   componentHierarchyMap: Map<string, IComponentDependencies>;
+  elementMetadata: Map<string, Map<string, ElementMetadata>>;
   crossFileKeyRegistry: Map<string, string>;
   vueFilesPathMap: Map<string, string>;
   getPageDirs: () => string[];
@@ -84,6 +86,7 @@ function isLessRich(candidate: HierarchyGenerationMetrics, previous: HierarchyGe
 export function createBuildProcessorPlugin(options: BuildProcessorOptions): PluginOption {
   const {
     componentHierarchyMap,
+    elementMetadata,
     crossFileKeyRegistry,
     vueFilesPathMap,
     getPageDirs,
@@ -394,6 +397,7 @@ export function createBuildProcessorPlugin(options: BuildProcessorOptions): Plug
         pageDirs: getPageDirs(),
         componentDirs: getComponentDirs(),
         layoutDirs: getLayoutDirs(),
+        elementMetadata,
       });
       lastGeneratedMetrics = metrics;
       loggerRef.current.info(`generated POMs (${metrics.entryCount} entries, ${metrics.interactiveComponentCount} interactive components, ${metrics.dataTestIdCount} selectors)`);

--- a/plugin/internal/dev-plugin.ts
+++ b/plugin/internal/dev-plugin.ts
@@ -9,6 +9,7 @@ import { compileScript, parse as parseSfc } from "@vue/compiler-sfc";
 import type { PluginOption, ViteDevServer } from "vite";
 
 import { generateFiles } from "../../class-generation";
+import type { ElementMetadata } from "../../metadata-collector";
 import { introspectNuxtPages, parseRouterFileFromCwd } from "../../router-introspection";
 import { createTestIdTransform } from "../../transform";
 import type { IComponentDependencies, NativeWrappersMap, RouterIntrospectionResult } from "../../utils";
@@ -19,6 +20,7 @@ import type { ResolvedGenerationSupportOptions } from "../resolved-generation-op
 import { resolveExistingIdBehavior } from "../vue-plugin";
 
 interface DevProcessorOptions {
+  elementMetadata: Map<string, Map<string, ElementMetadata>>;
   nativeWrappers: NativeWrappersMap;
   optionKeyAttribute: Record<string, string>;
   excludedComponents: string[];
@@ -40,6 +42,7 @@ interface DevProcessorOptions {
 
 export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOption {
   const {
+    elementMetadata,
     nativeWrappers,
     optionKeyAttribute,
     excludedComponents,
@@ -389,6 +392,7 @@ export function createDevProcessorPlugin(options: DevProcessorOptions): PluginOp
           vueRouterFluentChaining: routerAwarePoms,
           routerEntry: getResolvedRouterEntry(),
           routerType,
+          elementMetadata,
         });
         const t1 = performance.now();
         logInfo(`generate(${logLabel}): components=${snapshotHierarchy.size} in ${formatMs(t1 - t0)}`);

--- a/route-navigation-codegen.ts
+++ b/route-navigation-codegen.ts
@@ -22,6 +22,7 @@ export type NavigationTargetSelection =
     };
 
 export interface RouterNavigationWriterOptions {
+  componentName: string;
   routeName: NavigationTargetSelection;
   input?: NavigationInput;
   pathParamNames: string[];
@@ -29,6 +30,7 @@ export interface RouterNavigationWriterOptions {
 }
 
 export interface UrlNavigationWriterOptions {
+  componentName: string;
   routeTemplate: NavigationTargetSelection;
   input?: NavigationInput;
   pathParams: NavigationPathParam[];
@@ -98,11 +100,9 @@ function writeRouterTargetType(writer: TypeScriptWriter, includeQuery: boolean):
 }
 
 function writeRouterType(writer: TypeScriptWriter, includeQuery: boolean): void {
-  writer.write(`{ ${POM_ROUTER_GLOBAL_NAME}?: { push: (to: `);
+  writer.write(`{ ${POM_ROUTER_GLOBAL_NAME}?: { beginNavigation: (to: `);
   writeRouterTargetType(writer, includeQuery);
-  writer.write(") => Promise<unknown>; resolve: (to: ");
-  writeRouterTargetType(writer, includeQuery);
-  writer.write(") => { href: string } } }");
+  writer.write(") => number; navigation?: { id: number; status: \"pending\" | \"succeeded\" | \"failed\"; stage: \"waiting-for-router-ready\" | \"pushing-route\" | \"complete\"; targetName: string; error?: string } } }");
 }
 
 function writeRouterBinding(writer: TypeScriptWriter, includeQuery: boolean): void {
@@ -127,6 +127,71 @@ function writeRouterTarget(
     writer.write(`, query: ${queryExpression}`);
   }
   writer.write(" }");
+}
+
+function writeRouterNavigation(
+  writer: TypeScriptWriter,
+  writeName: WriterFunction,
+  includeQuery: boolean,
+): void {
+  writer.write("const navigationId = await this.page.evaluate((");
+  writeRouterBinding(writer, includeQuery);
+  writer.write(") => {").newLine();
+  writer.indent(() => {
+    writer.write("const router = (globalThis as ");
+    writeRouterType(writer, includeQuery);
+    writer.write(`).${POM_ROUTER_GLOBAL_NAME};`).newLine();
+    writer.writeLine("if (!router) {");
+    writer.indent(() => {
+      writer.writeLine('throw new Error("[vue-pom-generator] Vue Router bridge is unavailable.");');
+    });
+    writer.writeLine("}");
+    writer.write("return router.beginNavigation(");
+    writeRouterBinding(writer, includeQuery);
+    writer.write(");").newLine();
+  });
+  writer.write("}, ");
+  writeRouterTarget(writer, writeName, includeQuery, "routeParams", "routeQuery");
+  writer.write(");").newLine();
+  writer.writeLine("try {");
+  writer.indent(() => {
+    writer.write("await this.page.waitForFunction((id) => {").newLine();
+    writer.indent(() => {
+      writer.write("const navigation = (globalThis as ");
+      writeRouterType(writer, includeQuery);
+      writer.write(`).${POM_ROUTER_GLOBAL_NAME}?.navigation;`).newLine();
+      writer.writeLine('return navigation?.id === id && navigation.status !== "pending";');
+    });
+    writer.writeLine("}, navigationId, { timeout: 5000 });");
+  });
+  writer.writeLine("}");
+  writer.writeLine("catch (error) {");
+  writer.indent(() => {
+    writer.write("const navigation = await this.page.evaluate((id) => {").newLine();
+    writer.indent(() => {
+      writer.write("const current = (globalThis as ");
+      writeRouterType(writer, includeQuery);
+      writer.write(`).${POM_ROUTER_GLOBAL_NAME}?.navigation;`).newLine();
+      writer.writeLine("return current?.id === id ? current : undefined;");
+    });
+    writer.writeLine("}, navigationId).catch(() => undefined);");
+    writer.writeLine('const detail = error instanceof Error ? error.message : String(error);');
+    writer.writeLine('throw new Error(`[vue-pom-generator] Vue Router navigation timed out after 5000ms (stage: ${navigation?.stage ?? "unknown"}, target: ${navigation?.targetName ?? "unknown"}, current URL: ${this.page.url()}). ${detail}`);');
+  });
+  writer.writeLine("}");
+  writer.write("const navigationError = await this.page.evaluate((id) => {").newLine();
+  writer.indent(() => {
+    writer.write("const navigation = (globalThis as ");
+    writeRouterType(writer, includeQuery);
+    writer.write(`).${POM_ROUTER_GLOBAL_NAME}?.navigation;`).newLine();
+    writer.writeLine('return navigation?.id === id && navigation.status === "failed" ? navigation.error ?? "Unknown navigation error" : undefined;');
+  });
+  writer.writeLine("}, navigationId);");
+  writer.writeLine("if (navigationError) {");
+  writer.indent(() => {
+    writer.writeLine('throw new Error(`[vue-pom-generator] Vue Router navigation failed: ${navigationError}`);');
+  });
+  writer.writeLine("}");
 }
 
 function requireNavigationInput(
@@ -190,10 +255,11 @@ function writeSelectedTarget(
 
 /**
  * Emits the complete named-route navigation body. The caller supplies route metadata;
- * this writer owns params/query partitioning and both the cold-load and warm-router paths.
+ * this writer owns params/query partitioning and both the cold-boot and warm-router paths.
  */
 export function createRouterNavigationWriter(options: RouterNavigationWriterOptions): WriterFunction {
   return (writer) => {
+    writer.writeLine(`this.recordPomAction(${JSON.stringify(options.componentName)}, "goTo", []);`);
     writeSelectionPrelude(writer, options.routeName, options.input, options.pathParamNames);
     const writeRouteName: WriterFunction = nameWriter => writeSelectedTarget(nameWriter, options.routeName, options.input);
 
@@ -214,40 +280,11 @@ export function createRouterNavigationWriter(options: RouterNavigationWriterOpti
     writer.indent(() => {
       writer.writeLine('await this.page.goto("/", { waitUntil: "commit" });');
       writer.writeLine(
-        `await this.page.waitForFunction(() => typeof (globalThis as { ${POM_ROUTER_GLOBAL_NAME}?: unknown }).${POM_ROUTER_GLOBAL_NAME} !== "undefined", { timeout: 15000 });`,
+        `await this.page.waitForFunction(() => typeof (globalThis as { ${POM_ROUTER_GLOBAL_NAME}?: unknown }).${POM_ROUTER_GLOBAL_NAME} !== "undefined", undefined, { timeout: 5000 });`,
       );
-      writer.write("const href = await this.page.evaluate((");
-      writeRouterBinding(writer, includeQuery);
-      writer.write(") => (globalThis as ");
-      writeRouterType(writer, includeQuery);
-      writer.write(`).${POM_ROUTER_GLOBAL_NAME}?.resolve(`);
-      writeRouterBinding(writer, includeQuery);
-      writer.write(")?.href, ");
-      writeRouterTarget(writer, writeRouteName, includeQuery, "routeParams", "routeQuery");
-      writer.write(");").newLine();
-      writer.writeLine("if (href) {");
-      writer.indent(() => {
-        writer.writeLine('await this.page.goto(href, { waitUntil: "domcontentloaded" });');
-      });
-      writer.writeLine("}");
-    });
-    writer.writeLine("} else {");
-    writer.indent(() => {
-      writer.write("await this.page.evaluate(async (");
-      writeRouterBinding(writer, includeQuery);
-      writer.write(") => {").newLine();
-      writer.indent(() => {
-        writer.write("await (globalThis as ");
-        writeRouterType(writer, includeQuery);
-        writer.write(`).${POM_ROUTER_GLOBAL_NAME}?.push(`);
-        writeRouterBinding(writer, includeQuery);
-        writer.write(");").newLine();
-      });
-      writer.write("}, ");
-      writeRouterTarget(writer, writeRouteName, includeQuery, "routeParams", "routeQuery");
-      writer.write(");").newLine();
     });
     writer.writeLine("}");
+    writeRouterNavigation(writer, writeRouteName, includeQuery);
   };
 }
 
@@ -316,6 +353,7 @@ function writeRuntimeUrlNavigation(writer: TypeScriptWriter): void {
 /** Emits the complete URL-construction navigation body used for unnamed routes. */
 export function createUrlNavigationWriter(options: UrlNavigationWriterOptions): WriterFunction {
   return (writer) => {
+    writer.writeLine(`this.recordPomAction(${JSON.stringify(options.componentName)}, "goTo", []);`);
     writeSelectionPrelude(writer, options.routeTemplate, options.input, options.pathParams.map(param => param.name));
     if (options.routeTemplate.kind === "single") {
       writer.write(`let targetUrl = ${JSON.stringify(options.routeTemplate.target)};`).newLine();

--- a/router-bridge.ts
+++ b/router-bridge.ts
@@ -9,15 +9,83 @@ export interface PomNavigationRouter {
   // payload, so keep these callable constraints broad enough for Vue Router's overloads.
   push: (...args: never[]) => object | undefined;
   resolve: (...args: never[]) => { href: string };
+  isReady: () => Promise<void>;
+}
+
+export type PomNavigationStatus = "pending" | "succeeded" | "failed";
+export type PomNavigationStage = "waiting-for-router-ready" | "pushing-route" | "complete";
+
+export interface PomNavigationState {
+  id: number;
+  status: PomNavigationStatus;
+  stage: PomNavigationStage;
+  targetName: string;
+  error?: string;
+}
+
+export interface PomNavigationBridge {
+  navigation: PomNavigationState | undefined;
+  beginNavigation: (target: PomNavigationTarget) => number;
 }
 
 /** Global key shared by the runtime bridge and generated `goTo()` methods. */
 export const POM_ROUTER_GLOBAL_NAME = "__vuePomGeneratorRouter";
+
+function describeNavigationError<T>(error: T): string {
+  if (error instanceof Error) {
+    return error.stack ?? `${error.name}: ${error.message}`;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  try {
+    return JSON.stringify(error);
+  }
+  catch {
+    return String(error);
+  }
+}
 
 /**
  * Exposes a live application router to generated POM navigation methods.
  * Call this from the application entry point in environments where Playwright runs.
  */
 export function exposeRouterForPomNavigation(router: PomNavigationRouter): void {
-  Object.assign(globalThis, { [POM_ROUTER_GLOBAL_NAME]: router });
+  let nextNavigationId = 0;
+  const bridge: PomNavigationBridge = {
+    navigation: undefined,
+    beginNavigation(target) {
+      const navigation: PomNavigationState = {
+        id: ++nextNavigationId,
+        status: "pending",
+        stage: "waiting-for-router-ready",
+        targetName: target.name,
+      };
+      bridge.navigation = navigation;
+
+      // Keep the router's promise owned by application code. Returning it through
+      // page.evaluate lets the browser collect a still-pending promise before the
+      // automation protocol observes its result.
+      void (async () => {
+        try {
+          await router.isReady();
+          navigation.stage = "pushing-route";
+          await Reflect.apply(router.push, router, [target]);
+          navigation.status = "succeeded";
+          navigation.stage = "complete";
+        }
+        catch (error) {
+          navigation.status = "failed";
+          navigation.stage = "complete";
+          navigation.error = describeNavigationError(error);
+        }
+      })();
+
+      return navigation.id;
+    },
+  };
+
+  Object.assign(globalThis, { [POM_ROUTER_GLOBAL_NAME]: bridge });
 }

--- a/scripts/packed-smoke-check.mjs
+++ b/scripts/packed-smoke-check.mjs
@@ -25,7 +25,7 @@ const packageDir = path.resolve(scriptDir, "..");
 const peerVite = "7.3.1";
 const peerVue = "3.5.22";
 const peerPluginVue = "6.0.1";
-const consumerPlaywrightTest = "1.60.0";
+const consumerPlaywrightTest = "1.61.0";
 
 function lastNonEmptyLine(value) {
   // Avoid regex and split/replace/match-style parsing (repo lint rule).
@@ -80,8 +80,7 @@ try {
   );
 
   // Install peers + the packed tarball as a consumer would.
-  // Intentionally use a newer Playwright test version than our minimum supported peer so
-  // exact pinning would create a nested duplicate playwright install.
+  // Exercise the minimum supported Playwright Test peer as a consumer would.
   run(
     "npm",
     [

--- a/tests/broad/class-generation-base-page-ts.test.ts
+++ b/tests/broad/class-generation-base-page-ts.test.ts
@@ -49,8 +49,8 @@ class ExposedBasePage extends BasePage {
   public makeFluent<T extends object>(factory: () => Promise<T>): Fluent<T> {
     return this.fluent(factory);
   }
-  public clickTestId(testId: string, annotation = "", wait = true, description?: string) {
-    return this.clickByTestId(testId, annotation, wait, description);
+  public clickTestId(testId: string, annotation = "", wait = true, description?: string, action?: { componentName?: string; methodName: string; preferAssociatedLabel?: boolean }) {
+    return this.clickByTestId(testId, annotation, wait, description, action);
   }
   public clickLoc(locator: PwLocator, annotation = "", wait = true) {
     return this.clickLocator(locator, annotation, wait);
@@ -61,8 +61,8 @@ class ExposedBasePage extends BasePage {
   public fillTestId(testId: string, text: string, annotation = "", description?: string) {
     return this.fillInputByTestId(testId, text, annotation, description);
   }
-  public selectVSelect(testId: string, value: string, timeOut = 0, annotation = "", description?: string) {
-    return this.selectVSelectByTestId(testId, value, timeOut, annotation, description);
+  public selectVSelect(testId: string, value: string, annotation = "", description?: string) {
+    return this.selectVSelectByTestId(testId, value, annotation, description);
   }
   public fillLoc(locator: PwLocator, text: string, annotation = "") {
     return this.fillInputByLocator(locator, text, annotation);
@@ -147,12 +147,12 @@ describe("BasePage locators", () => {
     const rawLocator = new FakeLocator({ tagName: "DIV" });
     const byLabelLocator = new FakeLocator({ tagName: "DIV" });
     vi.spyOn(rawLocator, "describe").mockReturnValue(described);
-    vi.spyOn(byLabelLocator, "getByLabel").mockReturnValue(rawLocator);
+    vi.spyOn(byLabelLocator, "getByText").mockReturnValue(rawLocator);
     const fakePage = new FakePage();
     fakePage.locator = vi.fn(() => byLabelLocator);
     const page = new ExposedBasePage(fakePage);
     const result = page.locByLabel("panel", "Email", { exact: false, description: "email field" });
-    expect(byLabelLocator.getByLabel).toHaveBeenCalledWith("Email", { exact: false });
+    expect(byLabelLocator.getByText).toHaveBeenCalledWith("Email", { exact: false });
     expect(rawLocator.describe).toHaveBeenCalledWith("email field");
     expect(result).toBe(described);
   });
@@ -160,12 +160,12 @@ describe("BasePage locators", () => {
   it("defaults the exact flag to true when locating by label", () => {
     const byLabelLocator = new FakeLocator({ tagName: "DIV" });
     const rawLocator = new FakeLocator({ tagName: "DIV" });
-    vi.spyOn(byLabelLocator, "getByLabel").mockReturnValue(rawLocator);
+    vi.spyOn(byLabelLocator, "getByText").mockReturnValue(rawLocator);
     const fakePage = new FakePage();
     fakePage.locator = vi.fn(() => byLabelLocator);
     const page = new ExposedBasePage(fakePage);
     page.locByLabel("panel", "Email");
-    expect(byLabelLocator.getByLabel).toHaveBeenCalledWith("Email", { exact: true });
+    expect(byLabelLocator.getByText).toHaveBeenCalledWith("Email", { exact: true });
   });
 });
 
@@ -219,7 +219,7 @@ describe("BasePage action helpers", () => {
     expect(target.scrollCalls).toBeGreaterThan(0);
   });
 
-  it("clicks by test id and propagates afterClick for instrumented clicks", async () => {
+  it("clicks by test id without requiring custom instrumentation waits", async () => {
     const fakePage = new FakePage();
     const btn = new FakeLocator({ tagName: "BUTTON" }, { testId: "btn" });
     fakePage.locator = () => btn;
@@ -228,6 +228,42 @@ describe("BasePage action helpers", () => {
     // exercise the wait=false early return path
     await page.clickTestId("btn", "note", false);
     expect(btn.clicks).toBe(2);
+  });
+
+  it("clicks the visible associated label for generated checkbox actions", async () => {
+    const checkbox = new FakeLocator({ tagName: "INPUT" }, { id: "select-page", testId: "SelectPage-checkbox" });
+    const label = new FakeLocator({ tagName: "LABEL" });
+    const fakePage = new FakePage();
+    fakePage.locator = vi.fn((selector: string) => selector.startsWith("label[for=") ? label : checkbox);
+    const page = new ExposedBasePage(fakePage);
+
+    await page.clickTestId("SelectPage-checkbox", "", true, "Select page", {
+      componentName: "RecordListPage",
+      methodName: "clickSelectPage",
+      preferAssociatedLabel: true,
+    });
+
+    expect(label.clicks).toBe(1);
+    expect(checkbox.clicks).toBe(0);
+    expect(checkbox.presses).toEqual([]);
+  });
+
+  it("keyboard-activates a checkable input whose empty associated label has no visible box", async () => {
+    const checkbox = new FakeLocator({ tagName: "INPUT" }, { id: "select-page", testId: "SelectPage-checkbox" });
+    const emptyLabel = new FakeLocator({ tagName: "LABEL" }, { visible: false });
+    const fakePage = new FakePage();
+    fakePage.locator = vi.fn((selector: string) => selector.startsWith("label[for=") ? emptyLabel : checkbox);
+    const page = new ExposedBasePage(fakePage);
+
+    await page.clickTestId("SelectPage-checkbox", "", true, "Select page", {
+      componentName: "RecordListPage",
+      methodName: "clickSelectPage",
+      preferAssociatedLabel: true,
+    });
+
+    expect(emptyLabel.clicks).toBe(0);
+    expect(checkbox.clicks).toBe(0);
+    expect(checkbox.presses).toEqual(["Space"]);
   });
 
   it("clicks a locator directly", async () => {
@@ -283,12 +319,12 @@ describe("BasePage action helpers", () => {
       return original(selector);
     };
     fakePage.locator = () => root;
-    await page.selectVSelect("vs", "Acme", 0, "note", "vs field");
+    await page.selectVSelect("vs", "Acme", "note", "vs field");
     expect(input.clicks).toBeGreaterThanOrEqual(1);
     expect(option.clicks).toBe(1);
   });
 
-  it("selects a vue-select option when no dropdown option is present", async () => {
+  it("fails when no vue-select dropdown option becomes visible", async () => {
     const fakePage = new FakePage();
     const page = new ExposedBasePage(fakePage);
     const input = new FakeLocator({ tagName: "INPUT" });
@@ -301,7 +337,7 @@ describe("BasePage action helpers", () => {
       return original(selector);
     };
     fakePage.locator = () => root;
-    await page.selectVSelect("vs", "Acme", 0, "note");
+    await expect(page.selectVSelect("vs", "Acme", "note")).rejects.toThrow("locator did not become visible");
     expect(input.clicks).toBeGreaterThanOrEqual(1);
     expect(option.clicks).toBe(0);
   });
@@ -330,19 +366,17 @@ describe("BasePage action helpers", () => {
 
   it("checks visibility, text, wait, hover, and select by test id", async () => {
     const fakePage = new FakePage();
-    fakePage.isVisibleResult = false;
-    fakePage.textContentResult = "hello";
     const page = new ExposedBasePage(fakePage);
-    const input = new FakeLocator({ tagName: "SELECT" }, { testId: "sel" });
+    const input = new FakeLocator({ tagName: "SELECT" }, { testId: "sel", visible: false, textContent: "hello" });
     fakePage.locator = () => input;
     expect(await page.visibleTestId("x")).toBe(false);
     expect(await page.textTestId("x")).toBe("hello");
     await page.waitTestId("x", { timeout: 500 });
-    expect(fakePage.waitForSelectorCalls[0]).toEqual({ selector: '[data-testid="x"]', options: { timeout: 500 } });
+    expect(input.waitForCalls[0]).toEqual({ state: "visible", timeout: 500 });
     await page.hoverTestId("x");
-    expect(fakePage.hoverCalls).toContain('[data-testid="x"]');
+    expect(input.hoverCalls).toBe(1);
     await page.selectTestId("x", "opt");
-    expect(fakePage.selectOptionCalls[0]).toEqual({ selector: '[data-testid="x"]', value: "opt" });
+    expect(input.selectedOptions).toEqual(["opt"]);
   });
 });
 

--- a/tests/broad/helpers/fake-runtime.ts
+++ b/tests/broad/helpers/fake-runtime.ts
@@ -161,6 +161,10 @@ export class FakeLocator implements BasePageLocator {
   public readonly fills: string[] = [];
   public descendant?: FakeLocator;
   public lastClickOptions: { delay?: number; force?: boolean } | undefined;
+  public hoverCalls = 0;
+  public presses: string[] = [];
+  public readonly selectedOptions: string[] = [];
+  public readonly waitForCalls: Array<{ state?: "attached" | "detached" | "visible" | "hidden"; timeout?: number }> = [];
   public scrollCalls = 0;
 
   public constructor(
@@ -168,8 +172,11 @@ export class FakeLocator implements BasePageLocator {
     public readonly options: {
       boundingBox?: BoundingBox;
       count?: number;
+      id?: string;
+      textContent?: string | null;
       testId?: string;
       selector?: string;
+      visible?: boolean;
     } = {},
   ) {}
 
@@ -244,6 +251,9 @@ export class FakeLocator implements BasePageLocator {
     if (name === "data-testid") {
       return this.options.testId ?? null;
     }
+    if (name === "id") {
+      return this.options.id ?? null;
+    }
     return null;
   }
 
@@ -266,18 +276,27 @@ export class FakeLocator implements BasePageLocator {
     this.fills.push(text);
   }
 
-  async hover(): Promise<void> {}
+  async hover(): Promise<void> {
+    this.hoverCalls += 1;
+  }
 
-  async press(_key: string): Promise<void> {}
+  async press(key: string): Promise<void> {
+    this.presses.push(key);
+  }
 
   async check(): Promise<void> {}
 
   async uncheck(): Promise<void> {}
 
-  async waitFor(): Promise<void> {}
+  async waitFor(options?: { state?: "attached" | "detached" | "visible" | "hidden"; timeout?: number }): Promise<void> {
+    this.waitForCalls.push(options ?? {});
+    if ((this.options.count ?? 1) === 0) {
+      throw new Error("locator did not become visible");
+    }
+  }
 
   async isVisible(): Promise<boolean> {
-    return true;
+    return this.options.visible ?? true;
   }
 
   async isHidden(): Promise<boolean> {
@@ -293,7 +312,7 @@ export class FakeLocator implements BasePageLocator {
   }
 
   async textContent(): Promise<string | null> {
-    return null;
+    return this.options.textContent ?? null;
   }
 
   async innerText(): Promise<string> {
@@ -304,8 +323,10 @@ export class FakeLocator implements BasePageLocator {
     return "";
   }
 
-  async selectOption(): Promise<string[]> {
-    return [];
+  async selectOption(value: null | string | ReadonlyArray<string> | { value?: string; label?: string; index?: number } | ReadonlyArray<{ value?: string; label?: string; index?: number }>): Promise<string[]> {
+    const selected = typeof value === "string" ? value : "";
+    if (selected) this.selectedOptions.push(selected);
+    return selected ? [selected] : [];
   }
 
   async type(_text: string): Promise<void> {}

--- a/tests/class-generation-coverage.test.ts
+++ b/tests/class-generation-coverage.test.ts
@@ -523,6 +523,74 @@ describe("class-generation coverage", () => {
     }
   });
 
+  it("retains wrapper-only components that lead to a generated descendant POM", async () => {
+    const tempRoot = makeTempRoot("vue-pom-transitive-component-child-");
+
+    try {
+      const basePagePath = path.join(tempRoot, "base-page.ts");
+      writeMinimalBasePage(basePagePath);
+
+      const recordDialog = makeDeps({
+        filePath: path.join(tempRoot, "src", "components", "RecordDialog.vue"),
+        isView: false,
+        childrenComponentSet: new Set(["ActionWrapper"]),
+        dataTestIdSet: new Set([{
+          selectorValue: createPomStringPattern("RecordDialog-Name-input", "static", []),
+          pom: {
+            nativeRole: "input",
+            methodName: "Name",
+            selector: createPomStringPattern("RecordDialog-Name-input", "static", []),
+            parameters: createPomParameters(["text", "string"]),
+          },
+        }]),
+      });
+      const actionWrapper = makeDeps({
+        filePath: path.join(tempRoot, "src", "components", "ActionWrapper.vue"),
+        isView: false,
+        childrenComponentSet: new Set(["ActionButton"]),
+      });
+      const actionButton = makeDeps({
+        filePath: path.join(tempRoot, "src", "components", "ActionButton.vue"),
+        isView: false,
+        dataTestIdSet: new Set([{
+          selectorValue: createPomStringPattern("ActionButton-Run-button", "static", []),
+          pom: {
+            nativeRole: "button",
+            methodName: "Run",
+            selector: createPomStringPattern("ActionButton-Run-button", "static", []),
+            parameters: [],
+          },
+        }]),
+      });
+
+      const componentHierarchyMap = new Map<string, IComponentDependencies>([
+        ["RecordDialog", recordDialog],
+        ["ActionWrapper", actionWrapper],
+        ["ActionButton", actionButton],
+      ]);
+
+      const outDir = path.join(tempRoot, "pom");
+      await generateFiles(componentHierarchyMap, new Map(), basePagePath, {
+        outDir,
+        projectRoot: tempRoot,
+        typescriptOutputStructure: "split",
+      });
+
+      const dialogContent = readFile(path.join(outDir, "RecordDialog.g.ts"));
+      expect(dialogContent).toContain('import { ActionWrapper }');
+      expect(dialogContent).toContain('ActionWrapper: ActionWrapper;');
+      expect(dialogContent).toContain('this.ActionWrapper = new ActionWrapper(page);');
+
+      const wrapperContent = readFile(path.join(outDir, "ActionWrapper.g.ts"));
+      expect(wrapperContent).toContain('import { ActionButton }');
+      expect(wrapperContent).toContain('ActionButton: ActionButton;');
+      expect(wrapperContent).toContain('this.ActionButton = new ActionButton(page);');
+    }
+    finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("supports vueRouterFluentChaining by emitting route metadata and goToSelf/goTo methods", async () => {
     const tempRoot = makeTempRoot("vue-pom-router-fluent-");
 
@@ -595,9 +663,9 @@ describe("class-generation coverage", () => {
       // Route metadata + goTo helpers. The named route drives the runtime router via push.
       expect(content).toContain("static readonly route");
       expect(content).toContain("async goTo()");
-      expect(content).toContain("__vuePomGeneratorRouter?.push(");
+      expect(content).toContain("router.beginNavigation(");
       expect(content).toContain('name: "users"');
-      expect(content).toContain("await this.page.evaluate(async ({ name, params })");
+      expect(content).toContain("await this.page.evaluate(({ name, params })");
 
       // Trim + propagate testIdAttribute into BasePage super call.
       expect(content).toContain("super(page, { testIdAttribute: \"data-qa\" });");
@@ -713,15 +781,14 @@ describe("class-generation coverage", () => {
       };
 
       // Shared: named routes drive the runtime router, partitioning the generated method's
-      // flat navigation arguments into params and query records. Warm pages SPA-push via
-      // `__vuePomGeneratorRouter.push`; cold pages (about:blank, router not yet installed) boot then
-      // full-load the resolved target (`__vuePomGeneratorRouter.resolve(...).href`) so the route's
-      // component mounts via a stable page load instead of a race-prone SPA push.
-      const PUSH_CALL = "__vuePomGeneratorRouter?.push(";
-      const RESOLVE_CALL = "__vuePomGeneratorRouter?.resolve(";
+      // flat navigation arguments into params and query records. Both warm and cold pages SPA-push
+      // via `__vuePomGeneratorRouter.push`; cold pages (about:blank, router not yet installed) first
+      // boot the app, then `isReady()` prevents its initial navigation from racing the generated push.
+      const PUSH_CALL = "router.beginNavigation(";
+      const NAVIGATION_WAIT = 'navigation.status !== "pending"';
       const COLD_BOOT = 'this.page.goto("/", { waitUntil: "commit" })';
-      const COLD_TARGET_LOAD = 'await this.page.goto(href, { waitUntil: "domcontentloaded" })';
       const COLD_START_WAIT = "waitForFunction(() => typeof";
+      const COLD_START_TIMEOUT = "!== \"undefined\", undefined, { timeout: 5000 })";
       const IS_COLD = "const isCold =";
 
       // --- DashboardView: query-only, named -> optional goTo(params) that pushes query. ---
@@ -729,17 +796,18 @@ describe("class-generation coverage", () => {
       expect(dashboardClass).toContain("async goTo(params?: { section?: string | number })");
       expect(dashboardClass).toContain('name: "dashboard"');
       expect(dashboardClass).toContain(PUSH_CALL);
-      // Cold-start branch: boot "/", wait for the router, resolve the target, full-load it.
+      // Cold-start branch: boot "/", wait for the router, await initial navigation, then push.
       expect(dashboardClass).toContain(IS_COLD);
       expect(dashboardClass).toContain(COLD_BOOT);
       expect(dashboardClass).toContain(COLD_START_WAIT);
-      expect(dashboardClass).toContain(RESOLVE_CALL);
-      expect(dashboardClass).toContain(COLD_TARGET_LOAD);
+      expect(dashboardClass).toContain(COLD_START_TIMEOUT);
+      expect(dashboardClass).toContain(NAVIGATION_WAIT);
       // A path-paramless route emits an empty params record and a filtered query record.
       expect(dashboardClass).toContain("const routeParams = {};");
       expect(dashboardClass).toContain('const routeQuery = Object.fromEntries([["section", params?.["section"]]]');
-      expect(dashboardClass).toContain("resolve({ name, params, query })");
-      expect(dashboardClass).toContain("push({ name, params, query })");
+      expect(dashboardClass).toContain("beginNavigation({ name, params, query })");
+      expect(dashboardClass).not.toContain(".resolve(");
+      expect(dashboardClass).not.toContain("page.goto(href");
       expect(dashboardClass).not.toContain("targetUrl");
       expect(dashboardClass).not.toContain("replaceAll");
 
@@ -750,7 +818,7 @@ describe("class-generation coverage", () => {
       expect(usersClass).toContain('const routeParams = Object.fromEntries([["id", params["id"]]]');
       expect(usersClass).toContain('const routeQuery = Object.fromEntries([["q", params["q"]]]');
       expect(usersClass).toContain(PUSH_CALL);
-      expect(usersClass).toContain(RESOLVE_CALL);
+      expect(usersClass).toContain(NAVIGATION_WAIT);
       expect(usersClass).toContain(IS_COLD);
       // No no-arg overload signature for a parametrized-only route.
       expect(usersClass).not.toMatch(/goTo\(\): Promise<void>/);
@@ -768,12 +836,12 @@ describe("class-generation coverage", () => {
       // selects the parametrized route, including when an optional path param is undefined.
       expect(personsClass).toContain('const useParametrizedRoute = params !== undefined && ["id"].some(');
       expect(personsClass).toContain('name: useParametrizedRoute ? "persons-edit" : "persons-new"');
-      // The both-routes overload is also guarded: cold branch resolves + full-loads the target.
+      // The both-routes overload is also guarded: cold boot settles before the target push.
       expect(personsClass).toContain(IS_COLD);
       expect(personsClass).toContain(COLD_BOOT);
       expect(personsClass).toContain(COLD_START_WAIT);
-      expect(personsClass).toContain(RESOLVE_CALL);
-      expect(personsClass).toContain(COLD_TARGET_LOAD);
+      expect(personsClass).toContain(COLD_START_TIMEOUT);
+      expect(personsClass).toContain(NAVIGATION_WAIT);
       expect(personsClass).toContain('const routeParams = Object.fromEntries([["id", params?.["id"]]]');
       expect(personsClass).toContain('const routeQuery = Object.fromEntries([["mode", params?.["mode"]]]');
       expect(personsClass).toContain(PUSH_CALL);
@@ -1008,9 +1076,9 @@ describe("class-generation coverage", () => {
       const content = readFile(path.join(outDir, "page-object-models.g.ts"));
 
       expect(content).toContain('return this.locatorByTestId("UserListPage-Search-input", "User list search input");');
-      expect(content).toContain('await this.fillInputByTestId("UserListPage-Search-input", text, annotationText, "User list search input");');
+      expect(content).toContain('await this.fillInputByTestId("UserListPage-Search-input", text, annotationText, "User list search input", { componentName: "UserListPage", methodName: "typeSearch" });');
       expect(content).toContain('return this.locatorByTestId("UserListPage-Save-button", "User list save button");');
-      expect(content).toContain('await this.clickByTestId("UserListPage-Save-button", annotationText, wait, "User list save button");');
+      expect(content).toContain('await this.clickByTestId("UserListPage-Save-button", annotationText, wait, "User list save button", { componentName: "UserListPage", methodName: "clickSave" });');
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }

--- a/tests/dev-plugin-options.test.ts
+++ b/tests/dev-plugin-options.test.ts
@@ -102,6 +102,7 @@ describe("dev processor option plumbing", () => {
       const basePageClassPath = path.join(projectRoot, "base-page.ts");
 
       const plugin = createDevProcessorPlugin({
+        elementMetadata: new Map(),
         nativeWrappers: {},
         optionKeyAttribute: {},
         excludedComponents: [],
@@ -190,6 +191,7 @@ describe("dev processor option plumbing", () => {
       );
 
       const plugin = createDevProcessorPlugin({
+        elementMetadata: new Map(),
         nativeWrappers: {},
         optionKeyAttribute: {},
         excludedComponents: [],
@@ -257,6 +259,7 @@ describe("dev processor option plumbing", () => {
       });
 
       const plugin = createDevProcessorPlugin({
+        elementMetadata: new Map(),
         nativeWrappers: {},
         optionKeyAttribute: {},
         excludedComponents: [],

--- a/tests/eslint.test.ts
+++ b/tests/eslint.test.ts
@@ -2,10 +2,33 @@
 import { RuleTester } from "eslint";
 import { describe, it } from "vitest";
 
-import { noDataTestIdInSpecsRule, noPageFixtureInSpecsRule, noRawLocatorActionRule, noRawPlaywrightApisRule } from "../eslint/index";
+import { noDataTestIdInSpecsRule, noPageFixtureInSpecsRule, noRawLocatorActionRule, noRawPlaywrightApisRule, plugin, recommendedPlaywrightConfig } from "../eslint/index";
 
 const tester = new RuleTester({
 	languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+});
+
+describe("flat/recommended config", () => {
+	it("composes upstream Playwright wait/action rules as errors", () => {
+		const upstream = recommendedPlaywrightConfig[0];
+		const generator = recommendedPlaywrightConfig[1];
+
+		for (const ruleName of [
+			"playwright/no-force-option",
+			"playwright/no-networkidle",
+			"playwright/no-wait-for-selector",
+			"playwright/no-wait-for-timeout",
+			"playwright/prefer-web-first-assertions",
+		]) {
+			if (upstream?.rules?.[ruleName] !== "error") throw new Error(`${ruleName} must be an error`);
+		}
+		if (generator?.plugins?.["@immense/vue-pom-generator"] !== plugin) {
+			throw new Error("recommended config must install the generator plugin");
+		}
+		if (upstream?.rules?.["playwright/valid-describe-callback"] !== undefined) {
+			throw new Error("recommended config must not enable unrelated upstream policy");
+		}
+	});
 });
 
 describe("no-data-testid-in-specs", () => {
@@ -95,6 +118,18 @@ describe("no-raw-locator-action", () => {
 				{
 					code: "pom.ToggleButton.check()",
 					errors: [{ messageId: "noRawAction" }],
+				},
+				{
+					code: "pom.SubmitButton.scrollIntoViewIfNeeded()",
+					errors: [{ messageId: "noRawAction" }],
+				},
+				{
+					code: "pom.clickLocator(pom.SubmitButton)",
+					errors: [{ messageId: "noRawPomActionHelper" }],
+				},
+				{
+					code: "pom.clickByTestId('Submit-button')",
+					errors: [{ messageId: "noRawPomActionHelper" }],
 				},
 			],
 		});

--- a/tests/fixtures/MyRadioGroup_OptionId.vue
+++ b/tests/fixtures/MyRadioGroup_OptionId.vue
@@ -1,5 +1,5 @@
 <template>
   <div role="radiogroup">
-    <input v-for="(option, index) in options" :key="option.id" type="radio" name="option" :value="option.value" v-model="modelValue" />
+    <input v-for="option in options" :key="option.id" type="radio" name="option" :value="option.value" v-model="modelValue" />
   </div>
 </template>

--- a/tests/fixtures/generated-tsc/base-page.full.ts
+++ b/tests/fixtures/generated-tsc/base-page.full.ts
@@ -28,15 +28,17 @@ export class BasePage {
     return `[data-testid="${testId}"]`;
   }
 
-  protected async clickByTestId(_testId: string, _annotationText: string = "", _wait: boolean = true, _description?: string): Promise<void> {}
+  protected async clickByTestId(_testId: string, _annotationText: string = "", _wait: boolean = true, _description?: string, _action?: { componentName?: string; methodName: string; preferAssociatedLabel?: boolean }): Promise<void> {}
 
   protected async clickLocator(_locator: any, _annotationText: string = "", _wait: boolean = true): Promise<void> {}
 
-  protected async clickWithinTestIdByLabel(_rootTestId: string, _label: string, _annotationText: string = "", _wait: boolean = true, _options?: { exact?: boolean; description?: string }): Promise<void> {}
+  protected async clickWithinTestIdByLabel(_rootTestId: string, _label: string, _annotationText: string = "", _wait: boolean = true, _options?: { exact?: boolean; description?: string; componentName?: string; methodName?: string }): Promise<void> {}
 
-  protected async fillInputByTestId(_testId: string, _text: string, _annotationText: string = "", _description?: string): Promise<void> {}
+  protected async fillInputByTestId(_testId: string, _text: string, _annotationText: string = "", _description?: string, _action?: { componentName?: string; methodName: string }): Promise<void> {}
 
-  protected async selectVSelectByTestId(_testId: string, _value: string, _timeOut = 500, _annotationText: string = "", _description?: string): Promise<void> {}
+  protected async selectVSelectByTestId(_testId: string, _value: string, _annotationText: string = "", _description?: string, _action?: { componentName?: string; methodName: string }): Promise<void> {}
+
+  protected recordPomAction(_componentName: string | undefined, _methodName: string, _expectedTestIds: readonly string[]): void {}
 
   protected async animateCursorToElement(_selector: string, _executeClick = true, _delay = 100, _annotationText: string = "", _waitForInstrumentationEvent = true): Promise<void> {}
 }

--- a/tests/fixtures/generated-tsc/node.d.ts
+++ b/tests/fixtures/generated-tsc/node.d.ts
@@ -1,0 +1,3 @@
+declare module "node:fs/promises" {
+  export function writeFile(path: string, data: string, encoding: string): Promise<void>;
+}

--- a/tests/fixtures/generated-tsc/playwright-test.d.ts
+++ b/tests/fixtures/generated-tsc/playwright-test.d.ts
@@ -2,6 +2,7 @@
 export type Page = any;
 export type Locator = any;
 export type PlaywrightTestArgs = { page: Page };
+export type TestInfo = any;
 export type TestType<TestArgs = any, WorkerArgs = any> = {
   extend<T>(_fixtures: any): TestType<TestArgs & T, WorkerArgs>;
 };

--- a/tests/fixtures/generated-tsc/playwright.d.ts
+++ b/tests/fixtures/generated-tsc/playwright.d.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 export type Page = any;
+export type BrowserContext = any;
 export type Locator = any;
 export type Keyboard = any;
 export type Response = any;

--- a/tests/generated-tsc.test.ts
+++ b/tests/generated-tsc.test.ts
@@ -38,6 +38,7 @@ function copyRepoFixture(rootDir: string, fixtureName: string, destinationRelati
 }
 
 function writePlaywrightTypeStub(rootDir: string) {
+  copyRepoFixture(rootDir, "node.d.ts", path.join("node_modules", "@types", "node", "index.d.ts"));
   copyRepoFixture(rootDir, "playwright.d.ts", path.join("node_modules", "playwright", "index.d.ts"));
   copyRepoFixture(rootDir, "playwright-test.d.ts", path.join("node_modules", "@playwright", "test", "index.d.ts"));
 }
@@ -489,7 +490,12 @@ describe("generated output", () => {
     });
 
     const fixtureFile = path.join(outDir, "fixtures.g.ts");
+    const manifestFile = path.join(outDir, "pom-manifest.g.ts");
     const fixtureContent = fs.readFileSync(fixtureFile, "utf8");
+    expect(fs.existsSync(manifestFile)).toBe(true);
+    expect(fs.readFileSync(manifestFile, "utf8")).toContain("export const pomManifest");
+    expect(fixtureContent).toContain('from "./pom-manifest.g"');
+    expect(fixtureContent).toContain("installPomFailureDiagnostics");
     expect(fixtureContent).toContain("import { PersonListPage as PersonListPageOverride }");
     expect(fixtureContent).toContain("personListPage: PersonListPageOverride");
 
@@ -782,10 +788,11 @@ describe("generated output", () => {
         "  protected selectorForTestId(testId: string): string {",
         "    return `[data-testid=\"${testId}\"]`;",
         "  }",
-        "  protected async clickByTestId(_testId: string, _annotationText: string = '', _wait: boolean = true, _description?: string): Promise<void> {}",
+        "  protected async clickByTestId(_testId: string, _annotationText: string = '', _wait: boolean = true, _description?: string, _action?: { componentName?: string; methodName: string; preferAssociatedLabel?: boolean }): Promise<void> {}",
         "  protected async clickLocator(_locator: any, _annotationText: string = '', _wait: boolean = true): Promise<void> {}",
-        "  protected async fillInputByTestId(_testId: string, _text: string, _annotationText: string = '', _description?: string): Promise<void> {}",
-        "  protected async selectVSelectByTestId(_testId: string, _value: string, _timeOut = 500, _annotationText: string = '', _description?: string): Promise<void> {}",
+        "  protected async fillInputByTestId(_testId: string, _text: string, _annotationText: string = '', _description?: string, _action?: { componentName?: string; methodName: string }): Promise<void> {}",
+        "  protected async selectVSelectByTestId(_testId: string, _value: string, _annotationText: string = '', _description?: string, _action?: { componentName?: string; methodName: string }): Promise<void> {}",
+        "  protected recordPomAction(_componentName: string | undefined, _methodName: string, _expectedTestIds: readonly string[]): void {}",
         "  protected async animateCursorToElement(_selector: string, _executeClick = true, _delay = 100, _annotationText: string = '', _waitForInstrumentationEvent = true): Promise<void> {}",
         "}",
         "",

--- a/tests/method-generation.test.ts
+++ b/tests/method-generation.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { generateViewObjectModelMethodContent } from "../method-generation";
+import { createPomStringPattern } from "../pom-patterns";
+
+describe("alternate generated selectors", () => {
+  it("auto-waits for one visible generated candidate before clicking", () => {
+    const content = generateViewObjectModelMethodContent(
+      "RecordListPage",
+      undefined,
+      "CreateRecord",
+      "button",
+      createPomStringPattern("RecordListPage-Create-button", "static", []),
+      [createPomStringPattern("RecordListPage-New-button", "static", [])],
+      undefined,
+      [],
+    );
+
+    expect(content).toContain("await this.resolveVisibleTestIdLocator(candidates");
+    expect(content).toContain('"clickCreateRecord", "RecordListPage"');
+    expect(content).not.toContain("locator.count()");
+    expect(content).not.toContain("Failed to click any candidate locator");
+  });
+
+  it("uses the same candidate resolution for generated navigation", () => {
+    const content = generateViewObjectModelMethodContent(
+      "RecordListPage",
+      "RecordCreatePage",
+      "CreateRecord",
+      "button",
+      createPomStringPattern("RecordListPage-Create-routerlink", "static", []),
+      [createPomStringPattern("RecordListPage-New-routerlink", "static", [])],
+      undefined,
+      [],
+    );
+
+    expect(content).toContain("await this.resolveVisibleTestIdLocator(candidates");
+    expect(content).toContain('"goToCreateRecord", "RecordListPage"');
+    expect(content).not.toContain("locator.count()");
+  });
+});
+
+describe("generated checkbox actions", () => {
+  it("targets the visible associated label used by custom controls", () => {
+    const content = generateViewObjectModelMethodContent(
+      "RecordListPage",
+      undefined,
+      "SelectPage",
+      "checkbox",
+      createPomStringPattern("RecordListPage-SelectPage-checkbox", "static", []),
+      undefined,
+      undefined,
+      [],
+    );
+
+    expect(content).toContain('methodName: "clickSelectPage", preferAssociatedLabel: true');
+  });
+});
+
+describe("generated radio actions", () => {
+  it("targets the visible associated label used by custom controls", () => {
+    const content = generateViewObjectModelMethodContent(
+      "RadioGroup",
+      undefined,
+      "OptionByKey",
+      "radio",
+      createPomStringPattern("RadioGroup-${key}-Option-radio", "parameterized", ["key"]),
+      undefined,
+      undefined,
+      [{ name: "key", type: "string" }],
+    );
+
+    expect(content).toContain('methodName: "selectOptionByKey", preferAssociatedLabel: true');
+  });
+});

--- a/tests/playwright-diagnostics.test.ts
+++ b/tests/playwright-diagnostics.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment node
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Buffer } from "node:buffer";
+import type { BrowserContext, Page } from "playwright";
+import { describe, expect, it } from "vitest";
+
+import {
+  installPomFailureDiagnostics,
+  POM_FAILURE_ATTACHMENT_NAME,
+  recordPomAction,
+  type PomDiagnosticsTestInfo,
+  type PomManifest,
+} from "../class-generation/diagnostics";
+
+describe("Playwright failure diagnostics", () => {
+  it("captures live browser state, buffered errors, and parameterized method availability", async () => {
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "vue-pom-diagnostics-"));
+    try {
+      const pageListeners = new Map<string, (value: never) => void>();
+      const contextListeners = new Map<string, (value: never) => void>();
+      let page: Page;
+      const context = Object.assign({} as BrowserContext, {
+        pages: () => [page],
+        on: (event: string, callback: (value: never) => void) => {
+          contextListeners.set(event, callback);
+          return context;
+        },
+      });
+      page = Object.assign({} as Page, {
+        context: () => context,
+        evaluate: async () => ({
+          title: "Records",
+          elements: [{
+            testId: "RecordListPage-42-Delete-button",
+            tag: "button",
+            role: "button",
+            name: "Delete record",
+            visible: true,
+            enabled: true,
+          }],
+        }),
+        isClosed: () => false,
+        locator: () => ({ ariaSnapshot: async () => "- main:\n  - button \"Delete record\"" }),
+        on: (event: string, callback: (value: never) => void) => {
+          pageListeners.set(event, callback);
+          return page;
+        },
+        screenshot: async ({ path: screenshotPath }: { path: string }) => {
+          fs.writeFileSync(screenshotPath, "screenshot", "utf8");
+          return Buffer.from("screenshot");
+        },
+        url: () => "http://localhost/records",
+      });
+
+      const attachments: Array<{ name: string; path?: string }> = [];
+      const testInfo: PomDiagnosticsTestInfo = {
+        outputPath: (...segments) => path.join(outputDir, ...segments),
+        attach: async (name, options) => {
+          attachments.push({ name, path: options?.path });
+        },
+      };
+      const manifest: PomManifest = {
+        RecordListPage: {
+          componentName: "RecordListPage",
+          className: "RecordListPage",
+          sourceFile: "/repo/src/views/RecordListPage.vue",
+          kind: "view",
+          entries: [{
+            testId: "RecordListPage-${recordId}-Delete-button",
+            selectorPatternKind: "parameterized",
+            generatedMethods: [{
+              name: "clickDeleteRecord",
+              kind: "action",
+              parameters: [
+                { name: "recordId", type: "string" },
+                { name: "annotationText", typeExpression: "string = \"\"", type: "string", initializer: "\"\"" },
+              ],
+            }],
+          }],
+        },
+      };
+
+      const capture = installPomFailureDiagnostics(page, manifest, testInfo);
+      recordPomAction(page, {
+        componentName: "RecordListPage",
+        methodName: "clickDeleteRecord",
+        expectedTestIds: ["RecordListPage-42-Delete-button"],
+      });
+      pageListeners.get("console")?.({ type: () => "error", text: () => "browser failed" } as never);
+      pageListeners.get("pageerror")?.(new Error("uncaught browser error") as never);
+      pageListeners.get("request")?.({
+        method: () => "GET",
+        resourceType: () => "fetch",
+        url: () => "http://localhost/api/records/pending",
+      } as never);
+      pageListeners.get("requestfailed")?.({
+        failure: () => ({ errorText: "connection reset" }),
+        method: () => "GET",
+        url: () => "http://localhost/api/records",
+      } as never);
+      pageListeners.get("response")?.({
+        headers: () => ({ "content-type": "application/problem+json" }),
+        request: () => ({ method: () => "POST" }),
+        status: () => 500,
+        text: async () => JSON.stringify({ title: "Migration failed", detail: "Duplicate record" }),
+        url: () => "http://localhost/api/records/migrate",
+      } as never);
+
+      const result = await capture.capture();
+
+      expect(result.activeAction?.methodName).toBe("clickDeleteRecord");
+      expect(result.pages[0]?.component?.className).toBe("RecordListPage");
+      expect(result.pages[0]?.component?.methods[0]).toMatchObject({
+        signature: "clickDeleteRecord(recordId: string, annotationText: string = \"\")",
+        state: "present",
+      });
+      expect(result.console).toContain("[error] browser failed");
+      expect(result.pageErrors).toContain("uncaught browser error");
+      expect(result.networkFailures[0]).toContain("connection reset");
+      expect(result.httpFailures?.[0]).toEqual({
+        status: 500,
+        method: "POST",
+        url: "http://localhost/api/records/migrate",
+        contentType: "application/problem+json",
+        body: JSON.stringify({ title: "Migration failed", detail: "Duplicate record" }),
+      });
+      expect(result.pendingRequests?.[0]).toContain("GET fetch http://localhost/api/records/pending — pending");
+      expect(fs.existsSync(result.jsonPath)).toBe(true);
+      expect(attachments.some(attachment => attachment.name === POM_FAILURE_ATTACHMENT_NAME)).toBe(true);
+    }
+    finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/playwright-reporter.test.ts
+++ b/tests/playwright-reporter.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment node
+import type { TestCase, TestResult } from "@playwright/test/reporter";
+import { describe, expect, it } from "vitest";
+
+import type { PomFailureDiagnostics } from "../class-generation/diagnostics";
+import { formatPomFailureReport } from "../playwright/reporter";
+
+function fakeTestCase(): TestCase {
+  return Object.assign({} as TestCase, {
+    expectedStatus: "passed",
+    location: { file: "/repo/tests/playwright/record.spec.ts", line: 42, column: 3 },
+    parent: { project: () => ({ name: "chromium" }) },
+    titlePath: () => ["record.spec.ts", "records", "creates a record"],
+  });
+}
+
+function fakeResult(): TestResult {
+  return Object.assign({} as TestResult, {
+    attachments: [],
+    errors: [{ message: "locator did not become visible", stack: "Error: locator did not become visible\n  at record.spec.ts:42:3" }],
+    retry: 0,
+    status: "failed",
+  });
+}
+
+function diagnostics(): PomFailureDiagnostics {
+  return {
+    schemaVersion: 1,
+    capturedAt: "2026-08-15T00:00:00.000Z",
+    captureBudgetMs: 5_000,
+    activeAction: {
+      componentName: "RecordListPage",
+      methodName: "goToCreateRecord",
+      expectedTestIds: ["RecordListPage-Create-routerlink", "RecordListPage-New-routerlink"],
+    },
+    pages: [{
+      url: "http://localhost/records",
+      title: "Records",
+      closed: false,
+      ariaSnapshot: "- main:\n  - heading \"Records\"",
+      renderedElements: [{
+        testId: "RecordListPage-Create-routerlink",
+        tag: "a",
+        role: "link",
+        name: "Create record",
+        visible: true,
+        enabled: true,
+      }],
+      component: {
+        componentName: "RecordListPage",
+        className: "RecordListPage",
+        sourceFile: "/repo/src/views/RecordListPage.vue",
+        matchedTestIds: 1,
+        methods: [{
+          methodName: "goToCreateRecord",
+          kind: "action",
+          signature: "goToCreateRecord()",
+          expectedTestIds: ["RecordListPage-Create-routerlink", "RecordListPage-New-routerlink"],
+          state: "present",
+        }, {
+          methodName: "clickDeleteRecord",
+          kind: "action",
+          signature: "clickDeleteRecord(recordId: string)",
+          expectedTestIds: ["RecordListPage-${recordId}-Delete-button"],
+          state: "absent",
+        }],
+      },
+      routerNavigation: {
+        id: 3,
+        status: "pending",
+        stage: "waiting-for-router-ready",
+        targetName: "records",
+      },
+      screenshotPath: "/tmp/vue-pom-generator-failure.png",
+      captureErrors: [],
+    }],
+    console: ["[error] example browser error"],
+    pageErrors: [],
+    networkFailures: ["500 GET http://localhost/api/records"],
+    httpFailures: [{
+      status: 500,
+      method: "GET",
+      url: "http://localhost/api/records",
+      contentType: "application/problem+json",
+      body: '{"title":"Database unavailable"}',
+    }],
+    pendingRequests: ["GET fetch http://localhost/api/v1/auth — pending 5001ms"],
+    jsonPath: "/tmp/vue-pom-generator-failure.json",
+  };
+}
+
+describe("Playwright failure reporter", () => {
+  it("prints actionable generated-method context and an isolated rerun", () => {
+    const report = formatPomFailureReport(fakeTestCase(), fakeResult(), diagnostics());
+
+    expect(report).toContain("RecordListPage.goToCreateRecord");
+    expect(report).toContain("[present] goToCreateRecord()");
+    expect(report).toContain("[absent] clickDeleteRecord(recordId: string)");
+    expect(report).toContain("Availability describes the current page state");
+    expect(report).toContain("500 GET http://localhost/api/records");
+    expect(report).toContain("pending at waiting-for-router-ready -> records");
+    expect(report).toContain("GET fetch http://localhost/api/v1/auth — pending 5001ms");
+    expect(report).toContain("--max-failures=1");
+    expect(report).toContain("record.spec.ts:42");
+    expect(report).toContain("/tmp/vue-pom-generator-failure.json");
+    expect(report).toContain("HTTP error responses:");
+    expect(report).toContain('{"title":"Database unavailable"}');
+  });
+
+  it("keeps the footer when the stdout report is truncated", () => {
+    const report = formatPomFailureReport(fakeTestCase(), fakeResult(), diagnostics(), { maxOutputCharacters: 900 });
+
+    expect(report.length).toBeLessThanOrEqual(900);
+    expect(report).toContain("report truncated");
+    expect(report).toContain("Structured diagnostics:");
+    expect(report).toContain("--max-failures=1");
+  });
+
+  it("explains when no browser diagnostic attachment exists", () => {
+    const report = formatPomFailureReport(fakeTestCase(), fakeResult(), null);
+
+    expect(report).toContain("Browser diagnostics: unavailable");
+    expect(report).toContain("Structured diagnostics: unavailable");
+  });
+});

--- a/tests/pointer.test.ts
+++ b/tests/pointer.test.ts
@@ -31,6 +31,7 @@ class FakeKeyboard {
 class FakePage {
   public readonly keyboard = new FakeKeyboard();
   public readonly dom = new JSDOM("<!doctype html><html><body></body></html>");
+  public evaluateCalls = 0;
 
   public constructor() {
     this.setViewport(1280, 720);
@@ -44,6 +45,7 @@ class FakePage {
   }
 
   async evaluate<TResult, TArg>(fn: ((arg: TArg) => TResult) | string, arg?: TArg): Promise<TResult> {
+    this.evaluateCalls += 1;
     if (typeof fn === "string") {
       return undefined as TResult;
     }
@@ -99,10 +101,17 @@ class FakePage {
 interface FakeElement {
   tagName: string;
   isContentEditable?: boolean;
+  parentElement?: FakeElement | null;
+  getAnimations?: () => Array<{
+    playState: string;
+    effect?: { getComputedTiming: () => { iterations: number } };
+    finished: Promise<unknown>;
+  }>;
 }
 
 class FakeLocator {
   public clicks = 0;
+  public lastClickOptions: { delay?: number; force?: boolean } | undefined;
   public clears = 0;
   public readonly fills: string[] = [];
   public descendant?: FakeLocator;
@@ -146,8 +155,9 @@ class FakeLocator {
     return null;
   }
 
-  async click(_options?: { delay?: number; force?: boolean }) {
+  async click(options?: { delay?: number; force?: boolean }) {
     this.clicks += 1;
+    this.lastClickOptions = options;
   }
 
   async clear() {
@@ -254,7 +264,48 @@ describe("pointer", () => {
     await pointer.animateCursorToElementAndClickAndFill(wrapper as never, "Acme", true, 0);
 
     expect(wrapper.clicks).toBe(1);
+    expect(wrapper.lastClickOptions?.force).toBeUndefined();
     expect(input.fills).toEqual(["Acme"]);
+  });
+
+  it("treats an empty animation option as the fast non-forced path", async () => {
+    setPlaywrightAnimationOptions({});
+    const page = new FakePage();
+    const target = new FakeLocator({ tagName: "BUTTON" }, { testId: "Save-button" });
+
+    const pointer = new Pointer(page as never, "data-testid");
+    await pointer.animateCursorToElement(target as never, true, 1_000);
+
+    expect(target.clicks).toBe(1);
+    expect(target.lastClickOptions?.force).toBeUndefined();
+    expect(page.evaluateCalls).toBe(0);
+    expect(page.dom.window.document.getElementById("__pw_pointer__")).toBeNull();
+  });
+
+  it("waits for a finite ancestor transition before clicking", async () => {
+    setPlaywrightAnimationOptions({ enabled: false });
+    let finishTransition!: () => void;
+    const transitionFinished = new Promise<void>((resolve) => {
+      finishTransition = resolve;
+    });
+    const overlay: FakeElement = {
+      tagName: "DIV",
+      getAnimations: () => [{
+        playState: "running",
+        effect: { getComputedTiming: () => ({ iterations: 1 }) },
+        finished: transitionFinished,
+      }],
+    };
+    const target = new FakeLocator({ tagName: "BUTTON", parentElement: overlay });
+    const pointer = new Pointer(new FakePage() as never, "data-testid");
+
+    const click = pointer.animateCursorToElement(target as never, true, 0);
+    await Promise.resolve();
+    expect(target.clicks).toBe(0);
+
+    finishTransition();
+    await click;
+    expect(target.clicks).toBe(1);
   });
 
   it("renders the simple red fallback bubble by default", async () => {

--- a/tests/router-bridge.test.ts
+++ b/tests/router-bridge.test.ts
@@ -11,14 +11,80 @@ describe("router bridge", () => {
     Reflect.deleteProperty(globalThis, POM_ROUTER_GLOBAL_NAME);
   });
 
-  it("exposes the live router under the key used by generated POMs", () => {
+  it("tracks successful navigation without returning the router promise", async () => {
+    let resolvePush!: () => void;
+    const pushPromise = new Promise<void>((resolve) => {
+      resolvePush = resolve;
+    });
     const router: PomNavigationRouter = {
-      push: () => undefined,
+      push: () => pushPromise,
       resolve: () => ({ href: "/persons/1" }),
+      isReady: async () => {},
     };
 
     exposeRouterForPomNavigation(router);
 
-    expect(Reflect.get(globalThis, POM_ROUTER_GLOBAL_NAME)).toBe(router);
+    const bridge = Reflect.get(globalThis, POM_ROUTER_GLOBAL_NAME);
+    const navigationId = bridge.beginNavigation({ name: "persons", params: { id: 1 } });
+
+    expect(navigationId).toBe(1);
+    expect(bridge.navigation).toMatchObject({
+      id: 1,
+      status: "pending",
+      stage: "waiting-for-router-ready",
+      targetName: "persons",
+    });
+
+    resolvePush();
+    await pushPromise;
+    await Promise.resolve();
+
+    expect(bridge.navigation).toMatchObject({
+      id: 1,
+      status: "succeeded",
+      stage: "complete",
+      targetName: "persons",
+    });
+  });
+
+  it("identifies a navigation blocked on initial router readiness", async () => {
+    const routerReady = new Promise<void>(() => {});
+    const router: PomNavigationRouter = {
+      push: () => Promise.resolve(),
+      resolve: () => ({ href: "/records" }),
+      isReady: () => routerReady,
+    };
+
+    exposeRouterForPomNavigation(router);
+
+    const bridge = Reflect.get(globalThis, POM_ROUTER_GLOBAL_NAME);
+    bridge.beginNavigation({ name: "records", params: {} });
+    await Promise.resolve();
+
+    expect(bridge.navigation).toEqual({
+      id: 1,
+      status: "pending",
+      stage: "waiting-for-router-ready",
+      targetName: "records",
+    });
+  });
+
+  it("serializes rejected router navigation for generated POMs", async () => {
+    const router: PomNavigationRouter = {
+      push: () => Promise.reject(new Error("guard rejected navigation")),
+      resolve: () => ({ href: "/persons/1" }),
+      isReady: async () => {},
+    };
+
+    exposeRouterForPomNavigation(router);
+
+    const bridge = Reflect.get(globalThis, POM_ROUTER_GLOBAL_NAME);
+    bridge.beginNavigation({ name: "persons", params: { id: 1 } });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(bridge.navigation.status).toBe("failed");
+    expect(bridge.navigation.stage).toBe("complete");
+    expect(bridge.navigation.error).toContain("guard rejected navigation");
   });
 });

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -521,7 +521,7 @@ describe('createTestIdTransform', () => {
 
     expect(code).toContain('__testid_event__')
     expect(code).toContain('"data-click-instrumented": "1"')
-    expect(code).toContain('"data-testid": `MyComp-${item.key ?? item.data?.id ?? item.id ?? item.value ?? item}-Remove-button`')
+    expect(code).toContain('"data-testid": `MyComp-${item.key ?? item.data?.id ?? item.id ?? item.value ?? item.url ?? item}-Remove-button`')
     expect(code).not.toContain('__testid_click_event_strict__')
   })
 
@@ -618,7 +618,7 @@ describe('createTestIdTransform', () => {
     )
 
     const testId = findFirstDataTestId(ast)
-    expect(testId).toBe('`MyComp-${data.key ?? data.data?.id ?? data.id ?? data.value ?? data}-OpenProject-button`')
+    expect(testId).toBe('`MyComp-${data.key ?? data.data?.id ?? data.id ?? data.value ?? data.url ?? data}-OpenProject-button`')
   })
 
   it('injects a stable keyed test id for scoped slot data objects through v-if wrappers', () => {
@@ -645,7 +645,7 @@ describe('createTestIdTransform', () => {
     )
 
     const testId = findFirstDataTestId(ast)
-    expect(testId).toBe('`MyComp-${maintenanceItem.key ?? maintenanceItem.data?.id ?? maintenanceItem.id ?? maintenanceItem.value ?? maintenanceItem}-MoveToTop-button`')
+    expect(testId).toBe('`MyComp-${maintenanceItem.key ?? maintenanceItem.data?.id ?? maintenanceItem.id ?? maintenanceItem.value ?? maintenanceItem.url ?? maintenanceItem}-MoveToTop-button`')
   })
 
   it('injects a stable keyed test id for scoped slot data objects with key prop', () => {
@@ -667,6 +667,27 @@ describe('createTestIdTransform', () => {
 
     const testId = findFirstDataTestId(ast)
     expect(testId).toBe('`MyComp-${key}-Remove-button`')
+  })
+
+  it('uses a slot item URL before falling back to object stringification', () => {
+    const componentHierarchyMap = new Map()
+
+    const ast = compileAndCaptureAst(
+      `
+        <MyList :items="items">
+          <template #item="{ item }">
+            <button @click="navigate(item)">Open</button>
+          </template>
+        </MyList>
+      `,
+      {
+        filename: '/src/components/MyComp.vue',
+        nodeTransforms: [createTestIdTransform('MyComp', componentHierarchyMap, {}, [], '/src/views')],
+      },
+    )
+
+    const testId = findFirstDataTestId(ast)
+    expect(testId).toBe('`MyComp-${item.key ?? item.data?.id ?? item.id ?? item.value ?? item.url ?? item}-Navigate-button`')
   })
 
   it('emits a singleton (non-keyed) test id for a slot-scope callback click handler', () => {
@@ -753,7 +774,7 @@ describe('createTestIdTransform', () => {
     )
 
     const testId = findFirstDataTestId(childAst)
-    expect(testId).toBe('`RolePermissionSubject-${subject.key ?? subject.data?.id ?? subject.id ?? subject.value ?? subject}-SelectAll-button`')
+    expect(testId).toBe('`RolePermissionSubject-${subject.key ?? subject.data?.id ?? subject.id ?? subject.value ?? subject.url ?? subject}-SelectAll-button`')
   })
 
   it('does not key child component testids when not in a keyed slot', () => {
@@ -1526,6 +1547,41 @@ describe('createTestIdTransform', () => {
       (p): p is AttributeNode => p.type === NodeTypes.ATTRIBUTE && p.name === 'data-testid',
     )
     expect(dataTestIdAttr?.value?.content).toBe('MyPage-Computers missing critical-link')
+  })
+
+  it('does not infer an action for a fragment wrapper whose injected attribute cannot fall through', () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vue-pom-generator-fragment-wrapper-'))
+    const actionButtonPath = path.join(tempRoot, 'src', 'components', 'ActionButton.vue')
+    const fragmentButtonPath = path.join(tempRoot, 'src', 'components', 'FragmentButton.vue')
+    fs.mkdirSync(path.dirname(actionButtonPath), { recursive: true })
+    fs.writeFileSync(actionButtonPath, '<template><button type="button"><slot /></button></template>')
+    fs.writeFileSync(
+      fragmentButtonPath,
+      '<template><ActionButton :handler="handler" /><div class="dialog" /></template>',
+    )
+
+    const componentHierarchyMap = new Map<string, IComponentDependencies>()
+    const vueFilesPathMap = new Map<string, string>([
+      ['ActionButton', actionButtonPath],
+      ['FragmentButton', fragmentButtonPath],
+    ])
+
+    const ast = compileAndCaptureAst(
+      '<FragmentButton :handler="saveRecord" />',
+      {
+        filename: path.join(tempRoot, 'src', 'views', 'RecordPage.vue'),
+        nodeTransforms: [createTestIdTransform('RecordPage', componentHierarchyMap, {}, [], path.join(tempRoot, 'src', 'views'), { vueFilesPathMap })],
+      },
+    )
+
+    expect(ast.children[0]?.type).toBe(NodeTypes.ELEMENT)
+    const fragmentButton = ast.children[0] as ElementNode
+    expect(fragmentButton.props.some(
+      prop => prop.type === NodeTypes.ATTRIBUTE && prop.name === 'data-testid',
+    )).toBe(false)
+
+    const methods = componentHierarchyMap.get('RecordPage')?.generatedMethods
+    expect(methods?.has('clickSaveRecord')).not.toBe(true)
   })
 
   it('does not infer a link role from a bare <a> without an href (and throws for the omitted role)', () => {

--- a/tests/utils-coverage.test.ts
+++ b/tests/utils-coverage.test.ts
@@ -568,9 +568,9 @@ describe("utils.ts coverage", () => {
     const span = findFirstTag(compiled, "span");
 
     expect(getContainedInSlotDataKeyInfo(span, map)).toEqual({
-      selectorFragment: "${data.key ?? data.data?.id ?? data.id ?? data.value ?? data}",
-      runtimeFragment: "${data.key ?? data.data?.id ?? data.id ?? data.value ?? data}",
-      rawExpression: "data.key ?? data.data?.id ?? data.id ?? data.value ?? data",
+      selectorFragment: "${data.key ?? data.data?.id ?? data.id ?? data.value ?? data.url ?? data}",
+      runtimeFragment: "${data.key ?? data.data?.id ?? data.id ?? data.value ?? data.url ?? data}",
+      rawExpression: "data.key ?? data.data?.id ?? data.id ?? data.value ?? data.url ?? data",
     });
   });
 
@@ -950,9 +950,9 @@ describe("utils.ts coverage", () => {
       nativeRole: "button",
       preferredGeneratedValue: staticAttributeValue("ignored"),
       keyInfo: {
-        selectorFragment: "${data.key ?? data.data?.id ?? data.id ?? data.value ?? data}",
-        runtimeFragment: "${data.key ?? data.data?.id ?? data.id ?? data.value ?? data}",
-        rawExpression: "data.key ?? data.data?.id ?? data.id ?? data.value ?? data",
+        selectorFragment: "${data.key ?? data.data?.id ?? data.id ?? data.value ?? data.url ?? data}",
+        runtimeFragment: "${data.key ?? data.data?.id ?? data.id ?? data.value ?? data.url ?? data}",
+        rawExpression: "data.key ?? data.data?.id ?? data.id ?? data.value ?? data.url ?? data",
       },
       testIdAttribute: "data-testid",
       existingIdBehavior: "preserve",

--- a/transform.ts
+++ b/transform.ts
@@ -562,6 +562,21 @@ function tryInferNativeWrapperRoleFromSfc(
   try {
     const ast = parseTemplate(template, { comments: false });
 
+    // Vue only applies fallthrough attributes automatically when a component
+    // renders a single root. A fragment can contain an interactive descendant,
+    // but a data-testid injected on the component invocation will never reach
+    // that descendant unless the component explicitly forwards $attrs. Do not
+    // manufacture an action whose selector cannot exist; authors can declare an
+    // explicit nativeWrappers entry when a fragment intentionally forwards it.
+    const renderedRoots = ast.children.filter((child) => {
+      return child.type !== NodeTypes.COMMENT
+        && !(child.type === NodeTypes.TEXT && child.content.trim() === "");
+    });
+    if (renderedRoots.length !== 1) {
+      inferredNativeWrapperConfigByLookup.set(cacheKey, { role: "" });
+      return null;
+    }
+
     const nextSeen = new Set(seenTags);
     nextSeen.add(tag);
 
@@ -1175,8 +1190,14 @@ export function createTestIdTransform(
         // Cache onto the nativeWrappers map so downstream utilities (formatTagName, wrapper transform)
         // see it consistently.
         (nativeWrappers as NativeWrappersMap)[element.tag] = { role: inferred.role, inferred: true };
-      } else if (element.tag.endsWith("Button")) {
+      } else if (
+        element.tag.endsWith("Button")
+        && !tryResolveSfcPathForTag(element.tag, vueFilesPathMap, wrapperSearchRoots)
+      ) {
         // Recognition of conventional naming for button components.
+        // Only use this for components whose source is unavailable. When the
+        // source is available but cannot be safely inferred (for example, a
+        // fragment root), naming alone must not override that evidence.
         (nativeWrappers as NativeWrappersMap)[element.tag] = { role: "button" };
       } else if (element.tag === "DxDataGrid") {
         (nativeWrappers as NativeWrappersMap)[element.tag] = { role: "grid" };
@@ -1648,7 +1669,11 @@ export function createTestIdTransform(
       return;
     }
 
-    if (handlerInfo) {
+    // `handler` is only actionable when this invocation is a proven native
+    // wrapper. Arbitrary Vue components may expose a prop with that name, and
+    // fragment components cannot receive an injected fallthrough attribute.
+    // Emitting a method in either case creates a selector that cannot exist.
+    if (handlerInfo && nativeWrappers[element.tag]) {
       const testId = getHandlerAttributeValueDataTestId(handlerInfo.semanticNameHint);
 
       applyResolvedDataTestIdForElement({

--- a/utils.ts
+++ b/utils.ts
@@ -462,7 +462,7 @@ function isSimpleScopeIdentifier(value: string): boolean {
 }
 
 export function buildSlotScopeFallbackKeyExpression(identifier: string): string {
-  return `${identifier}.key ?? ${identifier}.data?.id ?? ${identifier}.id ?? ${identifier}.value ?? ${identifier}`;
+  return `${identifier}.key ?? ${identifier}.data?.id ?? ${identifier}.id ?? ${identifier}.value ?? ${identifier}.url ?? ${identifier}`;
 }
 
 function tryGetBindingIdentifierName(node: BabelNode | null | undefined): string | null {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
         index: "./index.ts",
         // eslint sub-export: import "@immense/vue-pom-generator/eslint"
         "eslint/index": "./eslint/index.ts",
+        // Playwright failure reporter: import "@immense/vue-pom-generator/playwright/reporter"
+        "playwright/reporter": "./playwright/reporter.ts",
         // browser-safe router bridge: import "@immense/vue-pom-generator/router"
         router: "./router-bridge.ts",
       },
@@ -23,9 +25,14 @@ export default defineConfig({
           "@vue/compiler-dom",
           "@vue/compiler-sfc",
           "vite",
+          "playwright",
+          "@playwright/test",
         ]);
 
-        return (id: string) => id.startsWith("node:") || externals.has(id);
+        return (id: string) => id.startsWith("node:")
+          || id.startsWith("playwright/")
+          || id.startsWith("@playwright/test/")
+          || externals.has(id);
       })(),
       output: [
         {


### PR DESCRIPTION
## Summary

- emit failure diagnostics for every unexpected Playwright failure before the browser context is destroyed
- report the active generated action, current route, rendered test IDs, accessibility state, generated method availability, console errors, failed requests, and bounded HTTP failure bodies
- write the report directly to stdout and emit GitHub Actions annotations, while retaining a JSON attachment for deeper inspection
- expose a generated-method manifest and a composable ESLint configuration that rejects manual waits, network-idle waits, forced actions, and raw locator patterns
- make generated actions fail within five seconds and remove redundant runtime waits
- centralize router navigation emission and tighten fragment, wrapper, radio, checkbox, pointer, and transitive-POM behavior uncovered by consumer testing

## Why

The prior failure path often reported only a locator timeout after 30 seconds, after the useful browser state had already been destroyed. In the Immy consumer suite, the new report immediately exposed a failed migration request and its Npgsql response body, identifying an open-reader SaveChanges defect without a second diagnostic run.

Test authors now get the most relevant page and network state in the original test output. Missing methods are reported neutrally as availability data so a broadly unexpected page state is obvious without treating conditional UI as an error.

## Validation

- npm test: 401 passed
- npm run typecheck
- npm run lint
- npm run smoke:pack
- Immy full Aspire-backed Playwright suite with max-failures 1: passed in 4m37s