### PR TITLE
Infer semantic option identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,12 +787,20 @@ misleading API. Components that do not forward the marker to a DOM root are omit
 component-instance composition rather than falling back to page-wide selectors; their
 own standalone fixture is still generated normally.
 
-When `injection.optionKeyAttribute` maps a radio component to `"value"`, its generated
-selection API uses the domain term directly: `selectByValue(value)`. Other configured
-attribute names retain `key` when the HTML attribute name is not a valid public TypeScript
-identifier (for example `data-value`). When the template does not expose a finite set of
-values, the generated parameter accepts primitive HTML values (`string | number | boolean |
-bigint`) so domain enums can be passed without string conversion.
+Repeated option controls use their semantic identity automatically:
+
+- radio inputs require `:value` and generate `selectByValue(value)`;
+- elements with `role="option"` require `:data-value` and generate a keyed option action;
+- other repeated controls continue to use their Vue `:key` identity.
+
+When the template does not expose a finite set of values, the generated option parameter
+accepts primitive HTML values (`string | number | boolean | bigint`) so domain enums can be
+passed without string conversion.
+
+Use `injection.optionKeyAttribute` only to override those conventions for a component.
+Map the component to `"key"` to explicitly use Vue's reconciliation key, or to another
+bound attribute such as `"data-option-id"`. A configured binding is required on recognized
+option controls; generation fails instead of silently choosing a different identity.
 
 `data-pom-instance` is generator-owned. Do not author it in Vue templates.
 

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -170,16 +170,19 @@ export interface VuePomGeneratorPluginOptions {
     nativeWrappers?: NativeWrappersMap;
 
     /**
-     * Per-component option-key attribute override.
+     * Per-component option identity override.
      *
-     * Maps an SFC component name to the attribute/binding name the keyed accessor should
-     * derive its key fragment from, instead of the default `:key` directive. A component
-     * absent from the map keeps the current `:key`-based behavior.
+     * Repeated radios use `:value` and repeated elements with `role="option"` use
+     * `:data-value` automatically. Map an SFC component name to another bound attribute
+     * when its option controls intentionally use a different identity. Use `"key"` to
+     * explicitly select Vue's reconciliation `:key` instead.
      *
-     * Example: `{ MyRadioGroup: "value" }` keys `page.Option[...]` off the `:value` binding
-     * on each option element rather than Vue's reconciliation `:key`.
+     * The configured binding is required on recognized option controls; a missing binding
+     * fails generation instead of silently changing selector identity.
      *
-     * Default: `{}` (every component uses `:key`).
+     * Example: `{ CustomOptionList: "data-option-id" }`.
+     *
+     * Default: `{}`.
      */
     optionKeyAttribute?: Record<string, string>;
 

--- a/tests/fixtures/MyList_OptionMousedownMissingValue.vue
+++ b/tests/fixtures/MyList_OptionMousedownMissingValue.vue
@@ -1,0 +1,7 @@
+<template>
+  <ul role="listbox">
+    <li v-for="(option, index) in options" :key="index" role="option" @mousedown.prevent="select(option)">
+      {{ option.label }}
+    </li>
+  </ul>
+</template>

--- a/tests/fixtures/MyRadioGroup_OptionChangeMissingValue.vue
+++ b/tests/fixtures/MyRadioGroup_OptionChangeMissingValue.vue
@@ -1,0 +1,15 @@
+<template>
+  <div role="radiogroup">
+    <template v-for="(option, index) in options" :key="index">
+      <label v-if="buttons">
+        <input
+          type="radio"
+          :name="name"
+          :checked="Object.is(modelValue, option.value)"
+          @change="modelValue = option.value"
+        >
+        {{ option.text }}
+      </label>
+    </template>
+  </div>
+</template>

--- a/tests/fixtures/MyRadioGroup_OptionValueMissingKey.vue
+++ b/tests/fixtures/MyRadioGroup_OptionValueMissingKey.vue
@@ -1,0 +1,12 @@
+<template>
+  <div role="radiogroup">
+    <!-- eslint-disable-next-line vue/require-v-for-key -->
+    <input
+      v-for="option in options"
+      v-model="modelValue"
+      type="radio"
+      name="option"
+      :value="option.value"
+    >
+  </div>
+</template>

--- a/tests/semantic-component-instances.test.ts
+++ b/tests/semantic-component-instances.test.ts
@@ -190,7 +190,6 @@ describe("semantic component instances", () => {
             existingIdBehavior: "error",
             vueFilesPathMap,
             wrapperSearchRoots: [componentsDir, viewsDir],
-            optionKeyAttribute: { ImmyRadioGroup: "value" },
           }),
         ],
       });

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -1928,7 +1928,7 @@ describe('createTestIdTransform', () => {
   })
 })
 
-describe('option-keying: per-component optionKeyAttribute config', () => {
+describe('option-keying: semantic inference and explicit overrides', () => {
   // Resolves the single keyed IDataTestId entry produced for the radio <input> in a
   // radiogroup v-for fixture, and asserts both the injected selector template
   // (selectorValue — what becomes data-testid in the DOM) and the keyed accessor's
@@ -1966,17 +1966,14 @@ describe('option-keying: per-component optionKeyAttribute config', () => {
     return { deps, keyed }
   }
 
-  it('keys off configured :value binding when :key is the non-meaningful v-for index', () => {
-    // config: optionKeyAttribute = { MyRadioGroup: "value" }
-    const { keyed } = compileRadioFixture('MyRadioGroup_OptionValue.vue', 'MyRadioGroup', {
-      optionKeyAttribute: { MyRadioGroup: 'value' },
-    })
+  it('uses a repeated radio value without component configuration', () => {
+    const { keyed } = compileRadioFixture('MyRadioGroup_OptionValue.vue', 'MyRadioGroup')
 
     // The injected data-testid template interpolates option.value, NOT the v-for index.
     expect((keyed!.selectorValue as { formatted: string }).formatted)
       .toBe('MyRadioGroup-${option.value}-option-radio')
 
-    // A configured `value` identity becomes the public parameter name, so generated
+    // A semantic `value` identity becomes the public parameter name, so generated
     // consumers can say selectByValue(value) rather than selectOptionValueByKey(key).
     expect(keyed!.pom?.selector).toEqual(createPomStringPattern('MyRadioGroup-${value}-option-radio', 'parameterized', ['value']))
 
@@ -1989,11 +1986,12 @@ describe('option-keying: per-component optionKeyAttribute config', () => {
     expect(keyed!.pom?.generatedActionName).toBe('selectByValue')
   })
 
-  it('default (no optionKeyAttribute config) keys off the non-meaningful :key=index — the gap', () => {
-    // config: (none)
-    const { keyed } = compileRadioFixture('MyRadioGroup_OptionValue.vue', 'MyRadioGroup')
+  it('allows explicit configuration to override the semantic radio value', () => {
+    const { keyed } = compileRadioFixture('MyRadioGroup_OptionValue.vue', 'MyRadioGroup', {
+      optionKeyAttribute: { MyRadioGroup: 'key' },
+    })
 
-    // Without the config, the keyed fragment comes from the enclosing v-for :key="index".
+    // An explicit `key` override uses the enclosing v-for :key="index".
     expect((keyed!.selectorValue as { formatted: string }).formatted)
       .toBe('MyRadioGroup-${index}-option-radio')
 
@@ -2001,20 +1999,21 @@ describe('option-keying: per-component optionKeyAttribute config', () => {
     expect(keyed!.pom?.parameters).toEqual(createPomParameters(['key', 'string'], ['annotationText', 'string = ""']))
   })
 
-  it('configured binding absent on the element falls back to the existing :key resolution', () => {
-    // config: optionKeyAttribute = { MyRadioGroup: "label" } but <input> has NO :label binding;
-    // the fixture's v-for :key is option.id, so the fall-through path keys by option.id.
-    const { keyed } = compileRadioFixture('MyRadioGroup_OptionId.vue', 'MyRadioGroup', {
+  it('rejects an explicit option identity override that is absent from a repeated radio', () => {
+    expect(() => compileRadioFixture('MyRadioGroup_OptionId.vue', 'MyRadioGroup', {
       optionKeyAttribute: { MyRadioGroup: 'label' },
-    })
+    })).toThrow(/optionKeyAttribute.*label.*does not bind :label/)
+  })
 
-    // getBindingKeyInfo(element, "label") returns null (no :label on <input>), so
-    // getBestAvailableKeyInfo falls through to the existing :key resolution -> option.id.
-    expect((keyed!.selectorValue as { formatted: string }).formatted)
-      .toBe('MyRadioGroup-${option.id}-option-radio')
+  it('rejects an explicit key override when the repeated radio has no Vue key', () => {
+    expect(() => compileRadioFixture('MyRadioGroup_OptionValueMissingKey.vue', 'MyRadioGroup', {
+      optionKeyAttribute: { MyRadioGroup: 'key' },
+    })).toThrow(/optionKeyAttribute.*"key".*no resolvable v-for :key/)
+  })
 
-    expect(keyed!.pom?.selector).toEqual(createPomStringPattern('MyRadioGroup-${key}-option-radio', 'parameterized', ['key']))
-    expect(keyed!.pom?.parameters).toEqual(createPomParameters(['key', 'string'], ['annotationText', 'string = ""']))
+  it('rejects a repeated radio without a bound value identity through structural wrappers', () => {
+    expect(() => compileRadioFixture('MyRadioGroup_OptionChangeMissingValue.vue', 'MyRadioGroup'))
+      .toThrow(/Repeated radio must bind :value/)
   })
 })
 
@@ -2059,11 +2058,9 @@ describe('action-event recognition: option-selection events beyond @click', () =
     // The fixture uses @change="modelValue = option.value" — the Vue idiom for radio
     // selection — instead of @click. Before action-event widening this produced an
     // EMPTY POM (no recognized handler); it must emit a keyed Option[key] accessor.
-    const { keyed } = compileOptionFixture('MyRadioGroup_OptionChange.vue', 'MyRadioGroup', {
-      optionKeyAttribute: { MyRadioGroup: 'value' },
-    })
+    const { keyed } = compileOptionFixture('MyRadioGroup_OptionChange.vue', 'MyRadioGroup')
 
-    // The keyed accessor is parameterized by the configured :value binding, collapsing
+    // The keyed accessor is parameterized by the inferred :value binding, collapsing
     // option.value -> ${value}, regardless of whether the radio is driven by @click or @change.
     // The fixture mirrors the real component-library radio pattern: a <template v-for>
     // wrapping v-if/v-else <input> branches with `:value` + `:checked` + `@change` (no
@@ -2081,17 +2078,20 @@ describe('action-event recognition: option-selection events beyond @click', () =
   it('emits a keyed accessor for a v-for <li role="option"> driven by @mousedown', () => {
     // Combobox/listbox option elements commonly use @mousedown (often .prevent) to
     // select on pointer-down for responsive UX. The fixture keys off :data-value
-    // (the meaningful option value) via optionKeyAttribute.
-    const { keyed } = compileOptionFixture('MyList_OptionMousedown.vue', 'MyList', {
-      optionKeyAttribute: { MyList: 'data-value' },
-    })
+    // (the meaningful option value) by convention.
+    const { keyed } = compileOptionFixture('MyList_OptionMousedown.vue', 'MyList')
 
-    // The keyed accessor is parameterized by the configured :data-value binding,
+    // The keyed accessor is parameterized by the conventional :data-value binding,
     // collapsing option.value -> ${key}. The suffix derives from the handler name
     // (select) + tag (li), matching the generator's accessor-naming convention.
     expect((keyed!.selectorValue as { formatted: string }).formatted)
       .toBe('MyList-${option.value}-Select-li')
     expect(keyed!.pom?.selector).toEqual(createPomStringPattern('MyList-${key}-Select-li', 'parameterized', ['key']))
     expect(keyed!.pom?.parameters.map((p: { name: string }) => p.name)).toContain('key')
+  })
+
+  it('rejects a repeated role=option without a bound data-value identity', () => {
+    expect(() => compileOptionFixture('MyList_OptionMousedownMissingValue.vue', 'MyList'))
+      .toThrow(/role="option".*must bind :data-value/)
   })
 })

--- a/transform.ts
+++ b/transform.ts
@@ -217,6 +217,30 @@ function getNativeHtmlControlRole(element: ElementNode): NativeRole | null {
   return getElementControlRole(element);
 }
 
+function getConventionalOptionIdentityAttribute(element: ElementNode): "data-value" | "value" | null {
+  const explicitRole = getStaticAttributeContent(element, "role")?.toLowerCase();
+  if (explicitRole === "option") {
+    return "data-value";
+  }
+  if (explicitRole === "radio") {
+    return "value";
+  }
+
+  const tag = element.tag.toLowerCase();
+  const type = getStaticAttributeContent(element, "type")?.toLowerCase();
+  if ((tag === "input" || tag === "uinput") && type === "radio") {
+    return "value";
+  }
+
+  return null;
+}
+
+function describeConventionalOption(element: ElementNode): string {
+  return getConventionalOptionIdentityAttribute(element) === "value"
+    ? "radio"
+    : `<${element.tag} role="option">`;
+}
+
 /**
  * Normalizes label text into the stable string used for generated control names.
  *
@@ -657,9 +681,8 @@ export function createTestIdTransform(
     /** Shared registry for cross-file keyed slot context. */
     crossFileKeyRegistry?: CrossFileKeyRegistry;
     /**
-     * Per-component map of SFC component name -> attribute/binding name to derive the
-     * keyed accessor's key fragment from (e.g. `{ MyRadioGroup: "value" }`).
-     * When a component is absent, the default `:key` directive resolution applies.
+     * Per-component map of SFC component name -> attribute/binding name that overrides
+     * the conventional identity for repeated option controls.
      */
     optionKeyAttribute?: Record<string, string>;
   } = {},
@@ -1023,12 +1046,28 @@ export function createTestIdTransform(
       const getBestAvailableKeyInfo = (): ResolvedKeyInfo | null => {
         const parentNode = (context.parent && typeof context.parent === "object") ? context.parent as { type?: number } : null;
         const isDirectVForChild = parentNode?.type === NodeTypes.FOR;
+        const isInVForScope = isDirectVForChild || context.scopes.vFor > 0;
+        const vForKeyInfo = (isDirectVForChild ? getKeyDirectiveInfo(element) : null)
+          || getContainedInVForDirectiveKeyInfo(context, element, hierarchyMap);
+        const conventionalIdentityAttribute = getConventionalOptionIdentityAttribute(element);
 
-        // Per-component optionKeyAttribute: when configured for this SFC, derive the keyed
-        // fragment from the named :bind directive (e.g. :value) on the option element
-        // BEFORE the default :key resolution. The default ":key" directive name is a no-op
-        // here (it would duplicate the existing path below), so only non-"key" names apply.
-        const configuredAttrName = optionKeyAttribute[componentName];
+        // Explicit component configuration wins over semantic inference. `key` opts a
+        // component back into its authored Vue reconciliation key; any other override
+        // must exist on a repeated option control or generation fails immediately.
+        const configuredAttrName = optionKeyAttribute[componentName]?.trim();
+        if (configuredAttrName === "key") {
+          if (vForKeyInfo) {
+            return vForKeyInfo;
+          }
+          if (isInVForScope && conventionalIdentityAttribute) {
+            const loc = element.loc.start;
+            throw new Error(
+              `[vue-pom-generator] optionKeyAttribute maps ${componentName} to "key", but repeated ${describeConventionalOption(element)} has no resolvable v-for :key.\n`
+              + `File: ${context.filename ?? "unknown"}:${loc.line}:${loc.column}\n\n`
+              + `Fix: bind :key on the repeated option or remove the override to use the conventional :${conventionalIdentityAttribute} identity.`,
+            );
+          }
+        }
         if (configuredAttrName && configuredAttrName !== "key") {
           const bindingKeyInfo = getBindingKeyInfo(element, configuredAttrName);
           if (bindingKeyInfo) {
@@ -1039,10 +1078,35 @@ export function createTestIdTransform(
             selectorParameterName = configuredAttrName === "value" ? "value" : "key";
             return bindingKeyInfo;
           }
+          if (isInVForScope && conventionalIdentityAttribute) {
+            const loc = element.loc.start;
+            throw new Error(
+              `[vue-pom-generator] optionKeyAttribute maps ${componentName} to "${configuredAttrName}", but repeated ${describeConventionalOption(element)} does not bind :${configuredAttrName}.\n`
+              + `File: ${context.filename ?? "unknown"}:${loc.line}:${loc.column}\n\n`
+              + `Fix: bind :${configuredAttrName} on the option element or remove the override to use the conventional :${conventionalIdentityAttribute} identity.`,
+            );
+          }
         }
 
-        const vForKeyInfo = (isDirectVForChild ? getKeyDirectiveInfo(element) : null)
-          || getContainedInVForDirectiveKeyInfo(context, element, hierarchyMap);
+        // Standard selection controls own a domain identity distinct from Vue's
+        // reconciliation key. Require that identity so generated option accessors are
+        // predictable: radios bind :value and ARIA options bind :data-value.
+        if (conventionalIdentityAttribute) {
+          const bindingKeyInfo = getBindingKeyInfo(element, conventionalIdentityAttribute);
+          if (bindingKeyInfo) {
+            selectorParameterName = conventionalIdentityAttribute === "value" ? "value" : "key";
+            return bindingKeyInfo;
+          }
+          if (isInVForScope) {
+            const loc = element.loc.start;
+            throw new Error(
+              `[vue-pom-generator] Repeated ${describeConventionalOption(element)} must bind :${conventionalIdentityAttribute} for generated option selection.\n`
+              + `Component: ${componentName}\n`
+              + `File: ${context.filename ?? "unknown"}:${loc.line}:${loc.column}`,
+            );
+          }
+        }
+
         if (vForKeyInfo) {
           return vForKeyInfo;
         }


### PR DESCRIPTION
## Summary

- infer repeated radio identity from `:value` and generate `selectByValue(value)`
- infer repeated `role="option"` identity from `:data-value`
- retain `optionKeyAttribute` as an explicit override and fail fast when a recognized option is missing its required identity
- document the conventions and cover structural wrappers, explicit overrides, and invalid markup

## Breaking change

Repeated radios must bind `:value`, and repeated elements with `role="option"` must bind `:data-value`. Missing explicit option identity overrides no longer silently fall back to Vue's reconciliation key.

## Validation

- `npm test` (42 files, 431 tests)
- `npm run typecheck`
- `npm run lint` (0 errors; 8 pre-existing fixture warnings)
- `npm run smoke:pack`
- `npm run test:playwright` (3 tests)
- ImmyBot generated-POM migration build using a local packed dependency (643 entries, 1,442 selectors)
