### PR TITLE
fix: preserve injected expression scope

### DIFF
--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -83,6 +83,10 @@ function compileWithRuntimeTemplateOptions(
   options: {
     nativeWrappers?: NativeWrappersMap
     bindingMetadata?: BindingMetadata
+    inline?: boolean
+    crossFileKeyRegistry?: Map<string, string>
+    vueFilesPathMap?: Map<string, string>
+    wrapperSearchRoots?: string[]
     annotatorMetadata?: {
       sourceAttribute: string
       metadataAttributePrefix: string
@@ -98,8 +102,8 @@ function compileWithRuntimeTemplateOptions(
     elementMetadata: new Map(),
     semanticNameMap: new Map(),
     componentHierarchyMap,
-    crossFileKeyRegistry: new Map(),
-    vueFilesPathMap: new Map(),
+    crossFileKeyRegistry: options.crossFileKeyRegistry ?? new Map(),
+    vueFilesPathMap: options.vueFilesPathMap ?? new Map(),
     skipTestIdGenerationInsideComponents: [],
     getViewsDirAbs: () => '/src/views',
     testIdAttribute: 'data-testid',
@@ -112,7 +116,7 @@ function compileWithRuntimeTemplateOptions(
       },
     },
     getSourceDirs: () => ['/src/views', '/src/components'],
-    getWrapperSearchRoots: () => [],
+    getWrapperSearchRoots: () => options.wrapperSearchRoots ?? [],
     getProjectRoot: () => '/',
     annotatorMetadata: options.annotatorMetadata ?? null,
   })
@@ -120,7 +124,7 @@ function compileWithRuntimeTemplateOptions(
   return compileDom(source, {
     ...templateCompilerOptions,
     filename: '/src/views/MyComp.vue',
-    inline: true,
+    inline: options.inline ?? true,
     cacheHandlers: true,
     bindingMetadata: options.bindingMetadata,
     mode: 'module',
@@ -569,6 +573,50 @@ describe('createTestIdTransform', () => {
     expect(code).not.toContain('${`${item.name}-${item.url}`}')
   })
 
+  it('rewrites injected cross-file key expressions using runtime prop bindings', () => {
+    const code = compileWithRuntimeTemplateOptions(
+      '<button @click="selectAll">Select All</button>',
+      {
+        bindingMetadata: {
+          selectAll: BindingTypes.SETUP_CONST,
+          subject: BindingTypes.PROPS,
+        },
+        crossFileKeyRegistry: new Map([['MyComp', 'subject']]),
+        inline: false,
+      },
+    )
+
+    expect(code).toContain('$props.subject.id')
+    expect(code).not.toMatch(/\$\{subject\?\./)
+  })
+
+  it('rewrites keyed component-instance markers using runtime setup bindings', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'vue-pom-runtime-scope-'))
+    const childPath = path.join(directory, 'ForwardingPanel.vue')
+    fs.writeFileSync(childPath, '<template><section v-bind="$attrs" /></template>')
+
+    try {
+      const code = compileWithRuntimeTemplateOptions(
+        '<ForwardingPanel :key="getPanelKey(state)" />',
+        {
+          bindingMetadata: {
+            getPanelKey: BindingTypes.SETUP_CONST,
+            state: BindingTypes.SETUP_REACTIVE_CONST,
+          },
+          inline: false,
+          vueFilesPathMap: new Map([['ForwardingPanel', childPath]]),
+          wrapperSearchRoots: [directory],
+        },
+      )
+
+      expect(code).toContain('$setup.getPanelKey($setup.state)')
+      expect(code).not.toContain('${getPanelKey(state)}')
+    }
+    finally {
+      fs.rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
   it('ignores singleton :key values when generating click test ids', () => {
     const componentHierarchyMap = new Map()
 
@@ -774,7 +822,7 @@ describe('createTestIdTransform', () => {
     )
 
     const testId = findFirstDataTestId(childAst)
-    expect(testId).toBe('`RolePermissionSubject-${subject.key ?? subject.data?.id ?? subject.id ?? subject.value ?? subject.url ?? subject}-SelectAll-button`')
+    expect(testId).toBe('`RolePermissionSubject-${_ctx.subject.key ?? _ctx.subject.data?.id ?? _ctx.subject.id ?? _ctx.subject.value ?? _ctx.subject.url ?? _ctx.subject}-SelectAll-button`')
   })
 
   it('does not key child component testids when not in a keyed slot', () => {

--- a/transform.ts
+++ b/transform.ts
@@ -12,7 +12,7 @@ import type {
   ForNode,
 } from "@vue/compiler-core";
 import type { AttributeValue, DataTestIdEntryOverrides, HierarchyMap, ResolvedKeyInfo } from "./utils";
-import { NodeTypes } from "@vue/compiler-core";
+import { createSimpleExpression, NodeTypes, processExpression } from "@vue/compiler-core";
 import { parseExpression } from "@babel/parser";
 import path from "node:path";
 import fs from "node:fs";
@@ -1132,7 +1132,12 @@ export function createTestIdTransform(
           const propName = crossFileKeyRegistry.get(componentName);
           if (propName) {
             const fallbackExpr = buildSlotScopeFallbackKeyExpression(propName);
-            return toResolvedKeyInfo(fallbackExpr, fallbackExpr);
+            const runtimeExpression = createSimpleExpression(fallbackExpr, false, element.loc);
+            const selectorExpression = context.prefixIdentifiers
+              ? processExpression(runtimeExpression, context)
+              : runtimeExpression;
+            const selectorSource = getVueExpressionSource(selectorExpression, "compiled", "content");
+            return toResolvedKeyInfo(selectorSource, fallbackExpr);
           }
         }
 
@@ -1205,7 +1210,7 @@ export function createTestIdTransform(
             ? createPomStringPattern(`${componentName}-\${key}-${instanceName}-component`, "parameterized", ["key"])
             : createPomStringPattern(`${componentName}-${instanceName}-component`, "static", []);
 
-          upsertAttribute(element, POM_INSTANCE_ATTRIBUTE, runtimeMarker);
+          upsertAttribute(element, POM_INSTANCE_ATTRIBUTE, runtimeMarker, context);
 
           const slotTemplate = getContainedInSlotTemplateNode(element, hierarchyMap);
           const slotName = slotTemplate ? getSlotNameFromTemplate(slotTemplate) : null;
@@ -1452,7 +1457,7 @@ export function createTestIdTransform(
           );
         }
 
-        upsertAttribute(element, "option-data-testid-prefix", optionDataTestIdPrefixValue);
+        upsertAttribute(element, "option-data-testid-prefix", optionDataTestIdPrefixValue, context);
       }
 
       const nativeRole = resolvedNativeWrappers[element.tag]?.role ?? element.tag;

--- a/utils.ts
+++ b/utils.ts
@@ -11,6 +11,7 @@ import {
   createSimpleExpression,
   ConstantTypes,
   NodeTypes,
+  processExpression,
   stringifyExpression,
 } from "@vue/compiler-core";
 import type {
@@ -2688,6 +2689,7 @@ export function upsertAttribute(
   element: ElementNode,
   attributeName: string,
   value: AttributeValue,
+  context?: TransformContext | null,
 ): void {
   element.props = element.props.filter((prop) => {
     // Remove static attribute: data-testid="..."
@@ -2710,6 +2712,7 @@ export function upsertAttribute(
 
   if (value.kind === "template") {
     // Dynamic binding: :data-testid="`ComponentName_tag_${key}`"
+    const expression = createSimpleExpression(`\`${value.template}\``, false, element.loc);
     element.props.push({
       type: NodeTypes.DIRECTIVE,
       name: "bind",
@@ -2720,7 +2723,12 @@ export function upsertAttribute(
         constType: 0,
         loc: element.loc,
       },
-      exp: createSimpleExpression(`\`${value.template}\``, false, element.loc),
+      // Custom node transforms run after Vue's built-in expression transform.
+      // Process generator-owned bindings explicitly so setup bindings, props,
+      // and v-for/slot locals retain the same runtime scope as authored bindings.
+      exp: context?.prefixIdentifiers
+        ? processExpression(expression, context)
+        : expression,
       modifiers: [],
       loc: element.loc,
     } as DirectiveNode);
@@ -3674,7 +3682,12 @@ export function applyResolvedDataTestId(args: {
 
   // 3) Apply attribute (only when we generated it) and register for POM generation.
   if (addHtmlAttribute && !fromExisting) {
-    upsertAttribute(args.element, testIdAttribute, dataTestId);
+    upsertAttribute(
+      args.element,
+      testIdAttribute,
+      runtimeDataTestId,
+      args.preferredRuntimeValue ? args.context : undefined,
+    );
   }
 
   const childComponentName = args.element.tag;
@@ -3720,13 +3733,18 @@ export function applyResolvedDataTestId(args: {
     }
 
     const metadataAttributePrefix = args.annotatorMetadata.metadataAttributePrefix;
-    upsertAttribute(args.element, args.annotatorMetadata.sourceAttribute, staticAttributeValue(`${filename}:${sourceLocation.line}:${sourceLocation.column}`));
-    upsertAttribute(args.element, `${metadataAttributePrefix}-component`, staticAttributeValue(args.componentName));
-    upsertAttribute(args.element, `${metadataAttributePrefix}-tag`, staticAttributeValue(args.element.tag));
-    upsertAttribute(args.element, `${metadataAttributePrefix}-testid`, runtimeDataTestId);
-    upsertAttribute(args.element, `${metadataAttributePrefix}-action`, staticAttributeValue(buildPomGeneratedActionName(dataTestIdEntry.pom)));
-    upsertAttribute(args.element, `${metadataAttributePrefix}-property`, staticAttributeValue(buildPomGeneratedPropertyName(dataTestIdEntry.pom)));
-    upsertAttribute(args.element, `${metadataAttributePrefix}-role`, staticAttributeValue(normalizedRole));
+    upsertAttribute(args.element, args.annotatorMetadata.sourceAttribute, staticAttributeValue(`${filename}:${sourceLocation.line}:${sourceLocation.column}`), args.context);
+    upsertAttribute(args.element, `${metadataAttributePrefix}-component`, staticAttributeValue(args.componentName), args.context);
+    upsertAttribute(args.element, `${metadataAttributePrefix}-tag`, staticAttributeValue(args.element.tag), args.context);
+    upsertAttribute(
+      args.element,
+      `${metadataAttributePrefix}-testid`,
+      runtimeDataTestId,
+      args.preferredRuntimeValue ? args.context : undefined,
+    );
+    upsertAttribute(args.element, `${metadataAttributePrefix}-action`, staticAttributeValue(buildPomGeneratedActionName(dataTestIdEntry.pom)), args.context);
+    upsertAttribute(args.element, `${metadataAttributePrefix}-property`, staticAttributeValue(buildPomGeneratedPropertyName(dataTestIdEntry.pom)), args.context);
+    upsertAttribute(args.element, `${metadataAttributePrefix}-role`, staticAttributeValue(normalizedRole), args.context);
   }
 
   args.dependencies.childrenComponentSet.add(childComponentName);


### PR DESCRIPTION
Generator-owned dynamic attributes are inserted after Vue expression transforms have already run. Explicitly process those injected expressions so props, setup bindings, and keyed component markers retain their runtime scope.

This fixes ReferenceError failures observed when enabling generated Vue Test Utils POMs in ImmyBot with v1.0.100.

Validation:
- npm test (436 passed)
- npm run typecheck
- npm run lint (0 errors; 8 existing fixture warnings)
- npm run knip
- npm run build
- npm run smoke:pack
- ImmyBot frontend unit suite with the packed local fix (1,872 passed; 3 skipped; 1 todo)