### PR TITLE
feat(playwright): export POM runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,22 @@ This is where most people need precision.
 
 Every `.ts` file in `customPoms.dir` is available for import from the generated TypeScript output.
 
+Handwritten helpers that extend the generator runtime should use its public entry point:
+
+```ts
+import { BasePage } from "@immense/vue-pom-generator/playwright/runtime";
+
+export class DataGrid extends BasePage {
+  async selectFirstRow(): Promise<void> {
+    await this.page.getByRole("row").nth(1).click();
+  }
+}
+```
+
+Do not import from a consumer's generated `_pom-runtime` directory. That directory is regenerated
+and is an implementation detail of the emitted files; the package export is the stable contract for
+handwritten POMs.
+
 - in aggregated mode, helper files become imports in the shared aggregate
 - in split mode, each generated file imports only the helpers it actually needs
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
       "types": "./dist/playwright/reporter.d.ts",
       "import": "./dist/playwright/reporter.mjs",
       "require": "./dist/playwright/reporter.cjs"
+    },
+    "./playwright/runtime": {
+      "types": "./dist/class-generation/base-page.d.ts",
+      "import": "./dist/playwright/runtime.mjs",
+      "require": "./dist/playwright/runtime.cjs"
     }
   },
   "files": [

--- a/scripts/packed-smoke-check.mjs
+++ b/scripts/packed-smoke-check.mjs
@@ -134,6 +134,24 @@ try {
     { cwd: tempRoot },
   );
 
+  // Verify handwritten POMs can consume the supported runtime entry point from a packed install.
+  run(
+    "node",
+    [
+      "-e",
+      [
+        "(async () => {",
+        "  const runtime = await import('@immense/vue-pom-generator/playwright/runtime');",
+        "  if (typeof runtime.BasePage !== 'function' || typeof runtime.ObjectId !== 'function') {",
+        "    throw new Error('Expected public Playwright runtime exports');",
+        "  }",
+        "  console.log('[packed-smoke] ok: public Playwright runtime');",
+        "})();",
+      ].join("\n"),
+    ],
+    { cwd: tempRoot },
+  );
+
   // Cleanup tarball + temp workspace.
   fs.rmSync(tarballPath, { force: true });
   fs.rmSync(tempRoot, { recursive: true, force: true });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,8 @@ export default defineConfig({
         "eslint/index": "./eslint/index.ts",
         // Playwright failure reporter: import "@immense/vue-pom-generator/playwright/reporter"
         "playwright/reporter": "./playwright/reporter.ts",
+        // Public BasePage runtime for handwritten POMs.
+        "playwright/runtime": "./class-generation/base-page.ts",
         // browser-safe router bridge: import "@immense/vue-pom-generator/router"
         router: "./router-bridge.ts",
       },


### PR DESCRIPTION
## Summary

- Export `BasePage`, `ObjectId`, and related types from `@immense/vue-pom-generator/playwright/runtime`.
- Document the supported import for handwritten POMs.
- Verify the subpath from an installed package tarball.

## Why

Consumers should not reach into their gitignored generated `_pom-runtime` tree to extend `BasePage`. The package entry point is a stable, typed contract backed by the same generic runtime source the generator vendors into emitted POMs.

## Validation

- `npm run build`
- `npm run typecheck`
- `npm run lint` (0 errors; 8 pre-existing fixture warnings)
- 36 focused BasePage tests
- `npm run smoke:pack`

## Release notes

- Added `@immense/vue-pom-generator/playwright/runtime` for handwritten Playwright page objects.