### PR TITLE
Fix primitive selector value types

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,7 +790,9 @@ own standalone fixture is still generated normally.
 When `injection.optionKeyAttribute` maps a radio component to `"value"`, its generated
 selection API uses the domain term directly: `selectByValue(value)`. Other configured
 attribute names retain `key` when the HTML attribute name is not a valid public TypeScript
-identifier (for example `data-value`).
+identifier (for example `data-value`). When the template does not expose a finite set of
+values, the generated parameter accepts primitive HTML values (`string | number | boolean |
+bigint`) so domain enums can be passed without string conversion.
 
 `data-pom-instance` is generator-owned. Do not author it in Vue templates.
 

--- a/tests/semantic-component-instances.test.ts
+++ b/tests/semantic-component-instances.test.ts
@@ -230,7 +230,7 @@ describe("semantic component instances", () => {
     expect(onboardingPom).toContain("OverridePolicyOptions: ImmyRadioGroup");
     expect(onboardingPom).toContain("this.OverridePolicyOptions = new ImmyRadioGroup(page, this.componentInstanceLocator(\"OnboardingOption-OverridePolicyOptions-component\"))");
 
-    expect(radioPom).toContain("async selectByValue(value: string, annotationText: string = \"\")");
+    expect(radioPom).toContain("async selectByValue(value: string | number | boolean | bigint, annotationText: string = \"\")");
     expect(radioPom).toContain("`ImmyRadioGroup-${value}-OptionValue-radio`");
 
     expect(formVtuPom).toContain("DynamicFormField(key: string): DynamicFormField & { readonly OnboardingOption: OnboardingOption }");
@@ -240,12 +240,25 @@ describe("semantic component instances", () => {
     expect(onboardingVtuPom).toContain("get OverridePolicyOptions(): ImmyRadioGroup");
     expect(onboardingVtuPom).toContain("return new ImmyRadioGroup(this.getComponentInstance(\"OnboardingOption-OverridePolicyOptions-component\"))");
     expect(onboardingVtuPom).not.toContain("this.OverridePolicyOptions =");
-    expect(radioVtuPom).toContain("async selectByValue(value: string)");
+    expect(radioVtuPom).toContain("async selectByValue(value: string | number | boolean | bigint)");
     expect(radioVtuPom).toContain("await this.getByTestId(`ImmyRadioGroup-${value}-OptionValue-radio`).setValue()");
     expect(radioVtuPom).not.toContain("annotationText");
     expect(fs.readFileSync(path.join(vueTestUtilsOutDir, "index.ts"), "utf8"))
       .toContain("export * from \"./DeploymentParametersForm.vtu.g\"");
 
+    fs.writeFileSync(
+      path.join(vueTestUtilsOutDir, "numeric-radio-consumer.ts"),
+      `
+        import type { DeploymentParametersForm } from "./DeploymentParametersForm.vtu.g";
+
+        declare const form: DeploymentParametersForm;
+        void form
+          .DynamicFormField("server")
+          .OnboardingOption
+          .OverridePolicyOptions
+          .selectByValue(3);
+      `,
+    );
     const typecheck = typecheckGeneratedVueTestUtilsFiles(projectRoot, vueTestUtilsOutDir);
     expect(typecheck.status, `${typecheck.stdout}\n${typecheck.stderr}`).toBe(0);
 
@@ -264,13 +277,13 @@ describe("semantic component instances", () => {
     const generated = require(runtimeBundlePath);
     const wrapper = mount(defineComponent({
       setup() {
-        const selected = reactive({ server: "Allow" });
+        const selected = reactive({ server: 2 });
         return () => h("form", [
           h("div", { "data-pom-instance": "DeploymentParametersForm-BaseDynamicForm-component" }, [
             h("section", { "data-pom-instance": "BaseDynamicForm-server-DynamicFormField-component" }, [
               h("div", { "data-pom-instance": "DeploymentParametersForm-OnboardingOption-component" }, [
                 h("div", { "data-pom-instance": "OnboardingOption-OverridePolicyOptions-component" }, [
-                  ...["Allow", "Require"].map(value => h("input", {
+                  ...[2, 3].map(value => h("input", {
                     type: "radio",
                     value,
                     checked: selected.server === value,
@@ -291,8 +304,8 @@ describe("semantic component instances", () => {
       .DynamicFormField("server")
       .OnboardingOption
       .OverridePolicyOptions
-      .selectByValue("Require");
+      .selectByValue(3);
 
-    expect(wrapper.get('[data-testid="selected-server"]').text()).toBe("Require");
+    expect(wrapper.get('[data-testid="selected-server"]').text()).toBe("3");
   });
 });

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -1982,7 +1982,10 @@ describe('option-keying: per-component optionKeyAttribute config', () => {
 
     // The accessor's parameter list carries the `value` parameter (plus the standard
     // annotationText argument that radio select methods accept).
-    expect(keyed!.pom?.parameters).toEqual(createPomParameters(['value', 'string'], ['annotationText', 'string = ""']))
+    expect(keyed!.pom?.parameters).toEqual(createPomParameters(
+      ['value', 'string | number | boolean | bigint'],
+      ['annotationText', 'string = ""'],
+    ))
     expect(keyed!.pom?.generatedActionName).toBe('selectByValue')
   })
 

--- a/utils.ts
+++ b/utils.ts
@@ -3231,9 +3231,12 @@ export function applyResolvedDataTestId(args: {
   // POM *shape* (method names, params) comes from semantic hints + Vue/Babel AST-derived
   // signals collected during the transform phase.
 
+  const selectorParameterName = args.selectorParameterName?.trim() || "key";
   const getKeyTypeFromValues = (values: string[] | null | undefined) => {
     if (!values || values.length === 0) {
-      return "string";
+      return selectorParameterName === "key"
+        ? "string"
+        : "string | number | boolean | bigint";
     }
     return values.map(v => JSON.stringify(v)).join(" | ");
   };
@@ -3268,7 +3271,6 @@ export function applyResolvedDataTestId(args: {
   // Parameterized selectors are represented explicitly in the POM spec: the formatted
   // pattern and its template variables are both carried as metadata from construction,
   // never re-derived from the formatted string.
-  const selectorParameterName = args.selectorParameterName?.trim() || "key";
   const pomKeyPattern = dataTestId.kind === "template"
     ? toPomKeyPattern(dataTestId, selectorParameterName)
     : null;


### PR DESCRIPTION
## Summary

- widen generated option-attribute selector parameters to primitive HTML values
- allow numeric domain enums in `selectByValue(...)` without string conversion
- retain string-only typing for ordinary structural `key` accessors
- add generated typecheck and numeric runtime coverage

## Verification

- `npm test` (428 passed)
- `npm run typecheck`
- `npm run lint` (0 errors; 8 existing fixture warnings)
- `npm run build`