### PR TITLE
fix(runtime): activate nested checkbox controls

### DIFF
--- a/class-generation/base-page.ts
+++ b/class-generation/base-page.ts
@@ -8,6 +8,7 @@ import type { CalloutRenderer } from "./callout";
 import { Pointer, type AfterPointerClick, type AfterPointerClickInfo, type PointerRenderer } from "./pointer";
 
 const POM_ACTIVE_ACTION_REGISTRY = Symbol.for("@immense/vue-pom-generator.active-action-registry");
+const CHECKABLE_CONTROL_SELECTOR = 'input[type="checkbox"], input[type="radio"]';
 
 interface PomActiveActionRecord {
   componentName?: string;
@@ -608,8 +609,11 @@ export class BasePage {
       // Vue components commonly consume an `id` prop while fallthrough attributes such as
       // `data-testid` land on the component's root wrapper. Prefer the nested native control
       // when present so generated checkbox actions activate the control instead of its wrapper.
-      const nestedControl = locator.locator('input[type="checkbox"], input[type="radio"]').first();
-      const control = (await nestedControl.count()) > 0 ? nestedControl : locator;
+      const testIdSelector = this.selectorForTestId(testId);
+      const control = this.describeLocator(this.page.locator([
+        `${testIdSelector}:is(${CHECKABLE_CONTROL_SELECTOR})`,
+        `${testIdSelector} :is(${CHECKABLE_CONTROL_SELECTOR})`,
+      ].join(", ")), description).first();
       clickTarget = control;
       const controlId = await control.getAttribute("id");
       if (controlId) {

--- a/class-generation/base-page.ts
+++ b/class-generation/base-page.ts
@@ -605,8 +605,13 @@ export class BasePage {
     let clickTarget = locator;
     let activateWithKeyboard = false;
     if (action?.preferAssociatedLabel) {
-      const visibleControl = locator;
-      const controlId = await visibleControl.getAttribute("id");
+      // Vue components commonly consume an `id` prop while fallthrough attributes such as
+      // `data-testid` land on the component's root wrapper. Prefer the nested native control
+      // when present so generated checkbox actions activate the control instead of its wrapper.
+      const nestedControl = locator.locator('input[type="checkbox"], input[type="radio"]').first();
+      const control = (await nestedControl.count()) > 0 ? nestedControl : locator;
+      clickTarget = control;
+      const controlId = await control.getAttribute("id");
       if (controlId) {
         // Bootstrap custom controls often use an empty label whose painted ::before/::after
         // pseudo-elements intercept the pointer. Playwright's visible filter can exclude that
@@ -625,14 +630,11 @@ export class BasePage {
           }
         }
       }
-      else {
-        clickTarget = visibleControl;
-      }
     }
     const afterClick = this.getAfterPointerClick(wait);
     if (activateWithKeyboard) {
-      await this.pointer.animateCursorToElement(locator, false, 200, annotationText);
-      await locator.press("Space");
+      await this.pointer.animateCursorToElement(clickTarget, false, 200, annotationText);
+      await clickTarget.press("Space");
       if (afterClick) {
         await afterClick({ testId, instrumented: true });
       }

--- a/tests/broad/class-generation-base-page-ts.test.ts
+++ b/tests/broad/class-generation-base-page-ts.test.ts
@@ -248,6 +248,27 @@ describe("BasePage action helpers", () => {
     expect(checkbox.presses).toEqual([]);
   });
 
+  it("clicks the label for a nested checkbox when the test id is on its wrapper", async () => {
+    const wrapper = new FakeLocator({ tagName: "DIV" }, { testId: "SelectPage-checkbox" });
+    const checkbox = new FakeLocator({ tagName: "INPUT" }, { id: "select-page" });
+    const label = new FakeLocator({ tagName: "LABEL" });
+    wrapper.descendant = checkbox;
+    const fakePage = new FakePage();
+    fakePage.locator = vi.fn((selector: string) => selector.startsWith("label[for=") ? label : wrapper);
+    const page = new ExposedBasePage(fakePage);
+
+    await page.clickTestId("SelectPage-checkbox", "", true, "Select page", {
+      componentName: "RecordListPage",
+      methodName: "clickSelectPage",
+      preferAssociatedLabel: true,
+    });
+
+    expect(label.clicks).toBe(1);
+    expect(wrapper.clicks).toBe(0);
+    expect(checkbox.clicks).toBe(0);
+    expect(checkbox.presses).toEqual([]);
+  });
+
   it("keyboard-activates a checkable input whose empty associated label has no visible box", async () => {
     const checkbox = new FakeLocator({ tagName: "INPUT" }, { id: "select-page", testId: "SelectPage-checkbox" });
     const emptyLabel = new FakeLocator({ tagName: "LABEL" }, { visible: false });
@@ -262,6 +283,27 @@ describe("BasePage action helpers", () => {
     });
 
     expect(emptyLabel.clicks).toBe(0);
+    expect(checkbox.clicks).toBe(0);
+    expect(checkbox.presses).toEqual(["Space"]);
+  });
+
+  it("keyboard-activates a nested checkbox whose associated label has no visible box", async () => {
+    const wrapper = new FakeLocator({ tagName: "DIV" }, { testId: "SelectPage-checkbox" });
+    const checkbox = new FakeLocator({ tagName: "INPUT" }, { id: "select-page" });
+    const emptyLabel = new FakeLocator({ tagName: "LABEL" }, { visible: false });
+    wrapper.descendant = checkbox;
+    const fakePage = new FakePage();
+    fakePage.locator = vi.fn((selector: string) => selector.startsWith("label[for=") ? emptyLabel : wrapper);
+    const page = new ExposedBasePage(fakePage);
+
+    await page.clickTestId("SelectPage-checkbox", "", true, "Select page", {
+      componentName: "RecordListPage",
+      methodName: "clickSelectPage",
+      preferAssociatedLabel: true,
+    });
+
+    expect(emptyLabel.clicks).toBe(0);
+    expect(wrapper.clicks).toBe(0);
     expect(checkbox.clicks).toBe(0);
     expect(checkbox.presses).toEqual(["Space"]);
   });

--- a/tests/broad/class-generation-base-page-ts.test.ts
+++ b/tests/broad/class-generation-base-page-ts.test.ts
@@ -248,25 +248,26 @@ describe("BasePage action helpers", () => {
     expect(checkbox.presses).toEqual([]);
   });
 
-  it("clicks the label for a nested checkbox when the test id is on its wrapper", async () => {
-    const wrapper = new FakeLocator({ tagName: "DIV" }, { testId: "SelectPage-checkbox" });
-    const checkbox = new FakeLocator({ tagName: "INPUT" }, { id: "select-page" });
+  it.each(["checkbox", "radio"] as const)("clicks the label for a nested %s when the test id is on its wrapper", async (type) => {
+    const wrapper = new FakeLocator({ tagName: "DIV" }, { testId: `ChoiceField-${type}` });
+    const control = new FakeLocator({ tagName: "INPUT" }, { id: `${type}-choice` });
     const label = new FakeLocator({ tagName: "LABEL" });
-    wrapper.descendant = checkbox;
+    wrapper.descendant = control;
     const fakePage = new FakePage();
-    fakePage.locator = vi.fn((selector: string) => selector.startsWith("label[for=") ? label : wrapper);
+    fakePage.locator = vi.fn((selector: string) => selector.startsWith("label[for=") ? label : selector.includes(":is(input[") ? control : wrapper);
     const page = new ExposedBasePage(fakePage);
 
-    await page.clickTestId("SelectPage-checkbox", "", true, "Select page", {
-      componentName: "RecordListPage",
-      methodName: "clickSelectPage",
+    await page.clickTestId(`ChoiceField-${type}`, "", true, "Choose option", {
+      componentName: "ExampleForm",
+      methodName: "chooseOption",
       preferAssociatedLabel: true,
     });
 
+    expect(fakePage.locator).toHaveBeenCalledWith(`[data-testid="ChoiceField-${type}"]:is(input[type="checkbox"], input[type="radio"]), [data-testid="ChoiceField-${type}"] :is(input[type="checkbox"], input[type="radio"])`);
     expect(label.clicks).toBe(1);
     expect(wrapper.clicks).toBe(0);
-    expect(checkbox.clicks).toBe(0);
-    expect(checkbox.presses).toEqual([]);
+    expect(control.clicks).toBe(0);
+    expect(control.presses).toEqual([]);
   });
 
   it("keyboard-activates a checkable input whose empty associated label has no visible box", async () => {
@@ -288,17 +289,17 @@ describe("BasePage action helpers", () => {
   });
 
   it("keyboard-activates a nested checkbox whose associated label has no visible box", async () => {
-    const wrapper = new FakeLocator({ tagName: "DIV" }, { testId: "SelectPage-checkbox" });
-    const checkbox = new FakeLocator({ tagName: "INPUT" }, { id: "select-page" });
+    const wrapper = new FakeLocator({ tagName: "DIV" }, { testId: "TermsField-checkbox" });
+    const checkbox = new FakeLocator({ tagName: "INPUT" }, { id: "terms" });
     const emptyLabel = new FakeLocator({ tagName: "LABEL" }, { visible: false });
     wrapper.descendant = checkbox;
     const fakePage = new FakePage();
-    fakePage.locator = vi.fn((selector: string) => selector.startsWith("label[for=") ? emptyLabel : wrapper);
+    fakePage.locator = vi.fn((selector: string) => selector.startsWith("label[for=") ? emptyLabel : selector.includes(":is(input[") ? checkbox : wrapper);
     const page = new ExposedBasePage(fakePage);
 
-    await page.clickTestId("SelectPage-checkbox", "", true, "Select page", {
-      componentName: "RecordListPage",
-      methodName: "clickSelectPage",
+    await page.clickTestId("TermsField-checkbox", "", true, "Accept terms", {
+      componentName: "ExampleForm",
+      methodName: "clickTerms",
       preferAssociatedLabel: true,
     });
 


### PR DESCRIPTION
## Summary

- resolve native checkbox and radio controls when a generated test ID lands on a wrapper
- use one auto-waiting locator for either the test-ID control or its nested control
- activate an associated label when available and use keyboard activation for zero-box labels

## Why

Vue components can consume an `id` prop while fallthrough attributes land on the root wrapper. Generated checkable actions must resolve the native control without taking a non-waiting DOM snapshot or falling back to clicking the wrapper.

## Validation

- `npm test` — 404 passed
- `npm run build`
- `npm run typecheck`
- `npm run lint` — 0 errors, 8 pre-existing fixture warnings
- `npm run test:playwright` — 3 passed
- `npm run smoke:pack`
- delayed-control Playwright probe resolved the native input after its wrapper rendered