### PR TITLE
feat!: generate scoped component instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,6 +734,66 @@ Actual current rules:
 
 Without `flatten`, helper composition still works; you just call through the helper property explicitly.
 
+## Semantic, scoped component instances
+
+Generated TypeScript POMs model component **invocations**, not only component types. Each
+addressable invocation receives a generator-owned `data-pom-instance` marker on the DOM
+root that accepts Vue fallthrough attributes. The child POM is rooted at that marker, so
+identical controls in two component instances cannot accidentally select each other.
+
+Instance names come from author-visible semantics, in this order:
+
+1. a static accessible name (`aria-label`, `label`, `title`, or `name`)
+2. the identifier bound to `:options`
+3. the `v-model` / `:model-value` identifier
+4. the component tag as the fallback
+
+The generator tries those candidates in order. If an earlier invocation already owns a
+semantic candidate, the later invocation uses its next candidate instead. For example, a
+dialog titled `RDP Password` can own `RdpPassword` while its nested copy-input falls back
+to `CopyToClipboardInput`. Repeated structural wrappers with no unique candidate are
+omitted from composition; their ordinary generated controls are unaffected.
+
+Static invocations become properties. Repeated invocations with a stable `:key` become
+methods whose argument selects the instance:
+
+```vue
+<DynamicFormField
+  v-for="parameter in parameters"
+  :key="parameter.name"
+  :parameter="parameter"
+/>
+
+<ImmyRadioGroup
+  aria-label="Override policy options"
+  :options="overridePolicyOptions"
+/>
+```
+
+```ts
+form
+  .DynamicFormField(parameterName)
+  .OnboardingOption
+  .OverridePolicyOptions
+  .selectByValue(ParameterOverridePolicy.Require);
+```
+
+Named slot content is projected onto the component instance that receives the slot. That
+is why the example can expose `OnboardingOption` beneath `DynamicFormField` even when an
+intermediate form component forwards the slot. The generator only emits this projection
+when the receiving boundary and every attached child have one statically provable scope.
+Keyed slot owners and keyed projected content fail generation instead of producing a
+misleading API. Components that do not forward the marker to a DOM root are omitted from
+component-instance composition rather than falling back to page-wide selectors; their
+own standalone fixture is still generated normally.
+
+When `injection.optionKeyAttribute` maps a radio component to `"value"`, its generated
+selection API uses the domain term directly: `selectByValue(value)`. Other configured
+attribute names retain `key` when the HTML attribute name is not a valid public TypeScript
+identifier (for example `data-value`).
+
+`data-pom-instance` is generator-owned. Do not author it in Vue templates.
+
 ## Playwright fixtures: actual behavior and caveats
 
 When `generation.playwright.fixtures` is enabled, the generator emits a strongly typed Playwright fixture module.

--- a/class-generation/base-page.ts
+++ b/class-generation/base-page.ts
@@ -75,6 +75,8 @@ export type Fluent<T extends object> = DeepFluent<T, T> & PromiseLike<T>;
 export type ValueFluent<T> = DeepValueFluent<T> & PromiseLike<T>;
 
 export interface BasePageOptions {
+  /** Locator that scopes every generated selector in this component POM. */
+  root?: PwLocator;
   renderers?: {
     callout?: CalloutRenderer;
     pointer?: PointerRenderer;
@@ -133,6 +135,7 @@ export class BasePage {
    * etc. for JS/DOM elements the generator can't key.
    */
   private readonly _page: PwPage;
+  private readonly _root?: PwLocator;
 
   /**
    * Playwright's full `Page`, exposed to subclasses. This is the single,
@@ -149,6 +152,7 @@ export class BasePage {
    */
   public constructor(page: PwPage, options?: BasePageOptions) {
     this._page = page;
+    this._root = options?.root;
     this.testIdAttribute = (options?.testIdAttribute || "data-testid").trim() || "data-testid";
 
     const pointerRenderer = options?.renderers?.pointer;
@@ -287,8 +291,20 @@ export class BasePage {
     return normalizedDescription ? locator.describe(normalizedDescription) : locator;
   }
 
+  private locatorInScope(selector: string, within?: PwLocator): Locator {
+    const root = within ?? this._root;
+    return (root ? root.locator(selector) : this._page.locator(selector)) as Locator;
+  }
+
+  /** Resolve a generated component-instance marker inside this POM's current scope. */
+  protected componentInstanceLocator(instanceId: string, within?: PwLocator): Locator {
+    return this.locatorInScope(`[data-pom-instance=${JSON.stringify(instanceId)}]`, within)
+      .filter({ visible: true })
+      .first();
+  }
+
   protected locatorByTestId(testId: string, description?: string): Locator {
-    return this.describeLocator(this.page.locator(this.selectorForTestId(testId)), description);
+    return this.describeLocator(this.locatorInScope(this.selectorForTestId(testId)), description);
   }
 
   protected async resolveVisibleTestIdLocator(
@@ -612,7 +628,7 @@ export class BasePage {
         // pseudo-elements intercept the pointer. Playwright's visible filter can exclude that
         // empty label even though its pseudo-element is the actual interaction surface, so first
         // select the associated label by DOM presence and then choose pointer or keyboard activation.
-        const associatedLabel = this.page.locator(`label[for=${JSON.stringify(controlId)}]`).first();
+        const associatedLabel = this.locatorInScope(`label[for=${JSON.stringify(controlId)}]`).first();
         if (await associatedLabel.count() > 0) {
           if (await associatedLabel.isVisible()) {
             clickTarget = associatedLabel;

--- a/class-generation/index.ts
+++ b/class-generation/index.ts
@@ -26,6 +26,7 @@ import {
   isParameterizedPomPattern,
   orderPomPatternParameters,
   toCSharpPomPatternExpression,
+  toTypeScriptPomPatternExpression,
   uniquePomStringPatterns,
   type PomStringPattern,
 } from "../pom-patterns";
@@ -37,6 +38,7 @@ import {
   buildCommentBlock,
   buildFilePrefix,
   createClassConstructor,
+  createClassGetter,
   createClassMethod,
   createClassProperty,
   renderSourceFile,
@@ -49,10 +51,12 @@ import {
   type PropertyDeclarationStructure,
   type TypeScriptClassMember,
   type TypeScriptSourceFile,
+  type TypeScriptWriter,
 } from "../typescript-codegen";
 import {
   IComponentDependencies,
   IDataTestId,
+  PomComponentInstanceSpec,
   PomExtraClickMethodSpec,
   PomPrimarySpec,
   PomSelectorSpec,
@@ -69,6 +73,17 @@ import {
 } from "../route-navigation-codegen";
 
 void setPlaywrightAnimationOptions;
+
+interface ResolvedComponentInstance extends PomComponentInstanceSpec {
+  componentRef: string;
+  className: string;
+}
+
+interface ResolvedProjectedComponentInstance {
+  owner: ResolvedComponentInstance;
+  target: ResolvedComponentInstance;
+  contents: ResolvedComponentInstance[];
+}
 
 export { generateViewObjectModelMethodContent };
 
@@ -2002,28 +2017,149 @@ function prepareViewObjectModelClass(
     return Array.from(nestedRefs).some(child => hasGeneratedPomSurface(child, nextSeen));
   };
 
-  const rawComponentRefsForInstances = usedComponentSet?.size
-    ? usedComponentSet
-    : childrenComponentSet;
-  // A component may render itself recursively (e.g. a tree/list that nests same-named
-  // children). Without this guard the generator emits `this.<SelfName> = new <SelfName>(page)`
-  // in the constructor, which infinitely recurses the moment any POM transitively
-  // instantiates this class. A self-reference is never a useful child instance (it would
-  // just re-wrap the same page), so drop it before it becomes a property + ctor assignment.
+  // Recursive component invocations cannot become eager child POM instances without
+  // infinitely constructing themselves.
   const ownClassName = toPascalCaseLocal(componentName);
   const isSelfReference = (ref: string): boolean => {
     return toPascalCaseLocal(normalizeTrackedComponentRef(ref)) === ownClassName && ownClassName.length > 0;
   };
+
+  const resolveComponentInstance = (spec: PomComponentInstanceSpec): ResolvedComponentInstance | null => {
+    const componentRef = resolveTrackedComponentRef(spec.componentName);
+    if (
+      !componentRef
+      || isSelfReference(componentRef)
+      || !hasGeneratedPomSurface(componentRef, new Set([componentName]))
+    ) {
+      return null;
+    }
+
+    return {
+      ...spec,
+      componentRef,
+      className: normalizeTrackedComponentRef(componentRef),
+    };
+  };
+
+  const uniqueInstances = (
+    instances: ResolvedComponentInstance[],
+    ownerName: string,
+  ): ResolvedComponentInstance[] => {
+    const byPublicName = new Map<string, ResolvedComponentInstance>();
+    for (const instance of instances) {
+      const existing = byPublicName.get(instance.instanceName);
+      if (!existing) {
+        byPublicName.set(instance.instanceName, instance);
+        continue;
+      }
+
+      const sameInvocationShape = existing.componentRef === instance.componentRef
+        && JSON.stringify(existing.selector) === JSON.stringify(instance.selector)
+        && JSON.stringify(existing.parameters) === JSON.stringify(instance.parameters);
+      if (sameInvocationShape) {
+        continue;
+      }
+
+      throw new VuePomGeneratorError(
+        `Semantic component instance name ${JSON.stringify(instance.instanceName)} is ambiguous in ${ownerName}.\n`
+        + `It refers to both <${existing.componentName}> and <${instance.componentName}>.\n\n`
+        + "Fix: give the invocations distinct accessible names or distinct semantic model/options bindings.",
+      );
+    }
+    return Array.from(byPublicName.values());
+  };
+
+  const allInvocationSpecs = dependencies.componentInstances ?? [];
+  const directComponentInstances = uniqueInstances(
+    allInvocationSpecs
+      .filter(spec => !spec.suppliedSlot)
+      .map(resolveComponentInstance)
+      .filter((instance): instance is ResolvedComponentInstance => !!instance),
+    componentName,
+  );
+
+  const projectedComponentInstances: ResolvedProjectedComponentInstance[] = [];
+  for (const owner of directComponentInstances) {
+    const ownerDependencies = componentHierarchyMap.get(owner.componentRef);
+    if (!ownerDependencies?.slotOutlets?.length) {
+      continue;
+    }
+
+    const suppliedBySlot = new Map<string, ResolvedComponentInstance[]>();
+    for (const suppliedSpec of allInvocationSpecs) {
+      if (suppliedSpec.suppliedSlot?.ownerSourceId !== owner.sourceId) {
+        continue;
+      }
+      const supplied = resolveComponentInstance(suppliedSpec);
+      if (!supplied) {
+        continue;
+      }
+      const values = suppliedBySlot.get(suppliedSpec.suppliedSlot.name) ?? [];
+      values.push(supplied);
+      suppliedBySlot.set(suppliedSpec.suppliedSlot.name, values);
+    }
+
+    for (const [slotName, rawContents] of suppliedBySlot) {
+      const outletTargetIds = new Set(
+        ownerDependencies.slotOutlets
+          .filter(outlet => outlet.name === slotName)
+          .map(outlet => outlet.targetSourceId),
+      );
+      const targetInstances = uniqueInstances(
+        (ownerDependencies.componentInstances ?? [])
+          .filter(spec => outletTargetIds.has(spec.sourceId))
+          .map(resolveComponentInstance)
+          .filter((instance): instance is ResolvedComponentInstance => !!instance),
+        `${owner.className} slot ${JSON.stringify(slotName)}`,
+      );
+      const contents = uniqueInstances(rawContents, `${componentName} slot ${JSON.stringify(slotName)}`);
+      for (const target of targetInstances) {
+        if (owner.parameters.length > 0) {
+          throw new VuePomGeneratorError(
+            `Cannot project slot ${JSON.stringify(slotName)} through keyed component instance ${owner.instanceName} in ${componentName}.\n`
+            + "The owner and projected target require distinct key scopes, which cannot be represented by one unambiguous generated accessor.",
+          );
+        }
+        const keyedContent = contents.find(content => content.parameters.length > 0);
+        if (keyedContent) {
+          throw new VuePomGeneratorError(
+            `Cannot attach keyed slot content ${keyedContent.instanceName} as a property of ${target.instanceName} in ${componentName}.\n`
+            + "Move the repetition to the receiving component boundary so the generator can expose it as a keyed accessor.",
+          );
+        }
+        const existingProjection = projectedComponentInstances.find((projection) => {
+          return projection.owner.sourceId === owner.sourceId
+            && projection.target.instanceName === target.instanceName
+            && projection.target.componentRef === target.componentRef
+            && JSON.stringify(projection.target.selector) === JSON.stringify(target.selector);
+        });
+        if (existingProjection) {
+          existingProjection.contents = uniqueInstances(
+            [...existingProjection.contents, ...contents],
+            `${componentName} projected ${target.instanceName}`,
+          );
+          continue;
+        }
+        projectedComponentInstances.push({ owner, target, contents });
+      }
+    }
+  }
+
+  const rawComponentRefsForInstances = usedComponentSet?.size
+    ? usedComponentSet
+    : childrenComponentSet;
   const componentRefsForInstances = new Set<string>();
-  for (const ref of rawComponentRefsForInstances) {
-    const resolvedRef = resolveTrackedComponentRef(ref) ?? normalizeTrackedComponentRef(ref);
-    if (isSelfReference(resolvedRef)) {
-      continue;
+  for (const instance of directComponentInstances) {
+    if (!isSelfReference(instance.componentRef)) {
+      componentRefsForInstances.add(instance.componentRef);
     }
-    if (!hasGeneratedPomSurface(resolvedRef, new Set([componentName]))) {
-      continue;
+  }
+  for (const projection of projectedComponentInstances) {
+    for (const instance of [projection.owner, projection.target, ...projection.contents]) {
+      if (!isSelfReference(instance.componentRef)) {
+        componentRefsForInstances.add(instance.componentRef);
+      }
     }
-    componentRefsForInstances.add(resolvedRef);
   }
 
   const hasChildComponent = (needle: string) => {
@@ -2078,8 +2214,19 @@ function prepareViewObjectModelClass(
     : [];
 
   const className = toPascalCaseLocal(componentName);
-  const childInstancePropertyNames = Array.from(componentRefsForInstances)
-    .map(child => child.split(".vue")[0]);
+  const childInstancePropertyNames = [
+    ...directComponentInstances.map(instance => instance.instanceName),
+    ...projectedComponentInstances.map(projection => projection.target.instanceName),
+  ];
+  const duplicateChildInstanceName = childInstancePropertyNames.find((name, index) => {
+    return childInstancePropertyNames.indexOf(name) !== index;
+  });
+  if (duplicateChildInstanceName) {
+    throw new VuePomGeneratorError(
+      `Semantic component instance ${JSON.stringify(duplicateChildInstanceName)} would be emitted more than once in ${componentName}.\n`
+      + "Fix: give direct and slot-projected instances distinct accessible names or semantic bindings.",
+    );
+  }
   const blockedViewPassthroughMethodNames = new Set(
     attachmentsForThisClass
       .filter(a => a.flatten)
@@ -2093,24 +2240,24 @@ function prepareViewObjectModelClass(
 
   const members: TypeScriptClassMember[] = [];
   if (isView && (componentRefsForInstances.size > 0 || attachmentsForThisClass.length > 0 || widgetInstances.length > 0)) {
-    members.push(...getComponentInstances(componentRefsForInstances, componentHierarchyMap, attachmentsForThisClass, widgetInstances));
-    members.push(getConstructor(componentRefsForInstances, componentHierarchyMap, attachmentsForThisClass, widgetInstances, { testIdAttribute }));
+    members.push(...getComponentInstances(directComponentInstances, projectedComponentInstances, attachmentsForThisClass, widgetInstances));
+    members.push(getConstructor(directComponentInstances, attachmentsForThisClass, widgetInstances, { testIdAttribute }));
   }
   if (!isView && (componentRefsForInstances.size > 0 || attachmentsForThisClass.length > 0)) {
-    members.push(...getComponentInstances(componentRefsForInstances, componentHierarchyMap, attachmentsForThisClass));
-    members.push(getConstructor(componentRefsForInstances, componentHierarchyMap, attachmentsForThisClass, [], { testIdAttribute }));
+    members.push(...getComponentInstances(directComponentInstances, projectedComponentInstances, attachmentsForThisClass));
+    members.push(getConstructor(directComponentInstances, attachmentsForThisClass, [], { testIdAttribute }));
   }
 
   members.push(
     ...getAttachmentPassthroughMethods(componentName, dependencies, attachmentsForThisClass, reservedAttachmentPassthroughNames),
   );
 
-  if (isView && componentRefsForInstances.size === 1) {
+  if (isView && directComponentInstances.length === 1) {
     members.push(
       ...getViewPassthroughMethods(
         componentName,
         dependencies,
-        componentRefsForInstances,
+        directComponentInstances,
         componentHierarchyMap,
         blockedViewPassthroughMethodNames,
       ),
@@ -2128,6 +2275,8 @@ function prepareViewObjectModelClass(
   return {
     className,
     componentRefsForInstances,
+    directComponentInstances,
+    projectedComponentInstances,
     attachmentsForThisClass,
     widgetInstances,
     isView,
@@ -2235,7 +2384,10 @@ function generateViewObjectModelContent(
       addNamedImport(sourceFile, {
         moduleSpecifier: "@playwright/test",
         isTypeOnly: true,
-        namedImports: [{ name: "Page", alias: "PwPage" }],
+        namedImports: [
+          { name: "Locator", alias: "PwLocator" },
+          { name: "Page", alias: "PwPage" },
+        ],
       });
     }
 
@@ -2273,7 +2425,7 @@ function generateViewObjectModelContent(
 function getViewPassthroughMethods(
   viewName: string,
   viewDependencies: IComponentDependencies,
-  childrenComponentSet: Set<string>,
+  componentInstances: ResolvedComponentInstance[],
   componentHierarchyMap: Map<string, IComponentDependencies>,
   blockedMethodNames: Set<string> = new Set(),
 ) {
@@ -2282,8 +2434,8 @@ function getViewPassthroughMethods(
   // methodName -> candidates
   const methodToChildren = new Map<string, Array<{ childProp: string; signature: PomMethodSignature }>>();
 
-  for (const child of childrenComponentSet) {
-    const childDeps = componentHierarchyMap.get(child);
+  for (const instance of componentInstances) {
+    const childDeps = componentHierarchyMap.get(instance.componentRef);
     if (!childDeps || !childDeps.dataTestIdSet?.size)
       continue;
 
@@ -2292,7 +2444,7 @@ function getViewPassthroughMethods(
       continue;
 
     // Property name matches how we emit instance fields (strip .vue if present).
-    const childProp = child.endsWith(".vue") ? child.slice(0, -4) : child;
+    const childProp = instance.instanceName;
 
     for (const [name, sig] of methods.entries()) {
       if (!sig)
@@ -3234,8 +3386,8 @@ function getWidgetInstancesForView(
 }
 
 function getComponentInstances(
-  childrenComponent: Set<string>,
-  componentHierarchyMap: Map<string, IComponentDependencies>,
+  componentInstances: ResolvedComponentInstance[],
+  projectedComponentInstances: ResolvedProjectedComponentInstance[],
   attachmentsForThisView: Array<{ className: string; propertyName: string }> = [],
   widgetInstances: WidgetInstance[] = [],
 ) {
@@ -3255,31 +3407,83 @@ function getComponentInstances(
     }));
   }
 
-  childrenComponent.forEach((child) => {
-    if (componentHierarchyMap.has(child)) {
-      const childName = child.split(".vue")[0];
+  for (const instance of componentInstances) {
+    if (instance.parameters.length === 0) {
       declarations.push(createClassProperty({
-        name: childName,
-        type: childName,
+        name: instance.instanceName,
+        type: instance.className,
       }));
+      continue;
     }
-  });
+
+    declarations.push(createClassMethod({
+      name: instance.instanceName,
+      parameters: toTypeScriptPomParameterStructures(instance.parameters),
+      returnType: instance.className,
+      statements: (writer) => {
+        writer.writeLine(`const root = this.componentInstanceLocator(${toTypeScriptPomPatternExpression(instance.selector)});`);
+        writer.writeLine(`return new ${instance.className}(this.page, root);`);
+      },
+    }));
+  }
+
+  for (const projection of projectedComponentInstances) {
+    const projectedPropertiesType = projection.contents.length > 0
+      ? ` & { ${projection.contents.map(content => `readonly ${content.instanceName}: ${content.className}`).join("; ")} }`
+      : "";
+    const statements = (writer: TypeScriptWriter) => {
+      const ownerSelector = toTypeScriptPomPatternExpression(projection.owner.selector);
+      const targetSelector = toTypeScriptPomPatternExpression(projection.target.selector);
+      writer.writeLine(`const ownerRoot = this.componentInstanceLocator(${ownerSelector});`);
+      writer.writeLine(`const root = this.componentInstanceLocator(${targetSelector}, ownerRoot);`);
+      writer.writeLine(`const instance = new ${projection.target.className}(this.page, root);`);
+      if (projection.contents.length === 0) {
+        writer.writeLine("return instance;");
+        return;
+      }
+
+      writer.writeLine("return Object.assign(instance, {");
+      writer.indent(() => {
+        for (const content of projection.contents) {
+          const contentSelector = toTypeScriptPomPatternExpression(content.selector);
+          writer.writeLine(`${content.instanceName}: new ${content.className}(this.page, this.componentInstanceLocator(${contentSelector}, root)),`);
+        }
+      });
+      writer.writeLine("});");
+    };
+    const returnType = `${projection.target.className}${projectedPropertiesType}`;
+
+    declarations.push(projection.target.parameters.length > 0
+      ? createClassMethod({
+          name: projection.target.instanceName,
+          parameters: toTypeScriptPomParameterStructures(projection.target.parameters),
+          returnType,
+          statements,
+        })
+      : createClassGetter({
+          name: projection.target.instanceName,
+          returnType,
+          statements,
+        }));
+  }
 
   return declarations;
 }
 
 function getConstructor(
-  childrenComponent: Set<string>,
-  componentHierarchyMap: Map<string, IComponentDependencies>,
+  componentInstances: ResolvedComponentInstance[],
   attachmentsForThisView: Array<{ className: string; propertyName: string }> = [],
   widgetInstances: WidgetInstance[] = [],
   options?: { testIdAttribute?: string },
 ) {
   const attr = (options?.testIdAttribute ?? "data-testid").trim() || "data-testid";
   return createClassConstructor({
-    parameters: [{ name: "page", type: "PwPage" }],
+    parameters: [
+      { name: "page", type: "PwPage" },
+      { name: "root", type: "PwLocator", hasQuestionToken: true },
+    ],
     statements: (writer) => {
-      writer.writeLine(`super(page, { testIdAttribute: ${JSON.stringify(attr)} });`);
+      writer.writeLine(`super(page, { root, testIdAttribute: ${JSON.stringify(attr)} });`);
 
       for (const a of attachmentsForThisView) {
         // Hand-written (custom) POMs are declared against Playwright's full `Page`.
@@ -3292,12 +3496,12 @@ function getConstructor(
         writer.writeLine(`this.${w.propertyName} = new ${w.className}(this.page, ${JSON.stringify(w.testId)});`);
       }
 
-      childrenComponent.forEach((child) => {
-        if (componentHierarchyMap.has(child)) {
-          const childName = child.split(".vue")[0];
-          writer.writeLine(`this.${childName} = new ${childName}(page);`);
+      for (const instance of componentInstances) {
+        if (instance.parameters.length === 0) {
+          const selector = toTypeScriptPomPatternExpression(instance.selector);
+          writer.writeLine(`this.${instance.instanceName} = new ${instance.className}(page, this.componentInstanceLocator(${selector}));`);
         }
-      });
+      }
     },
   });
 }

--- a/tests/base-page.test.ts
+++ b/tests/base-page.test.ts
@@ -8,6 +8,10 @@ class TestBasePage extends BasePage {
   public getLocator(testId: string, description?: string) {
     return this.locatorByTestId(testId, description);
   }
+
+  public getComponentInstance(instanceId: string) {
+    return this.componentInstanceLocator(instanceId);
+  }
 }
 
 describe("BasePage", () => {
@@ -33,5 +37,26 @@ describe("BasePage", () => {
     expect(basePage.getLocator("save-button", "Tenant editor save button")).toBe(describedLocator);
     expect(page.locator).toHaveBeenCalledWith('[data-testid="save-button"]');
     expect(rawLocator.describe).toHaveBeenCalledWith("Tenant editor save button");
+  });
+
+  it("resolves generated selectors and nested component instances inside the supplied root", () => {
+    const testIdLocator = new FakeLocator({ tagName: "INPUT" });
+    const componentLocator = new FakeLocator({ tagName: "DIV" });
+    const root = new FakeLocator({ tagName: "SECTION" });
+    root.locator = vi.fn((selector: string) => {
+      return selector.includes("data-pom-instance") ? componentLocator : testIdLocator;
+    });
+    const page = new FakePage();
+    page.locator = vi.fn(() => {
+      throw new Error("Scoped POMs must not query the page root");
+    });
+
+    const basePage = new TestBasePage(page, { root });
+
+    expect(basePage.getLocator("required-option")).toBe(testIdLocator);
+    expect(basePage.getComponentInstance("field-name-component")).toBe(componentLocator);
+    expect(root.locator).toHaveBeenNthCalledWith(1, '[data-testid="required-option"]');
+    expect(root.locator).toHaveBeenNthCalledWith(2, '[data-pom-instance="field-name-component"]');
+    expect(page.locator).not.toHaveBeenCalled();
   });
 });

--- a/tests/class-generation-coverage.test.ts
+++ b/tests/class-generation-coverage.test.ts
@@ -36,8 +36,11 @@ function writeMinimalBasePage(filePath: string) {
       "export type Fluent<T extends object> = T & PromiseLike<T>;",
       "export class BasePage {",
       "  public page: any;",
-      "  public constructor(page?: any, _options?: { testIdAttribute?: string }) {",
+      "  public constructor(page?: any, _options?: { root?: any; testIdAttribute?: string }) {",
       "    this.page = page;",
+      "  }",
+      "  protected componentInstanceLocator(_instanceId: string, _within?: any): any {",
+      "    return null as any;",
       "  }",
       "  protected describeLocator<T>(_locator: T, _description?: string): T {",
       "    return _locator;",
@@ -70,6 +73,8 @@ function makeDeps(options: Partial<IComponentDependencies> & { filePath: string 
     dataTestIdSet: options.dataTestIdSet ?? new Set(),
     methodsContent: options.methodsContent ?? "\n",
     generatedMethods: options.generatedMethods,
+    componentInstances: options.componentInstances,
+    slotOutlets: options.slotOutlets,
     isView: options.isView,
   };
 }
@@ -351,6 +356,13 @@ describe("class-generation coverage", () => {
         isView: true,
         usedComponentSet: new Set(["TenantDetailsEditForm"]),
         dataTestIdSet: new Set([navigationEntry]),
+        componentInstances: [{
+          sourceId: "tenant-form",
+          componentName: "TenantDetailsEditForm",
+          instanceName: "TenantDetailsEditForm",
+          selector: createPomStringPattern("TenantListPage-TenantDetailsEditForm-component", "static", []),
+          parameters: [],
+        }],
       });
 
       const depsForm = makeDeps({
@@ -427,6 +439,13 @@ describe("class-generation coverage", () => {
         filePath: path.join(tempRoot, "src", "views", "DeploymentDetailsPage.vue"),
         isView: true,
         usedComponentSet: new Set(["MaintenanceItemConfiguration"]),
+        componentInstances: [{
+          sourceId: "configuration",
+          componentName: "MaintenanceItemConfiguration",
+          instanceName: "MaintenanceItemConfiguration",
+          selector: createPomStringPattern("DeploymentDetailsPage-MaintenanceItemConfiguration-component", "static", []),
+          parameters: [],
+        }],
       });
 
       const depsNestedComponent = makeDeps({
@@ -460,10 +479,10 @@ describe("class-generation coverage", () => {
 
       const pageContent = readFile(path.join(outDir, "DeploymentDetailsPage.g.ts"));
       expect(pageContent).toContain('import { MaintenanceItemsMaintenanceItemConfiguration }');
-      expect(pageContent).toContain('MaintenanceItemsMaintenanceItemConfiguration: MaintenanceItemsMaintenanceItemConfiguration;');
-      expect(pageContent).toContain('this.MaintenanceItemsMaintenanceItemConfiguration = new MaintenanceItemsMaintenanceItemConfiguration(page);');
+      expect(pageContent).toContain('MaintenanceItemConfiguration: MaintenanceItemsMaintenanceItemConfiguration;');
+      expect(pageContent).toContain('this.MaintenanceItemConfiguration = new MaintenanceItemsMaintenanceItemConfiguration(page, this.componentInstanceLocator("DeploymentDetailsPage-MaintenanceItemConfiguration-component"));');
       expect(pageContent).toContain('async clickSave(');
-      expect(pageContent).toContain('return await this.MaintenanceItemsMaintenanceItemConfiguration.clickSave(wait, annotationText)');
+      expect(pageContent).toContain('return await this.MaintenanceItemConfiguration.clickSave(wait, annotationText)');
     }
     finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
@@ -481,6 +500,13 @@ describe("class-generation coverage", () => {
         filePath: path.join(tempRoot, "src", "components", "MaintenanceItems", "MaintenanceItemConfiguration.vue"),
         isView: false,
         childrenComponentSet: new Set(["MaintenanceItemsMaintenanceItemSelector"]),
+        componentInstances: [{
+          sourceId: "selector",
+          componentName: "MaintenanceItemsMaintenanceItemSelector",
+          instanceName: "MaintenanceItemSelector",
+          selector: createPomStringPattern("MaintenanceItemConfiguration-MaintenanceItemSelector-component", "static", []),
+          parameters: [],
+        }],
       });
 
       const depsChildComponent = makeDeps({
@@ -513,10 +539,10 @@ describe("class-generation coverage", () => {
       });
 
       const componentContent = readFile(path.join(outDir, "MaintenanceItemsMaintenanceItemConfiguration.g.ts"));
-      expect(componentContent).toContain('import type { Page as PwPage } from "@playwright/test";');
+      expect(componentContent).toContain('import type { Locator as PwLocator, Page as PwPage } from "@playwright/test";');
       expect(componentContent).toContain('import { MaintenanceItemsMaintenanceItemSelector }');
-      expect(componentContent).toContain('MaintenanceItemsMaintenanceItemSelector: MaintenanceItemsMaintenanceItemSelector;');
-      expect(componentContent).toContain('this.MaintenanceItemsMaintenanceItemSelector = new MaintenanceItemsMaintenanceItemSelector(page);');
+      expect(componentContent).toContain('MaintenanceItemSelector: MaintenanceItemsMaintenanceItemSelector;');
+      expect(componentContent).toContain('this.MaintenanceItemSelector = new MaintenanceItemsMaintenanceItemSelector(page, this.componentInstanceLocator("MaintenanceItemConfiguration-MaintenanceItemSelector-component"));');
     }
     finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
@@ -534,6 +560,13 @@ describe("class-generation coverage", () => {
         filePath: path.join(tempRoot, "src", "components", "RecordDialog.vue"),
         isView: false,
         childrenComponentSet: new Set(["ActionWrapper"]),
+        componentInstances: [{
+          sourceId: "action-wrapper",
+          componentName: "ActionWrapper",
+          instanceName: "ActionWrapper",
+          selector: createPomStringPattern("RecordDialog-ActionWrapper-component", "static", []),
+          parameters: [],
+        }],
         dataTestIdSet: new Set([{
           selectorValue: createPomStringPattern("RecordDialog-Name-input", "static", []),
           pom: {
@@ -548,6 +581,13 @@ describe("class-generation coverage", () => {
         filePath: path.join(tempRoot, "src", "components", "ActionWrapper.vue"),
         isView: false,
         childrenComponentSet: new Set(["ActionButton"]),
+        componentInstances: [{
+          sourceId: "action-button",
+          componentName: "ActionButton",
+          instanceName: "ActionButton",
+          selector: createPomStringPattern("ActionWrapper-ActionButton-component", "static", []),
+          parameters: [],
+        }],
       });
       const actionButton = makeDeps({
         filePath: path.join(tempRoot, "src", "components", "ActionButton.vue"),
@@ -579,12 +619,12 @@ describe("class-generation coverage", () => {
       const dialogContent = readFile(path.join(outDir, "RecordDialog.g.ts"));
       expect(dialogContent).toContain('import { ActionWrapper }');
       expect(dialogContent).toContain('ActionWrapper: ActionWrapper;');
-      expect(dialogContent).toContain('this.ActionWrapper = new ActionWrapper(page);');
+      expect(dialogContent).toContain('this.ActionWrapper = new ActionWrapper(page, this.componentInstanceLocator("RecordDialog-ActionWrapper-component"));');
 
       const wrapperContent = readFile(path.join(outDir, "ActionWrapper.g.ts"));
       expect(wrapperContent).toContain('import { ActionButton }');
       expect(wrapperContent).toContain('ActionButton: ActionButton;');
-      expect(wrapperContent).toContain('this.ActionButton = new ActionButton(page);');
+      expect(wrapperContent).toContain('this.ActionButton = new ActionButton(page, this.componentInstanceLocator("ActionWrapper-ActionButton-component"));');
     }
     finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
@@ -668,7 +708,7 @@ describe("class-generation coverage", () => {
       expect(content).toContain("await this.page.evaluate(({ name, params })");
 
       // Trim + propagate testIdAttribute into BasePage super call.
-      expect(content).toContain("super(page, { testIdAttribute: \"data-qa\" });");
+      expect(content).toContain("super(page, { root, testIdAttribute: \"data-qa\" });");
 
       // ToggleWidget instance generated. `this.page` surfaces the full `Page`
       // (BasePage widens it for subclasses), so custom-POM attachments take it directly.

--- a/tests/fixtures/generated-tsc/base-page.full.ts
+++ b/tests/fixtures/generated-tsc/base-page.full.ts
@@ -4,8 +4,12 @@ export type Fluent<T extends object> = T & PromiseLike<T>;
 export class BasePage {
   public page: any;
 
-  public constructor(page?: any, _options?: { testIdAttribute?: string }) {
+  public constructor(page?: any, _options?: { root?: any; testIdAttribute?: string }) {
     this.page = page;
+  }
+
+  protected componentInstanceLocator(_instanceId: string, _within?: any): any {
+    return null as any;
   }
 
   protected fluent<T extends object>(_factory: () => Promise<T>): Fluent<T> {

--- a/tests/fixtures/generated-tsc/base-page.minimal.ts
+++ b/tests/fixtures/generated-tsc/base-page.minimal.ts
@@ -4,7 +4,11 @@ export type Fluent<T extends object> = T & PromiseLike<T>;
 export class BasePage {
   public page: any;
 
-  public constructor(page?: any, _options?: { testIdAttribute?: string }) {
+  public constructor(page?: any, _options?: { root?: any; testIdAttribute?: string }) {
     this.page = page;
+  }
+
+  protected componentInstanceLocator(_instanceId: string, _within?: any): any {
+    return null as any;
   }
 }

--- a/tests/generated-tsc.test.ts
+++ b/tests/generated-tsc.test.ts
@@ -323,6 +323,13 @@ describe("generated output", () => {
       childrenComponentSet: new Set(["TenantDetailsEditForm"]),
       usedComponentSet: new Set(["TenantDetailsEditForm"]),
       dataTestIdSet: new Set([navigationEntry]),
+      componentInstances: [{
+        sourceId: "tenant-form",
+        componentName: "TenantDetailsEditForm",
+        instanceName: "TenantDetailsEditForm",
+        selector: createPomStringPattern("TenantListPage-TenantDetailsEditForm-component", "static", []),
+        parameters: [],
+      }],
       generatedMethods: new Map(),
       isView: true,
     };
@@ -407,6 +414,22 @@ describe("generated output", () => {
       childrenComponentSet: new Set([componentName, "TreeViewItemValue"]),
       usedComponentSet: new Set([componentName, "TreeViewItemValue"]),
       dataTestIdSet: new Set([toggleEntry]),
+      componentInstances: [
+        {
+          sourceId: "self",
+          componentName,
+          instanceName: componentName,
+          selector: createPomStringPattern("TreeViewItem-TreeViewItem-component", "static", []),
+          parameters: [],
+        },
+        {
+          sourceId: "value",
+          componentName: "TreeViewItemValue",
+          instanceName: "TreeViewItemValue",
+          selector: createPomStringPattern("TreeViewItem-TreeViewItemValue-component", "static", []),
+          parameters: [],
+        },
+      ],
       generatedMethods: new Map(),
       isView: false,
     };
@@ -440,7 +463,7 @@ describe("generated output", () => {
     // ...and so must the matching property declaration.
     expect(generatedContent).not.toMatch(new RegExp(`^\\s*${componentName}:\\s*${componentName};`, "m"));
     // The genuine child instance is still emitted.
-    expect(generatedContent).toContain("this.TreeViewItemValue = new TreeViewItemValue(page)");
+    expect(generatedContent).toContain("this.TreeViewItemValue = new TreeViewItemValue(page, this.componentInstanceLocator(\"TreeViewItem-TreeViewItemValue-component\"))");
 
     // The generated barrel must typecheck — proving the class is constructible (no recursion).
     const result = runTscNoEmit([path.join(outDir, "index.ts")], { cwd: tempRoot });
@@ -563,7 +586,7 @@ describe("generated output", () => {
       [
         "export type Fluent<T extends object> = T & PromiseLike<T>;",
         "export class BasePage {",
-        "  constructor(public page?: any, _options?: { testIdAttribute?: string }) {}",
+        "  constructor(public page?: any, _options?: { root?: any; testIdAttribute?: string }) {}",
         "}",
       ].join("\n"),
     );
@@ -621,7 +644,7 @@ describe("generated output", () => {
       [
         "export type Fluent<T extends object> = T & PromiseLike<T>;",
         "export class BasePage {",
-        "  constructor(public page?: any, _options?: { testIdAttribute?: string }) {}",
+        "  constructor(public page?: any, _options?: { root?: any; testIdAttribute?: string }) {}",
         "}",
       ].join("\n"),
     );
@@ -709,7 +732,7 @@ describe("generated output", () => {
       [
         "export type Fluent<T extends object> = T & PromiseLike<T>;",
         "export class BasePage {",
-        "  constructor(public page?: any, _options?: { testIdAttribute?: string }) {}",
+        "  constructor(public page?: any, _options?: { root?: any; testIdAttribute?: string }) {}",
         "}",
       ].join("\n"),
     );
@@ -770,8 +793,11 @@ describe("generated output", () => {
         "export type Fluent<T extends object> = T & PromiseLike<T>;",
         "export class BasePage {",
         "  public page: any;",
-        "  public constructor(page?: any, _options?: { testIdAttribute?: string }) {",
+        "  public constructor(page?: any, _options?: { root?: any; testIdAttribute?: string }) {",
         "    this.page = page;",
+        "  }",
+        "  protected componentInstanceLocator(_instanceId: string, _within?: any): any {",
+        "    return null as any;",
         "  }",
         "  protected fluent<T extends object>(_factory: () => Promise<T>): Fluent<T> {",
         "    throw new Error('not implemented');",
@@ -842,6 +868,22 @@ describe("generated output", () => {
       childrenComponentSet: new Set(),
       usedComponentSet: new Set([childA, childB]),
       dataTestIdSet: new Set(),
+      componentInstances: [
+        {
+          sourceId: "child-a",
+          componentName: childA,
+          instanceName: childA,
+          selector: createPomStringPattern("TestViewPage-ChildA-component", "static", []),
+          parameters: [],
+        },
+        {
+          sourceId: "child-b",
+          componentName: childB,
+          instanceName: childB,
+          selector: createPomStringPattern("TestViewPage-ChildB-component", "static", []),
+          parameters: [],
+        },
+      ],
       generatedMethods: new Map(),
       isView: true,
     };
@@ -889,6 +931,13 @@ describe("generated output", () => {
       ...depsViewWithTwoChildren,
       filePath: path.join(tempRoot, `${viewName}Single.vue`),
       usedComponentSet: new Set([childA]),
+      componentInstances: [{
+        sourceId: "child-a",
+        componentName: childA,
+        instanceName: childA,
+        selector: createPomStringPattern("TestViewPageSingle-ChildA-component", "static", []),
+        parameters: [],
+      }],
     };
     const componentHierarchyMapOne = new Map<string, IComponentDependencies>([
       ["TestViewPageSingle", depsViewSingleChild],

--- a/tests/semantic-component-instances.test.ts
+++ b/tests/semantic-component-instances.test.ts
@@ -1,0 +1,189 @@
+// @vitest-environment node
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { compile } from "@vue/compiler-dom";
+import { parse as parseSfc } from "@vue/compiler-sfc";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { generateFiles } from "../class-generation";
+import { createTestIdTransform } from "../transform";
+import type { IComponentDependencies } from "../utils";
+import { resetWrapperContractCaches } from "../wrapper-contract";
+
+describe("semantic component instances", () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(() => {
+    resetWrapperContractCaches();
+    for (const directory of temporaryDirectories.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("generates a keyed, slot-projected, semantically named component chain", async () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vue-pom-semantic-instances-"));
+    temporaryDirectories.push(projectRoot);
+    const componentsDir = path.join(projectRoot, "src", "components");
+    const viewsDir = path.join(projectRoot, "src", "views");
+    fs.mkdirSync(componentsDir, { recursive: true });
+    fs.mkdirSync(viewsDir, { recursive: true });
+
+    const sources = new Map<string, { filePath: string; source: string }>([
+      ["DeploymentParametersForm", {
+        filePath: path.join(viewsDir, "DeploymentParametersForm.vue"),
+        source: `
+          <template>
+            <BaseDynamicForm :parameters="parameters">
+              <template #parameterNameLine="{ parameter }">
+                <OnboardingOption :model-value="parameter.onboardingOption" />
+              </template>
+            </BaseDynamicForm>
+            <ClipboardDialog title="RDP Password">
+              <CopyToClipboardInput :model-value="state.rdpPassword" />
+            </ClipboardDialog>
+          </template>
+        `,
+      }],
+      ["BaseDynamicForm", {
+        filePath: path.join(componentsDir, "BaseDynamicForm.vue"),
+        source: `
+          <template>
+            <div>
+              <DynamicFormField
+                v-for="parameter in parameters"
+                :key="parameter.name"
+                :parameter="parameter"
+                :model-value="parameter.value"
+              >
+                <template #parameterNameLine="{ parameter }">
+                  <slot name="parameterNameLine" :parameter="parameter" />
+                </template>
+              </DynamicFormField>
+            </div>
+          </template>
+        `,
+      }],
+      ["DynamicFormField", {
+        filePath: path.join(componentsDir, "DynamicFormField.vue"),
+        source: `
+          <template>
+            <div>
+              <slot name="parameterNameLine" :parameter="parameter" />
+              <input v-model="parameter.value" />
+            </div>
+          </template>
+        `,
+      }],
+      ["OnboardingOption", {
+        filePath: path.join(componentsDir, "OnboardingOption.vue"),
+        source: `
+          <template>
+            <div>
+              <ImmyRadioGroup
+                :model-value="modelValue"
+                :options="overridePolicyOptions"
+              />
+            </div>
+          </template>
+        `,
+      }],
+      ["ImmyRadioGroup", {
+        filePath: path.join(componentsDir, "ImmyRadioGroup.vue"),
+        source: `
+          <template>
+            <div role="radiogroup">
+              <label v-for="option in options" :key="option.value">
+                <input
+                  type="radio"
+                  :value="option.value"
+                  :checked="modelValue === option.value"
+                  @change="$emit('update:modelValue', option.value)"
+                />
+                <span>{{ option.label }}</span>
+              </label>
+            </div>
+          </template>
+        `,
+      }],
+      ["ClipboardDialog", {
+        filePath: path.join(componentsDir, "ClipboardDialog.vue"),
+        source: `
+          <template>
+            <section>
+              <button aria-label="Close">Close</button>
+              <slot />
+            </section>
+          </template>
+        `,
+      }],
+      ["CopyToClipboardInput", {
+        filePath: path.join(componentsDir, "CopyToClipboardInput.vue"),
+        source: `
+          <template>
+            <input aria-label="Copy value" :value="modelValue" />
+          </template>
+        `,
+      }],
+    ]);
+
+    const componentHierarchyMap = new Map<string, IComponentDependencies>();
+    const compiledTemplateByComponent = new Map<string, string>();
+    const vueFilesPathMap = new Map(
+      Array.from(sources, ([componentName, value]) => [componentName, value.filePath]),
+    );
+
+    for (const [, { filePath, source }] of sources) {
+      fs.writeFileSync(filePath, source);
+    }
+
+    for (const [componentName, { filePath, source }] of sources) {
+      const template = parseSfc(source, { filename: filePath }).descriptor.template?.content ?? "";
+      const compiled = compile(template, {
+        filename: filePath,
+        expressionPlugins: ["typescript"],
+        nodeTransforms: [
+          createTestIdTransform(componentName, componentHierarchyMap, {}, [], viewsDir, {
+            existingIdBehavior: "error",
+            vueFilesPathMap,
+            wrapperSearchRoots: [componentsDir, viewsDir],
+            optionKeyAttribute: { ImmyRadioGroup: "value" },
+          }),
+        ],
+      });
+      compiledTemplateByComponent.set(componentName, compiled.code);
+    }
+
+    const outDir = path.join(projectRoot, "generated");
+    await generateFiles(
+      componentHierarchyMap,
+      vueFilesPathMap,
+      path.resolve("class-generation", "base-page.ts"),
+      {
+        outDir,
+        projectRoot,
+        typescriptOutputStructure: "split",
+      },
+    );
+
+    const formPom = fs.readFileSync(path.join(outDir, "DeploymentParametersForm.g.ts"), "utf8");
+    const onboardingPom = fs.readFileSync(path.join(outDir, "OnboardingOption.g.ts"), "utf8");
+    const radioPom = fs.readFileSync(path.join(outDir, "ImmyRadioGroup.g.ts"), "utf8");
+
+    expect(formPom).toContain("DynamicFormField(key: string): DynamicFormField & { readonly OnboardingOption: OnboardingOption }");
+    expect(formPom).toContain("const ownerRoot = this.componentInstanceLocator(\"DeploymentParametersForm-BaseDynamicForm-component\")");
+    expect(formPom).toContain("const root = this.componentInstanceLocator(`BaseDynamicForm-${key}-DynamicFormField-component`, ownerRoot)");
+    expect(formPom).toContain("OnboardingOption: new OnboardingOption(this.page, this.componentInstanceLocator(\"DeploymentParametersForm-OnboardingOption-component\", root))");
+    expect(compiledTemplateByComponent.get("DeploymentParametersForm"))
+      .toContain("DeploymentParametersForm-RdpPassword-component");
+    expect(compiledTemplateByComponent.get("DeploymentParametersForm"))
+      .toContain("DeploymentParametersForm-CopyToClipboardInput-component");
+
+    expect(onboardingPom).toContain("OverridePolicyOptions: ImmyRadioGroup");
+    expect(onboardingPom).toContain("this.OverridePolicyOptions = new ImmyRadioGroup(page, this.componentInstanceLocator(\"OnboardingOption-OverridePolicyOptions-component\"))");
+
+    expect(radioPom).toContain("async selectByValue(value: string, annotationText: string = \"\")");
+    expect(radioPom).toContain("`ImmyRadioGroup-${value}-OptionValue-radio`");
+  });
+});

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -1976,13 +1976,14 @@ describe('option-keying: per-component optionKeyAttribute config', () => {
     expect((keyed!.selectorValue as { formatted: string }).formatted)
       .toBe('MyRadioGroup-${option.value}-option-radio')
 
-    // The keyed accessor's selector pattern is parameterized by `key` (the generated
-    // parameter name), collapsing option.value -> ${key}.
-    expect(keyed!.pom?.selector).toEqual(createPomStringPattern('MyRadioGroup-${key}-option-radio', 'parameterized', ['key']))
+    // A configured `value` identity becomes the public parameter name, so generated
+    // consumers can say selectByValue(value) rather than selectOptionValueByKey(key).
+    expect(keyed!.pom?.selector).toEqual(createPomStringPattern('MyRadioGroup-${value}-option-radio', 'parameterized', ['value']))
 
-    // The accessor's parameter list carries the `key` parameter (plus the standard
+    // The accessor's parameter list carries the `value` parameter (plus the standard
     // annotationText argument that radio select methods accept).
-    expect(keyed!.pom?.parameters).toEqual(createPomParameters(['key', 'string'], ['annotationText', 'string = ""']))
+    expect(keyed!.pom?.parameters).toEqual(createPomParameters(['value', 'string'], ['annotationText', 'string = ""']))
+    expect(keyed!.pom?.generatedActionName).toBe('selectByValue')
   })
 
   it('default (no optionKeyAttribute config) keys off the non-meaningful :key=index — the gap', () => {
@@ -2060,7 +2061,7 @@ describe('action-event recognition: option-selection events beyond @click', () =
     })
 
     // The keyed accessor is parameterized by the configured :value binding, collapsing
-    // option.value -> ${key}, regardless of whether the radio is driven by @click or @change.
+    // option.value -> ${value}, regardless of whether the radio is driven by @click or @change.
     // The fixture mirrors the real component-library radio pattern: a <template v-for>
     // wrapping v-if/v-else <input> branches with `:value` + `:checked` + `@change` (no
     // v-model, to preserve typed values). The `:value` fallback yields the identifier
@@ -2068,9 +2069,10 @@ describe('action-event recognition: option-selection events beyond @click', () =
     // a role-based keyed accessor rather than the @change handler-name path.
     expect((keyed!.selectorValue as { formatted: string }).formatted)
       .toBe('MyRadioGroup-${option.value}-OptionValue-radio')
-    expect(keyed!.pom?.selector).toEqual(createPomStringPattern('MyRadioGroup-${key}-OptionValue-radio', 'parameterized', ['key']))
-    // The accessor carries a `key` parameter (the option value the test selects by).
-    expect(keyed!.pom?.parameters.map((p: { name: string }) => p.name)).toContain('key')
+    expect(keyed!.pom?.selector).toEqual(createPomStringPattern('MyRadioGroup-${value}-OptionValue-radio', 'parameterized', ['value']))
+    // The accessor carries a `value` parameter (the option value the test selects by).
+    expect(keyed!.pom?.parameters.map((p: { name: string }) => p.name)).toContain('value')
+    expect(keyed!.pom?.generatedActionName).toBe('selectByValue')
   })
 
   it('emits a keyed accessor for a v-for <li role="option"> driven by @mousedown', () => {

--- a/transform.ts
+++ b/transform.ts
@@ -17,6 +17,8 @@ import { parseExpression } from "@babel/parser";
 import path from "node:path";
 import fs from "node:fs";
 import { TESTID_CLICK_EVENT_NAME } from "./click-instrumentation";
+import { createPomParameterSpec } from "./pom-params";
+import { createPomStringPattern } from "./pom-patterns";
 import {
   buildVueSfcPathIndex,
   getElementControlRole,
@@ -69,6 +71,139 @@ import {
 } from "./utils";
 
 const CLICK_EVENT_NAME = TESTID_CLICK_EVENT_NAME;
+const POM_INSTANCE_ATTRIBUTE = "data-pom-instance";
+
+interface SemanticExpressionNode {
+  type?: string;
+  name?: string;
+  value?: string;
+  computed?: boolean;
+  property?: SemanticExpressionNode;
+  object?: SemanticExpressionNode;
+  expression?: SemanticExpressionNode;
+  callee?: SemanticExpressionNode;
+}
+
+function getLastSemanticIdentifier(node: SemanticExpressionNode | null | undefined): string | null {
+  if (!node) {
+    return null;
+  }
+
+  if (node.type === "Identifier") {
+    return node.name?.trim() || null;
+  }
+
+  if (node.type === "MemberExpression" || node.type === "OptionalMemberExpression") {
+    if (!node.computed && node.property?.type === "Identifier") {
+      return node.property.name?.trim() || null;
+    }
+    if (node.computed && node.property?.type === "StringLiteral") {
+      return node.property.value?.trim() || null;
+    }
+    return getLastSemanticIdentifier(node.object);
+  }
+
+  if (node.type === "CallExpression" || node.type === "OptionalCallExpression") {
+    return getLastSemanticIdentifier(node.callee);
+  }
+
+  if (
+    node.type === "TSAsExpression"
+    || node.type === "TSTypeAssertion"
+    || node.type === "TSNonNullExpression"
+    || node.type === "ChainExpression"
+  ) {
+    return getLastSemanticIdentifier(node.expression);
+  }
+
+  return null;
+}
+
+function getBoundSemanticName(element: ElementNode, attributeName: string): string | null {
+  const directive = element.props.find((prop): prop is DirectiveNode => {
+    return prop.type === NodeTypes.DIRECTIVE
+      && prop.name === "bind"
+      && prop.arg?.type === NodeTypes.SIMPLE_EXPRESSION
+      && prop.arg.content === attributeName
+      && !!prop.exp;
+  });
+  if (!directive?.exp) {
+    return null;
+  }
+
+  const source = getVueExpressionSource(
+    directive.exp as SimpleExpressionNode | CompoundExpressionNode,
+    "loc",
+    "content",
+    "compiled",
+  );
+  if (!source) {
+    return null;
+  }
+
+  try {
+    const identifier = getLastSemanticIdentifier(parseExpression(source, { plugins: ["typescript"] }) as SemanticExpressionNode);
+    return identifier ? toPascalCase(identifier) : null;
+  }
+  catch {
+    return null;
+  }
+}
+
+function getComponentInstanceNameCandidates(element: ElementNode): string[] {
+  const explicitAccessibleNames = ["aria-label", "label", "title", "name"]
+    .map(attributeName => getStaticAttributeContent(element, attributeName))
+    .filter((value): value is string => !!value)
+    .map(toPascalCase);
+
+  const optionsName = getBoundSemanticName(element, "options");
+  const { vModel, modelValue } = getModelBindingValues(element);
+  const modelName = modelValue || vModel;
+  const candidates = [
+    ...explicitAccessibleNames,
+    optionsName && optionsName !== "Options" ? optionsName : null,
+    modelName && !new Set(["Data", "Item", "ModelValue", "Value"]).has(modelName)
+      ? toPascalCase(modelName)
+      : null,
+    toPascalCase(element.tag),
+  ].filter((value): value is string => !!value);
+
+  return Array.from(new Set(candidates));
+}
+
+function getElementSourceId(element: ElementNode): string {
+  return `${element.tag}:${element.loc.start.offset}:${element.loc.end.offset}`;
+}
+
+function getNearestComponentAncestor(
+  element: ElementNode,
+  hierarchyMap: HierarchyMap,
+  isComponentLikeTag: (tag: string) => boolean,
+): ElementNode | null {
+  let parent = hierarchyMap.get(element) ?? null;
+  while (parent) {
+    if (isComponentLikeTag(parent.tag)) {
+      return parent;
+    }
+    parent = hierarchyMap.get(parent) ?? null;
+  }
+  return null;
+}
+
+function getSlotNameFromTemplate(element: ElementNode): string | null {
+  const directive = element.props.find((prop): prop is DirectiveNode => {
+    return prop.type === NodeTypes.DIRECTIVE && prop.name === "slot";
+  });
+  if (!directive) {
+    return null;
+  }
+  if (!directive.arg) {
+    return "default";
+  }
+  return directive.arg.type === NodeTypes.SIMPLE_EXPRESSION
+    ? directive.arg.content.trim() || "default"
+    : null;
+}
 
 function getStaticAttributeContent(element: ElementNode, name: string): string | null {
   const attr = element.props.find((prop): prop is AttributeNode => {
@@ -543,6 +678,7 @@ export function createTestIdTransform(
     Object.entries(nativeWrappers).map(([tag, config]) => [tag, { ...config }]),
   );
   const wrapperContractByTag = new Map<string, ReturnType<typeof resolveWrapperContractForTag>>();
+  const instanceWrapperContractByTag = new Map<string, ReturnType<typeof resolveWrapperContractForTag>>();
   const getWrapperContract = (tag: string) => {
     if (!wrapperContractByTag.has(tag)) {
       wrapperContractByTag.set(tag, resolveWrapperContractForTag({
@@ -553,6 +689,17 @@ export function createTestIdTransform(
       }));
     }
     return wrapperContractByTag.get(tag) ?? null;
+  };
+  const getInstanceWrapperContract = (tag: string) => {
+    if (!instanceWrapperContractByTag.has(tag)) {
+      instanceWrapperContractByTag.set(tag, resolveWrapperContractForTag({
+        tag,
+        vueFilesPathMap,
+        wrapperSearchRoots,
+        testIdAttribute: POM_INSTANCE_ATTRIBUTE,
+      }));
+    }
+    return instanceWrapperContractByTag.get(tag) ?? null;
   };
 
   // Some projects (and dev environments) use symlinks. We want viewsDir containment checks
@@ -595,6 +742,11 @@ export function createTestIdTransform(
   const conditionalMergeGroupByElement = new WeakMap<ElementNode, string>();
   const conditionalMergeGroupByElementLoc = new Map<string, string>();
   const conditionalMergeGroupByIfBranch = new WeakMap<IfBranchNode, string>();
+  const componentInstanceNameOwnerByName = new Map<string, {
+    componentName: string;
+    keyed: boolean;
+    sourceId: string;
+  }>();
   let conditionalMergeGroupCounter = 0;
 
   const getElementLocationKey = (element: ElementNode): string | null => {
@@ -728,6 +880,8 @@ export function createTestIdTransform(
           childrenComponentSet: new Set<string>(),
           usedComponentSet: new Set<string>(),
           dataTestIdSet: new Set(),
+          componentInstances: [],
+          slotOutlets: [],
           isView,
           methodsContent: "",
         };
@@ -746,6 +900,18 @@ export function createTestIdTransform(
       const isUpper = isAsciiUppercaseLetterCode(first);
       return isUpper || tag.includes("-");
     };
+
+    if (element.tag === "slot") {
+      const slotName = getStaticAttributeContent(element, "name") ?? "default";
+      const target = getNearestComponentAncestor(element, hierarchyMap, isComponentLikeTag);
+      if (target) {
+        dependencies.slotOutlets ??= [];
+        const outlet = { name: slotName, targetSourceId: getElementSourceId(target) };
+        if (!dependencies.slotOutlets.some(existing => existing.name === outlet.name && existing.targetSourceId === outlet.targetSourceId)) {
+          dependencies.slotOutlets.push(outlet);
+        }
+      }
+    }
 
     // Track all component-like tags used in the template, even when we do not emit a data-testid.
     // This supports per-view helper attachment (e.g. Grid) based on component usage.
@@ -853,6 +1019,7 @@ export function createTestIdTransform(
       };
     }
 
+      let selectorParameterName = "key";
       const getBestAvailableKeyInfo = (): ResolvedKeyInfo | null => {
         const parentNode = (context.parent && typeof context.parent === "object") ? context.parent as { type?: number } : null;
         const isDirectVForChild = parentNode?.type === NodeTypes.FOR;
@@ -865,6 +1032,11 @@ export function createTestIdTransform(
         if (configuredAttrName && configuredAttrName !== "key") {
           const bindingKeyInfo = getBindingKeyInfo(element, configuredAttrName);
           if (bindingKeyInfo) {
+            // `value` is the author-facing identity for option controls and produces
+            // APIs such as selectByValue(value). Attribute names such as `data-value`
+            // are selector implementation details rather than valid TS identifiers,
+            // so they retain the generic `key` parameter.
+            selectorParameterName = configuredAttrName === "value" ? "value" : "key";
             return bindingKeyInfo;
           }
         }
@@ -917,6 +1089,80 @@ export function createTestIdTransform(
 
       // Runtime click wrappers use the same normalization, but only need the runtime fragment itself.
       const bestRuntimeKeyPlaceholder = bestKeyInfo?.runtimeFragment ?? null;
+
+    // Component composition needs invocation identity, not merely the child type. A
+    // generator-owned marker falls through to the child's DOM root and becomes the
+    // scope for its generated POM. Slot-scope keys are deliberately excluded here:
+    // supplied slot content is already scoped by the keyed component receiving the
+    // slot, and requiring the same key again would produce `Field(key).Option(key)`.
+    if (isComponentLikeTag(element.tag)) {
+      const componentInstanceKeyInfo = getKeyDirectiveInfo(element)
+        || getContainedInVForDirectiveKeyInfo(context, element, hierarchyMap);
+      const instanceContract = getInstanceWrapperContract(element.tag);
+
+      if ((instanceContract?.forwardedTestIdTargetOffsets.size ?? 0) > 0) {
+        if (tryGetExistingElementDataTestId(element, POM_INSTANCE_ATTRIBUTE)) {
+          const loc = element.loc.start;
+          throw new Error(
+            `[vue-pom-generator] ${POM_INSTANCE_ATTRIBUTE} is generator-owned and cannot be authored manually.\n`
+            + `Component: ${componentName}\n`
+            + `File: ${context.filename ?? "unknown"}:${loc.line}:${loc.column}`,
+          );
+        }
+
+        const sourceId = getElementSourceId(element);
+        const semanticNameCandidates = getComponentInstanceNameCandidates(element);
+        const componentTypeName = toPascalCase(element.tag);
+        const instanceNameCandidates = componentInstanceKeyInfo
+          ? [componentTypeName, ...semanticNameCandidates.filter(candidate => candidate !== componentTypeName)]
+          : semanticNameCandidates;
+        const instanceName = instanceNameCandidates
+          .find((candidate) => {
+            const owner = componentInstanceNameOwnerByName.get(candidate);
+            return !owner || (
+              !!componentInstanceKeyInfo
+              && owner.keyed
+              && owner.componentName === element.tag
+            );
+          });
+        // Repeated structural wrappers often have no semantic signal beyond their tag.
+        // Once every candidate is already claimed, omit only this composition edge;
+        // normal control/test-id generation for the invocation still runs below.
+        if (instanceName) {
+          componentInstanceNameOwnerByName.set(instanceName, {
+            componentName: element.tag,
+            keyed: !!componentInstanceKeyInfo,
+            sourceId,
+          });
+          const runtimeMarker = componentInstanceKeyInfo
+            ? templateAttributeValue(`${componentName}-${componentInstanceKeyInfo.runtimeFragment}-${instanceName}-component`)
+            : staticAttributeValue(`${componentName}-${instanceName}-component`);
+          const selector = componentInstanceKeyInfo
+            ? createPomStringPattern(`${componentName}-\${key}-${instanceName}-component`, "parameterized", ["key"])
+            : createPomStringPattern(`${componentName}-${instanceName}-component`, "static", []);
+
+          upsertAttribute(element, POM_INSTANCE_ATTRIBUTE, runtimeMarker);
+
+          const slotTemplate = getContainedInSlotTemplateNode(element, hierarchyMap);
+          const slotName = slotTemplate ? getSlotNameFromTemplate(slotTemplate) : null;
+          const slotOwner = slotTemplate
+            ? getNearestComponentAncestor(slotTemplate, hierarchyMap, isComponentLikeTag)
+            : null;
+
+          dependencies.componentInstances ??= [];
+          dependencies.componentInstances.push({
+            sourceId,
+            componentName: element.tag,
+            instanceName,
+            selector,
+            parameters: componentInstanceKeyInfo ? [createPomParameterSpec("key", "string")] : [],
+            suppliedSlot: slotName && slotOwner
+              ? { ownerSourceId: getElementSourceId(slotOwner), name: slotName }
+              : undefined,
+          });
+        }
+      }
+    }
 
     // If we can prove the v-for iterable is a static literal list, capture the concrete
     // values (e.g. ['One', 'Two']). Downstream codegen can use this to:
@@ -1078,6 +1324,7 @@ export function createTestIdTransform(
         preferredGeneratedValue: args.preferredGeneratedValue,
         preferredRuntimeValue: args.preferredRuntimeValue,
         keyInfo: bestKeyInfo,
+        selectorParameterName,
         keyValuesOverride,
         entryOverrides: args.entryOverrides,
         semanticNameHint: args.semanticNameHint,

--- a/utils.ts
+++ b/utils.ts
@@ -2948,34 +2948,30 @@ function safeMethodNameFromParts(parts: string[]) {
 }
 
 /**
- * Replaces any `${...}` interpolation in a template string with the stable POM placeholder `${key}`.
- *
- * This is only for the generated POM selector shape. Runtime/test-id generation keeps the real
- * interpolation expressions; the POM layer just needs to know that a keyed slot exists and where
- * it sits relative to the surrounding literal text.
- */
-/**
- * Replaces any `${...}` interpolation in a template string with the stable POM placeholder `${key}`,
+ * Replaces any `${...}` interpolation in a template string with a stable POM parameter placeholder,
  * and reports the template variable names carried as metadata.
  *
  * This is only for the generated POM selector shape. Runtime/test-id generation keeps the real
  * interpolation expressions; the POM layer just needs to know that a keyed slot exists and where
- * it sits relative to the surrounding literal text. Every interpolation collapses to the single
- * `${key}` slot, so the variable name is the constant `key` — known at construction, not derived
- * from the emitted string.
+ * it sits relative to the surrounding literal text. Every interpolation collapses to the supplied
+ * parameter name (defaulting to `key`), which is known at construction rather than derived from the
+ * emitted string.
  */
-function toPomKeyPattern(templateValue: Extract<AttributeValue, { kind: "template" }>): { formatted: string; templateVariables: string[] } {
+function toPomKeyPattern(
+  templateValue: Extract<AttributeValue, { kind: "template" }>,
+  parameterName: string = "key",
+): { formatted: string; templateVariables: string[] } {
   const { templateLiteral } = templateValue.parsedTemplate;
   let out = "";
   let hasExpression = false;
   for (let i = 0; i < templateLiteral.quasis.length; i += 1) {
     out += templateLiteral.quasis[i]?.value.raw ?? "";
     if (templateLiteral.expressions[i]) {
-      out += "${key}";
+      out += `\${${parameterName}}`;
       hasExpression = true;
     }
   }
-  return { formatted: out, templateVariables: hasExpression ? ["key"] : [] };
+  return { formatted: out, templateVariables: hasExpression ? [parameterName] : [] };
 }
 
 // Internal exports for unit testing (not part of the public plugin API).
@@ -3054,6 +3050,8 @@ export function applyResolvedDataTestId(args: {
   preferredGeneratedValue: AttributeValue;
   preferredRuntimeValue?: AttributeValue;
   keyInfo: ResolvedKeyInfo | null;
+  /** Public selector parameter name. `optionKeyAttribute` uses the attribute name (for example `value`). */
+  selectorParameterName?: string;
   /** Optional enumerable key values (e.g. derived from v-for="item in ['One','Two']"). */
   keyValuesOverride?: string[] | null;
   entryOverrides?: DataTestIdEntryOverrides;
@@ -3270,7 +3268,10 @@ export function applyResolvedDataTestId(args: {
   // Parameterized selectors are represented explicitly in the POM spec: the formatted
   // pattern and its template variables are both carried as metadata from construction,
   // never re-derived from the formatted string.
-  const pomKeyPattern = dataTestId.kind === "template" ? toPomKeyPattern(dataTestId) : null;
+  const selectorParameterName = args.selectorParameterName?.trim() || "key";
+  const pomKeyPattern = dataTestId.kind === "template"
+    ? toPomKeyPattern(dataTestId, selectorParameterName)
+    : null;
   const formattedDataTestIdForPom = dataTestId.kind === "template"
     ? pomKeyPattern!.formatted
     : dataTestId.value;
@@ -3469,8 +3470,11 @@ export function applyResolvedDataTestId(args: {
       }
     }
 
-    if (selectorIsParameterized && !existingPom.parameters.some(param => param.name === "key")) {
-      existingPom.parameters = [createPomParameterSpec("key", keyTypeFromValues), ...existingPom.parameters];
+    if (selectorIsParameterized && !existingPom.parameters.some(param => param.name === selectorParameterName)) {
+      existingPom.parameters = [
+        createPomParameterSpec(selectorParameterName, keyTypeFromValues),
+        ...existingPom.parameters,
+      ];
     }
 
     return true;
@@ -3491,7 +3495,12 @@ export function applyResolvedDataTestId(args: {
       const baseWithSuffix = suffix === 1 ? base : `${base}${suffix}`;
       // Keep the ByKey segment at the end so downstream logic (and parameterized getter naming)
       // can reliably strip it when needed.
-      const candidate = selectorIsParameterized ? `${baseWithSuffix}ByKey` : baseWithSuffix;
+      const parameterizedSuffix = `By${upperFirst(selectorParameterName)}`;
+      const candidate = selectorIsParameterized
+        ? (normalizedRole === "radio" && selectorParameterName !== "key"
+            ? parameterizedSuffix
+            : `${baseWithSuffix}${parameterizedSuffix}`)
+        : baseWithSuffix;
 
       const actionName = getPrimaryActionMethodName(candidate);
 
@@ -3539,7 +3548,9 @@ export function applyResolvedDataTestId(args: {
         // Only try role-suffixing when the base name isn't already role-suffixed.
         if (!hasRoleSuffix(baseNameUpper, roleSuffix)) {
           const baseWithRoleSuffix = `${baseWithSuffix}${roleSuffix}`;
-          const candidateWithRoleSuffix = selectorIsParameterized ? `${baseWithRoleSuffix}ByKey` : baseWithRoleSuffix;
+          const candidateWithRoleSuffix = selectorIsParameterized
+            ? `${baseWithRoleSuffix}By${upperFirst(selectorParameterName)}`
+            : baseWithRoleSuffix;
           const actionNameWithRoleSuffix = getPrimaryActionMethodName(candidateWithRoleSuffix);
 
           const getterCandidatesWithRoleSuffix = getPrimaryGetterNameCandidates(candidateWithRoleSuffix);
@@ -3630,7 +3641,7 @@ export function applyResolvedDataTestId(args: {
   }
 
   let parameters: PomParameterSpec[] = selectorIsParameterized
-    ? [createPomParameterSpec("key", keyTypeFromValues)]
+    ? [createPomParameterSpec(selectorParameterName, keyTypeFromValues)]
     : [];
 
   switch (normalizedRole) {
@@ -3656,8 +3667,8 @@ export function applyResolvedDataTestId(args: {
   }
 
   const normalizedParameters = selectorIsParameterized
-    ? setPomParameter(parameters, "key", keyTypeFromValues)
-    : removePomParameter(parameters, "key");
+    ? setPomParameter(parameters, selectorParameterName, keyTypeFromValues)
+    : removePomParameter(parameters, selectorParameterName);
 
   // 3) Apply attribute (only when we generated it) and register for POM generation.
   if (addHtmlAttribute && !fromExisting) {
@@ -4194,6 +4205,37 @@ export interface PomExtraClickMethodSpec {
   parameters: PomParameterSpec[];
 }
 
+/**
+ * One component invocation that can be addressed as a scoped child POM.
+ *
+ * The transform records invocation identity rather than only the component type so
+ * codegen can expose semantic APIs such as `form.AddressFields` and keyed APIs such
+ * as `form.DynamicFormField(parameterName)` without widening selectors to the page.
+ */
+export interface PomComponentInstanceSpec {
+  /** Stable source-local identity used to connect slot outlets to invocations. */
+  sourceId: string;
+  /** Vue component tag / generated POM class name. */
+  componentName: string;
+  /** Semantic public member name inferred from the invocation's bindings. */
+  instanceName: string;
+  /** Generator-owned runtime marker used to scope the child POM. */
+  selector: PomStringPattern;
+  /** Key parameter for repeated component invocations; empty for static instances. */
+  parameters: PomParameterSpec[];
+  /** When supplied through a slot, identifies the receiving invocation and slot. */
+  suppliedSlot?: {
+    ownerSourceId: string;
+    name: string;
+  };
+}
+
+/** Connects a component's slot outlet to the child invocation that receives it. */
+export interface PomSlotOutletSpec {
+  name: string;
+  targetSourceId: string;
+}
+
 export interface IComponentDependencies {
   filePath: string;
   childrenComponentSet: Set<string>; // all child components used in this component
@@ -4205,6 +4247,10 @@ export interface IComponentDependencies {
    */
   usedComponentSet: Set<string>;
   dataTestIdSet: Set<IDataTestId>; // all data-testid values used in this component
+  /** Scoped, semantic component invocations discovered in this template. */
+  componentInstances?: PomComponentInstanceSpec[];
+  /** Slot outlets whose rendered content is nested under another component invocation. */
+  slotOutlets?: PomSlotOutletSpec[];
   /** Optional cached codegen output so buildEnd can skip re-deriving method strings. */
   methodsContent?: string;
   /**


### PR DESCRIPTION
## Summary

- Generate scoped child POMs for semantic Vue component invocations instead of page-wide component-type properties.
- Carry stable `:key` identity through repeated components and named-slot forwarding.
- Infer instance names from accessible names, option/model bindings, and component tags.
- Emit `selectByValue(value)` when a radio wrapper uses `optionKeyAttribute: "value"`.

This enables:

```ts
form
  .DynamicFormField(parameterName)
  .OnboardingOption
  .OverridePolicyOptions
  .selectByValue(ParameterOverridePolicy.Require);
```

## Breaking change

Generated child POM properties now use semantic invocation names and scoped roots. Consumers must regenerate POMs and update affected call sites. Components that cannot forward the generator-owned scope marker are omitted from composition instead of falling back to page-wide selectors.

## Validation

- `npm test -- --run` (419 passed)
- `npm run typecheck`
- `npm run lint` (0 errors; 8 existing fixture warnings)
- `npm run build`
- `npm run test:playwright -- --max-failures=1` (3 passed)
- `npm run smoke:pack`
- Built current Immy frontend through a local file dependency (643 POMs / 1,443 selectors)
- Proved the exact chain above with semantic consumer names; no handwritten locators or generator naming config